### PR TITLE
Fast MCP Server + Setup CLI Binary Install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: uv sync --group dev --python ${{ matrix.python-version }}
+
+      - name: Run tests
+        run: uv run pytest -v
+
+      - name: Run Ruff lint checks
+        if: matrix.python-version == '3.13'
+        run: uv run ruff check src tests
+
+      - name: Run Ruff formatting checks
+        if: matrix.python-version == '3.13'
+        run: uv run ruff format --check src tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,98 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version tag (e.g., v0.1.0)"
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: linux-amd64
+          - os: ubuntu-24.04-arm
+            target: linux-arm64
+          - os: macos-latest
+            target: darwin-arm64
+          - os: macos-13
+            target: darwin-amd64
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Build binary with PyInstaller
+        run: |
+          uv run pyinstaller --name topos \
+            --onefile \
+            --clean \
+            --collect-all tree_sitter \
+            --collect-all tree_sitter_python \
+            src/topos/main.py
+
+      - name: Rename binary with platform suffix
+        run: mv dist/topos dist/topos-${{ matrix.target }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: topos-${{ matrix.target }}
+          path: dist/topos-${{ matrix.target }}
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Get version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          else
+            echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create checksums
+        run: |
+          cd dist
+          sha256sum topos-* > checksums.txt
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.VERSION }}
+          name: Release ${{ steps.version.outputs.VERSION }}
+          draft: false
+          prerelease: false
+          files: |
+            dist/topos-*
+            dist/checksums.txt
+          generate_release_notes: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Agents
 .cursor/
 .claude/
+.gemini/
+topos-skill/
+*.skill
 
 # Python env
 uv.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Agents
 .cursor/
 .claude/
+.gemini/
 
 # Python env
 uv.lock

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,114 @@
+#!/bin/sh
+set -e
+
+REPO="Krv-Labs/topos"
+INSTALL_DIR="/usr/local/bin"
+BINARY_NAME="topos"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+info() {
+    printf "${GREEN}>>>${NC} %s\n" "$1"
+}
+
+warn() {
+    printf "${YELLOW}>>>${NC} %s\n" "$1"
+}
+
+error() {
+    printf "${RED}>>>${NC} %s\n" "$1" >&2
+    exit 1
+}
+
+detect_platform() {
+    OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+    ARCH=$(uname -m)
+
+    case "$OS" in
+        linux)
+            OS="linux"
+            ;;
+        darwin)
+            OS="darwin"
+            ;;
+        *)
+            error "Unsupported operating system: $OS"
+            ;;
+    esac
+
+    case "$ARCH" in
+        x86_64|amd64)
+            ARCH="amd64"
+            ;;
+        arm64|aarch64)
+            ARCH="arm64"
+            ;;
+        *)
+            error "Unsupported architecture: $ARCH"
+            ;;
+    esac
+
+    PLATFORM="${OS}-${ARCH}"
+    info "Detected platform: $PLATFORM"
+}
+
+get_latest_version() {
+    VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+    if [ -z "$VERSION" ]; then
+        error "Failed to fetch latest version"
+    fi
+    info "Latest version: $VERSION"
+}
+
+download_binary() {
+    DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${BINARY_NAME}-${PLATFORM}"
+    
+    info "Downloading from: $DOWNLOAD_URL"
+    
+    TMPDIR=$(mktemp -d)
+    TMPFILE="${TMPDIR}/${BINARY_NAME}"
+    
+    if ! curl -fsSL "$DOWNLOAD_URL" -o "$TMPFILE"; then
+        rm -rf "$TMPDIR"
+        error "Failed to download binary"
+    fi
+    
+    chmod +x "$TMPFILE"
+}
+
+install_binary() {
+    info "Installing to $INSTALL_DIR/$BINARY_NAME"
+    
+    if [ -w "$INSTALL_DIR" ]; then
+        mv "$TMPFILE" "$INSTALL_DIR/$BINARY_NAME"
+    else
+        warn "Elevated permissions required to install to $INSTALL_DIR"
+        sudo mv "$TMPFILE" "$INSTALL_DIR/$BINARY_NAME"
+    fi
+    
+    rm -rf "$TMPDIR"
+}
+
+verify_installation() {
+    if command -v "$BINARY_NAME" >/dev/null 2>&1; then
+        info "Successfully installed $BINARY_NAME!"
+        info "Run '$BINARY_NAME --help' to get started"
+    else
+        warn "Binary installed but not in PATH. Add $INSTALL_DIR to your PATH"
+    fi
+}
+
+main() {
+    info "Installing topos..."
+    detect_platform
+    get_latest_version
+    download_binary
+    install_binary
+    verify_installation
+}
+
+main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,9 +51,11 @@ select = ["E", "F", "I", "UP", "B", "SIM"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["src"]
+addopts = "--cov=src/topos --cov-report=term-missing"
 
 [dependency-groups]
 dev = [
     "pytest>=9.0.2",
+    "pytest-cov>=7.1.0",
     "ruff>=0.15.8",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ version = "0.1.0"
 description = "Treating programs as morphisms in a world of commodity code. Building the subobject classifier for rigorous program evaluations."
 readme = "README.md"
 requires-python = ">=3.11"
-license = { text = "MIT" }
+license = { text = "BSD-3-Clause" }
 authors = [{ name = "Krv Labs", email = "team@krv.ai"}]
 keywords = ["code-quality", "static-analysis", "category-theory", "topos", "ast"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -21,6 +21,7 @@ dependencies = [
     "tree-sitter>=0.23",
     "tree-sitter-python>=0.23",
     "click>=8.1",
+    "fastmcp",
 ]
 
 [project.optional-dependencies]
@@ -31,6 +32,7 @@ dev = [
 
 [project.scripts]
 topos = "topos.main:cli"
+topos-mcp = "topos.server:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "tree-sitter>=0.23",
     "tree-sitter-python>=0.23",
     "click>=8.1",
-    "fastmcp",
+    "fastmcp>=0.1",
 ]
 
 [project.optional-dependencies]

--- a/src/topos/main.py
+++ b/src/topos/main.py
@@ -108,9 +108,7 @@ def evaluate(
     else:
         _output_text(results, verbose)
 
-    overall = classifier.combine(
-        *[EvaluationValue[r["evaluation"]] for r in results]
-    )
+    overall = classifier.combine(*[EvaluationValue[r["evaluation"]] for r in results])
     click.echo()
     click.echo(f"Overall: {overall}")
 

--- a/src/topos/server.py
+++ b/src/topos/server.py
@@ -18,9 +18,7 @@ except PackageNotFoundError:
 
 mcp = FastMCP("topos", version=__version__)
 
-FILE_ACCESS_ROOT = Path(
-    os.getenv("TOPOS_MCP_FILE_ROOT", Path.cwd())
-).resolve()
+FILE_ACCESS_ROOT = Path(os.getenv("TOPOS_MCP_FILE_ROOT", Path.cwd())).resolve()
 
 
 def _is_within_allowed_root(path: Path) -> bool:
@@ -61,11 +59,11 @@ def evaluate_code(code: str, language: str = "python") -> dict[str, Any]:
     """
     Evaluate code quality directly from a string.
     Analyzes the code and classifies it in the evaluation lattice.
-    
+
     Args:
         code: The raw source code to evaluate.
         language: The programming language (default: 'python').
-        
+
     Returns:
         A dictionary containing the evaluation result,
         metrics, and classification symbol.
@@ -92,7 +90,7 @@ def evaluate_code(code: str, language: str = "python") -> dict[str, Any]:
 def evaluate_file(filepath: str) -> dict[str, Any]:
     """
     Evaluate code quality of a file.
-    
+
     Args:
         filepath: The path to the Python file to evaluate.
     """
@@ -111,12 +109,12 @@ def compare_code(
     """
     Compare structural distance between two code strings.
     Computes the AST edit distance (topological drift).
-    
+
     Args:
         source_code: The source code string.
         target_code: The target code string (e.g., a proposed refactor).
         language: The programming language (default: 'python').
-        
+
     Returns:
         A dictionary containing distance metrics and edit operations.
     """
@@ -174,14 +172,14 @@ def assess_improvement(
 ) -> dict[str, Any]:
     """
     Assess if the proposed code is an improvement over the current code.
-    Uses the topos evaluation lattice and structural metrics to determine if the 
+    Uses the topos evaluation lattice and structural metrics to determine if the
     change improves quality, reduces complexity, or maintainability.
-    
+
     Args:
         current_code: The existing source code.
         proposed_code: The new or refactored code.
         language: The programming language (default: 'python').
-        
+
     Returns:
         A comparative analysis of the improvement.
     """
@@ -243,16 +241,12 @@ def assess_improvement(
                 "complexity_delta": complexity_delta,
                 "distance_computed": can_compute_distance,
                 "structural_distance": (
-                    dist_res.normalized_distance
-                    if dist_res is not None
-                    else None
+                    dist_res.normalized_distance if dist_res is not None else None
                 ),
                 "similarity": (
-                    1.0 - dist_res.normalized_distance
-                    if dist_res is not None
-                    else None
+                    1.0 - dist_res.normalized_distance if dist_res is not None else None
                 ),
-            }
+            },
         }
     except Exception as e:
         return {"error": str(e)}
@@ -262,7 +256,7 @@ def assess_improvement(
 def inspect_code(code: str, language: str = "python") -> dict[str, Any]:
     """
     Inspect detailed metrics for a code string.
-    
+
     Args:
         code: The source code to inspect.
         language: The programming language (default: 'python').

--- a/src/topos/server.py
+++ b/src/topos/server.py
@@ -1,0 +1,235 @@
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import Any
+
+from fastmcp import FastMCP
+
+from topos.core.morphism import ProgramMorphism
+from topos.logic.omega import SubobjectClassifier
+from topos.metrics.complexity import calculate_function_complexities
+from topos.metrics.distance import calculate_ast_distance
+from topos.metrics.entropy import calculate_entropy_detailed
+
+try:
+    __version__ = version("topos")
+except PackageNotFoundError:
+    __version__ = "dev"
+
+mcp = FastMCP("topos", version=__version__)
+
+
+@mcp.tool()
+def evaluate_code(code: str, language: str = "python") -> dict[str, Any]:
+    """
+    Evaluate code quality directly from a string.
+    Analyzes the code and classifies it in the evaluation lattice.
+    
+    Args:
+        code: The raw source code to evaluate.
+        language: The programming language (default: 'python').
+        
+    Returns:
+        A dictionary containing the evaluation result, metrics, and classification symbol.
+    """
+    classifier = SubobjectClassifier()
+    try:
+        morphism = ProgramMorphism(source=code, language=language)
+        result = classifier.classify_detailed(morphism)
+
+        return {
+            "evaluation": result.evaluation.name,
+            "symbol": result.evaluation.symbol,
+            "description": result.evaluation.description,
+            "complexity_score": result.complexity_score,
+            "entropy_score": result.entropy_score,
+            "is_valid": result.is_valid,
+            "metrics": result.metrics,
+        }
+    except Exception as e:
+        return {"error": str(e)}
+
+
+@mcp.tool()
+def evaluate_file(filepath: str) -> dict[str, Any]:
+    """
+    Evaluate code quality of a file.
+    
+    Args:
+        filepath: The path to the Python file to evaluate.
+    """
+    path = Path(filepath)
+    if not path.exists():
+        return {"error": f"File not found: {filepath}"}
+    return evaluate_code(path.read_text(encoding="utf-8"))
+
+
+@mcp.tool()
+def compare_code(source_code: str, target_code: str, language: str = "python") -> dict[str, Any]:
+    """
+    Compare structural distance between two code strings.
+    Computes the AST edit distance (topological drift).
+    
+    Args:
+        source_code: The source code string.
+        target_code: The target code string (e.g., a proposed refactor).
+        language: The programming language (default: 'python').
+        
+    Returns:
+        A dictionary containing distance metrics and edit operations.
+    """
+    try:
+        source_morph = ProgramMorphism(source=source_code, language=language)
+        target_morph = ProgramMorphism(source=target_code, language=language)
+
+        if source_morph.ast is None or target_morph.ast is None:
+            return {"error": "Failed to parse one or both code snippets."}
+
+        result = calculate_ast_distance(source_morph.ast, target_morph.ast)
+
+        return {
+            "raw_distance": result.raw_distance,
+            "normalized_distance": result.normalized_distance,
+            "similarity": 1.0 - result.normalized_distance,
+            "operations": result.operations,
+        }
+    except Exception as e:
+        return {"error": str(e)}
+
+
+@mcp.tool()
+def compare_files(source: str, target: str) -> dict[str, Any]:
+    """
+    Compare structural distance between two files.
+    """
+    source_path = Path(source)
+    target_path = Path(target)
+
+    if not source_path.exists():
+        return {"error": f"Source file not found: {source}"}
+    if not target_path.exists():
+        return {"error": f"Target file not found: {target}"}
+
+    return compare_code(
+        source_path.read_text(encoding="utf-8"),
+        target_path.read_text(encoding="utf-8")
+    )
+
+
+@mcp.tool()
+def assess_improvement(current_code: str, proposed_code: str, language: str = "python") -> dict[str, Any]:
+    """
+    Assess if the proposed code is an improvement over the current code.
+    Uses the topos evaluation lattice and structural metrics to determine if the 
+    change improves quality, reduces complexity, or maintainability.
+    
+    Args:
+        current_code: The existing source code.
+        proposed_code: The new or refactored code.
+        language: The programming language (default: 'python').
+        
+    Returns:
+        A comparative analysis of the improvement.
+    """
+    classifier = SubobjectClassifier()
+    lattice = classifier.omega
+
+    try:
+        curr_morph = ProgramMorphism(source=current_code, language=language)
+        prop_morph = ProgramMorphism(source=proposed_code, language=language)
+
+        curr_res = classifier.classify_detailed(curr_morph)
+        prop_res = classifier.classify_detailed(prop_morph)
+
+        # Lattice check
+        is_improvement = lattice.leq(curr_res.evaluation, prop_res.evaluation) and curr_res.evaluation != prop_res.evaluation
+        is_regression = lattice.leq(prop_res.evaluation, curr_res.evaluation) and curr_res.evaluation != prop_res.evaluation
+        
+        # Complexity check
+        complexity_delta = prop_res.complexity_score - curr_res.complexity_score
+        
+        # Distance check
+        dist_res = calculate_ast_distance(curr_morph.ast, prop_morph.ast) if curr_morph.ast and prop_morph.ast else None
+
+        status = "LATERAL_MOVE"
+        if is_improvement:
+            status = "IMPROVEMENT"
+        elif is_regression:
+            status = "REGRESSION"
+        elif curr_res.evaluation == prop_res.evaluation:
+            if complexity_delta < 0:
+                status = "IMPROVEMENT (Lower Complexity)"
+            elif complexity_delta > 0:
+                status = "REGRESSION (Higher Complexity)"
+
+        return {
+            "status": status,
+            "current": {
+                "evaluation": curr_res.evaluation.name,
+                "symbol": curr_res.evaluation.symbol,
+                "complexity": curr_res.complexity_score,
+            },
+            "proposed": {
+                "evaluation": prop_res.evaluation.name,
+                "symbol": prop_res.evaluation.symbol,
+                "complexity": prop_res.complexity_score,
+            },
+            "analysis": {
+                "evaluation_improved": is_improvement,
+                "evaluation_regressed": is_regression,
+                "complexity_delta": complexity_delta,
+                "structural_distance": dist_res.normalized_distance if dist_res else 1.0,
+                "similarity": 1.0 - (dist_res.normalized_distance if dist_res else 1.0),
+            }
+        }
+    except Exception as e:
+        return {"error": str(e)}
+
+
+@mcp.tool()
+def inspect_code(code: str, language: str = "python") -> dict[str, Any]:
+    """
+    Inspect detailed metrics for a code string.
+    
+    Args:
+        code: The source code to inspect.
+        language: The programming language (default: 'python').
+    """
+    try:
+        morphism = ProgramMorphism(source=code, language=language)
+        classifier = SubobjectClassifier()
+        result = classifier.classify_detailed(morphism)
+
+        inspection: dict[str, Any] = {
+            "evaluation": result.evaluation.name,
+            "symbol": result.evaluation.symbol,
+            "is_valid": result.is_valid,
+            "complexity_score": result.complexity_score,
+            "entropy_score": result.entropy_score,
+            "ast_metrics": result.metrics,
+            "functions": {},
+            "entropy_details": {},
+        }
+
+        if morphism.ast:
+            func_complexities = calculate_function_complexities(morphism.ast)
+            if func_complexities:
+                inspection["functions"] = func_complexities
+
+        entropy = calculate_entropy_detailed(morphism.source)
+        inspection["entropy_details"] = {
+            "compression_ratio": entropy.ratio,
+            "interpretation": entropy.interpretation,
+        }
+
+        return inspection
+    except Exception as e:
+        return {"error": str(e)}
+
+
+def main() -> None:
+    """Entry point for the MCP server."""
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/topos/server.py
+++ b/src/topos/server.py
@@ -1,3 +1,4 @@
+import os
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import Any
@@ -17,6 +18,43 @@ except PackageNotFoundError:
 
 mcp = FastMCP("topos", version=__version__)
 
+FILE_ACCESS_ROOT = Path(
+    os.getenv("TOPOS_MCP_FILE_ROOT", Path.cwd())
+).resolve()
+
+
+def _is_within_allowed_root(path: Path) -> bool:
+    """Return whether a path is under the configured file access root."""
+    try:
+        path.relative_to(FILE_ACCESS_ROOT)
+        return True
+    except ValueError:
+        return False
+
+
+def _read_safe_utf8_file(filepath: str) -> tuple[str | None, dict[str, str] | None]:
+    """Read a UTF-8 file if it is within the allowed root and safe to access."""
+    path = Path(filepath)
+
+    try:
+        resolved_path = path.resolve(strict=False)
+    except OSError:
+        return None, {"error": f"Invalid path: {filepath}"}
+
+    if not _is_within_allowed_root(resolved_path):
+        return None, {"error": f"Access denied: path must be under {FILE_ACCESS_ROOT}"}
+
+    try:
+        return resolved_path.read_text(encoding="utf-8"), None
+    except FileNotFoundError:
+        return None, {"error": f"File not found: {filepath}"}
+    except IsADirectoryError:
+        return None, {"error": f"Path is not a file: {filepath}"}
+    except UnicodeDecodeError:
+        return None, {"error": f"File is not valid UTF-8 text: {filepath}"}
+    except OSError as exc:
+        return None, {"error": f"Unable to read file '{filepath}': {exc}"}
+
 
 @mcp.tool()
 def evaluate_code(code: str, language: str = "python") -> dict[str, Any]:
@@ -29,7 +67,8 @@ def evaluate_code(code: str, language: str = "python") -> dict[str, Any]:
         language: The programming language (default: 'python').
         
     Returns:
-        A dictionary containing the evaluation result, metrics, and classification symbol.
+        A dictionary containing the evaluation result,
+        metrics, and classification symbol.
     """
     classifier = SubobjectClassifier()
     try:
@@ -57,14 +96,18 @@ def evaluate_file(filepath: str) -> dict[str, Any]:
     Args:
         filepath: The path to the Python file to evaluate.
     """
-    path = Path(filepath)
-    if not path.exists():
-        return {"error": f"File not found: {filepath}"}
-    return evaluate_code(path.read_text(encoding="utf-8"))
+    source, error = _read_safe_utf8_file(filepath)
+    if error:
+        return error
+    return evaluate_code(source)
 
 
 @mcp.tool()
-def compare_code(source_code: str, target_code: str, language: str = "python") -> dict[str, Any]:
+def compare_code(
+    source_code: str,
+    target_code: str,
+    language: str = "python",
+) -> dict[str, Any]:
     """
     Compare structural distance between two code strings.
     Computes the AST edit distance (topological drift).
@@ -80,9 +123,15 @@ def compare_code(source_code: str, target_code: str, language: str = "python") -
     try:
         source_morph = ProgramMorphism(source=source_code, language=language)
         target_morph = ProgramMorphism(source=target_code, language=language)
+        source_valid = source_morph.is_valid
+        target_valid = target_morph.is_valid
 
-        if source_morph.ast is None or target_morph.ast is None:
-            return {"error": "Failed to parse one or both code snippets."}
+        if not source_valid or not target_valid:
+            return {
+                "error": "Failed to parse one or both code snippets.",
+                "source_valid": source_valid,
+                "target_valid": target_valid,
+            }
 
         result = calculate_ast_distance(source_morph.ast, target_morph.ast)
 
@@ -91,6 +140,8 @@ def compare_code(source_code: str, target_code: str, language: str = "python") -
             "normalized_distance": result.normalized_distance,
             "similarity": 1.0 - result.normalized_distance,
             "operations": result.operations,
+            "source_valid": source_valid,
+            "target_valid": target_valid,
         }
     except Exception as e:
         return {"error": str(e)}
@@ -101,22 +152,26 @@ def compare_files(source: str, target: str) -> dict[str, Any]:
     """
     Compare structural distance between two files.
     """
-    source_path = Path(source)
-    target_path = Path(target)
+    source_text, source_error = _read_safe_utf8_file(source)
+    if source_error:
+        return {"error": f"Source file error: {source_error['error']}"}
 
-    if not source_path.exists():
-        return {"error": f"Source file not found: {source}"}
-    if not target_path.exists():
-        return {"error": f"Target file not found: {target}"}
+    target_text, target_error = _read_safe_utf8_file(target)
+    if target_error:
+        return {"error": f"Target file error: {target_error['error']}"}
 
     return compare_code(
-        source_path.read_text(encoding="utf-8"),
-        target_path.read_text(encoding="utf-8")
+        source_text,
+        target_text,
     )
 
 
 @mcp.tool()
-def assess_improvement(current_code: str, proposed_code: str, language: str = "python") -> dict[str, Any]:
+def assess_improvement(
+    current_code: str,
+    proposed_code: str,
+    language: str = "python",
+) -> dict[str, Any]:
     """
     Assess if the proposed code is an improvement over the current code.
     Uses the topos evaluation lattice and structural metrics to determine if the 
@@ -140,15 +195,24 @@ def assess_improvement(current_code: str, proposed_code: str, language: str = "p
         curr_res = classifier.classify_detailed(curr_morph)
         prop_res = classifier.classify_detailed(prop_morph)
 
-        # Lattice check
-        is_improvement = lattice.leq(curr_res.evaluation, prop_res.evaluation) and curr_res.evaluation != prop_res.evaluation
-        is_regression = lattice.leq(prop_res.evaluation, curr_res.evaluation) and curr_res.evaluation != prop_res.evaluation
-        
-        # Complexity check
+        is_changed_evaluation = curr_res.evaluation != prop_res.evaluation
+        is_improvement = (
+            lattice.leq(curr_res.evaluation, prop_res.evaluation)
+            and is_changed_evaluation
+        )
+        is_regression = (
+            lattice.leq(prop_res.evaluation, curr_res.evaluation)
+            and is_changed_evaluation
+        )
+
         complexity_delta = prop_res.complexity_score - curr_res.complexity_score
-        
-        # Distance check
-        dist_res = calculate_ast_distance(curr_morph.ast, prop_morph.ast) if curr_morph.ast and prop_morph.ast else None
+
+        can_compute_distance = curr_res.is_valid and prop_res.is_valid
+        dist_res = (
+            calculate_ast_distance(curr_morph.ast, prop_morph.ast)
+            if can_compute_distance
+            else None
+        )
 
         status = "LATERAL_MOVE"
         if is_improvement:
@@ -177,8 +241,17 @@ def assess_improvement(current_code: str, proposed_code: str, language: str = "p
                 "evaluation_improved": is_improvement,
                 "evaluation_regressed": is_regression,
                 "complexity_delta": complexity_delta,
-                "structural_distance": dist_res.normalized_distance if dist_res else 1.0,
-                "similarity": 1.0 - (dist_res.normalized_distance if dist_res else 1.0),
+                "distance_computed": can_compute_distance,
+                "structural_distance": (
+                    dist_res.normalized_distance
+                    if dist_res is not None
+                    else None
+                ),
+                "similarity": (
+                    1.0 - dist_res.normalized_distance
+                    if dist_res is not None
+                    else None
+                ),
             }
         }
     except Exception as e:

--- a/src/topos/utils/__init__.py
+++ b/src/topos/utils/__init__.py
@@ -7,6 +7,6 @@ Provides a language-agnostic interface to tree-sitter, designed
 for future extension to multiple programming languages.
 """
 
-from topos.utils.tree_sitter import parse_python, PythonParser
+from topos.utils.tree_sitter import PythonParser, parse_python
 
 __all__ = ["parse_python", "PythonParser"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,64 +1,71 @@
-import pytest
 from click.testing import CliRunner
+
 from topos.main import cli
+
 
 def test_cli_help():
     runner = CliRunner()
-    result = runner.invoke(cli, ['--help'])
+    result = runner.invoke(cli, ["--help"])
     assert result.exit_code == 0
-    assert 'Topos: Category-theoretic code quality evaluation' in result.output
+    assert "Topos: Category-theoretic code quality evaluation" in result.output
+
 
 def test_evaluate_command(tmp_path):
     runner = CliRunner()
-    
+
     # Create a dummy python file
     p = tmp_path / "test_file.py"
     p.write_text("def my_func():\n    pass\n", encoding="utf-8")
-    
-    result = runner.invoke(cli, ['evaluate', str(p)])
+
+    result = runner.invoke(cli, ["evaluate", str(p)])
     assert result.exit_code == 0
-    assert 'test_file.py' in result.output
-    assert 'Overall:' in result.output
+    assert "test_file.py" in result.output
+    assert "Overall:" in result.output
+
 
 def test_evaluate_command_json(tmp_path):
     runner = CliRunner()
     p = tmp_path / "test_file.py"
     p.write_text("def my_func():\n    pass\n", encoding="utf-8")
-    
-    result = runner.invoke(cli, ['evaluate', str(p), '--json'])
+
+    result = runner.invoke(cli, ["evaluate", str(p), "--json"])
     assert result.exit_code == 0
     assert '"results":' in result.output
+
 
 def test_compare_command(tmp_path):
     runner = CliRunner()
     p1 = tmp_path / "file1.py"
     p1.write_text("x = 1\n", encoding="utf-8")
-    
+
     p2 = tmp_path / "file2.py"
     p2.write_text("y = 2\n", encoding="utf-8")
-    
-    result = runner.invoke(cli, ['compare', str(p1), str(p2), '--verbose'])
+
+    result = runner.invoke(cli, ["compare", str(p1), str(p2), "--verbose"])
     assert result.exit_code == 0
-    assert 'Edit Distance:' in result.output
-    assert 'Operations:' in result.output
+    assert "Edit Distance:" in result.output
+    assert "Operations:" in result.output
+
 
 def test_inspect_command(tmp_path):
     runner = CliRunner()
     p = tmp_path / "inspect_file.py"
     p.write_text("def func(x):\n    return x + 1\n", encoding="utf-8")
-    
-    result = runner.invoke(cli, ['inspect', str(p)])
+
+    result = runner.invoke(cli, ["inspect", str(p)])
     assert result.exit_code == 0
-    assert 'Classification' in result.output
-    assert 'Metrics' in result.output
-    assert 'func: 1' in result.output
+    assert "Classification" in result.output
+    assert "Metrics" in result.output
+    assert "func: 1" in result.output
+
 
 def test_evaluate_no_paths():
     runner = CliRunner()
-    result = runner.invoke(cli, ['evaluate'])
-    # Because of the click argument decorator `paths` not having default empty, 
+    result = runner.invoke(cli, ["evaluate"])
+    # Because of the click argument decorator `paths` not having default empty,
     # click might intercept it before our code. Wait, click nargs=-1 does not intercept.
     assert result.exit_code == 1
+
 
 def test_evaluate_directory(tmp_path):
     runner = CliRunner()
@@ -66,7 +73,7 @@ def test_evaluate_directory(tmp_path):
     d.mkdir()
     p = d / "test_file.py"
     p.write_text("def my_func():\n    pass\n", encoding="utf-8")
-    
-    result = runner.invoke(cli, ['evaluate', str(d), '-r'])
+
+    result = runner.invoke(cli, ["evaluate", str(d), "-r"])
     assert result.exit_code == 0
-    assert 'test_file.py' in result.output
+    assert "test_file.py" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,72 @@
+import pytest
+from click.testing import CliRunner
+from topos.main import cli
+
+def test_cli_help():
+    runner = CliRunner()
+    result = runner.invoke(cli, ['--help'])
+    assert result.exit_code == 0
+    assert 'Topos: Category-theoretic code quality evaluation' in result.output
+
+def test_evaluate_command(tmp_path):
+    runner = CliRunner()
+    
+    # Create a dummy python file
+    p = tmp_path / "test_file.py"
+    p.write_text("def my_func():\n    pass\n", encoding="utf-8")
+    
+    result = runner.invoke(cli, ['evaluate', str(p)])
+    assert result.exit_code == 0
+    assert 'test_file.py' in result.output
+    assert 'Overall:' in result.output
+
+def test_evaluate_command_json(tmp_path):
+    runner = CliRunner()
+    p = tmp_path / "test_file.py"
+    p.write_text("def my_func():\n    pass\n", encoding="utf-8")
+    
+    result = runner.invoke(cli, ['evaluate', str(p), '--json'])
+    assert result.exit_code == 0
+    assert '"results":' in result.output
+
+def test_compare_command(tmp_path):
+    runner = CliRunner()
+    p1 = tmp_path / "file1.py"
+    p1.write_text("x = 1\n", encoding="utf-8")
+    
+    p2 = tmp_path / "file2.py"
+    p2.write_text("y = 2\n", encoding="utf-8")
+    
+    result = runner.invoke(cli, ['compare', str(p1), str(p2), '--verbose'])
+    assert result.exit_code == 0
+    assert 'Edit Distance:' in result.output
+    assert 'Operations:' in result.output
+
+def test_inspect_command(tmp_path):
+    runner = CliRunner()
+    p = tmp_path / "inspect_file.py"
+    p.write_text("def func(x):\n    return x + 1\n", encoding="utf-8")
+    
+    result = runner.invoke(cli, ['inspect', str(p)])
+    assert result.exit_code == 0
+    assert 'Classification' in result.output
+    assert 'Metrics' in result.output
+    assert 'func: 1' in result.output
+
+def test_evaluate_no_paths():
+    runner = CliRunner()
+    result = runner.invoke(cli, ['evaluate'])
+    # Because of the click argument decorator `paths` not having default empty, 
+    # click might intercept it before our code. Wait, click nargs=-1 does not intercept.
+    assert result.exit_code == 1
+
+def test_evaluate_directory(tmp_path):
+    runner = CliRunner()
+    d = tmp_path / "src"
+    d.mkdir()
+    p = d / "test_file.py"
+    p.write_text("def my_func():\n    pass\n", encoding="utf-8")
+    
+    result = runner.invoke(cli, ['evaluate', str(d), '-r'])
+    assert result.exit_code == 0
+    assert 'test_file.py' in result.output

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,78 @@
+import pytest
+from topos.core.object import ProgramObject
+from topos.core.morphism import ProgramMorphism
+from topos.utils.tree_sitter import parse_python
+
+def test_program_object_basic():
+    source = "def hello():\n    print('world')"
+    root = parse_python(source)
+    obj = ProgramObject(root=root, source=source)
+    
+    assert obj.source == source
+    assert obj.language == "python"
+    assert obj.is_valid is True
+    assert obj.node_count > 0
+    assert obj.depth > 0
+
+def test_program_object_traversal():
+    source = "x = 1 + 2"
+    root = parse_python(source)
+    obj = ProgramObject(root=root, source=source)
+    
+    nodes = list(obj.traverse())
+    assert len(nodes) == obj.node_count
+    
+    # Check for specific node types
+    assignments = list(obj.nodes_of_type("assignment"))
+    assert len(assignments) == 1
+
+def test_program_morphism_basic():
+    source = "def add(a, b): return a + b"
+    morphism = ProgramMorphism(source=source)
+    
+    assert morphism.source == source
+    assert morphism.is_valid is True
+    assert morphism.ast is not None
+    assert "add" in morphism.name or "<morphism:" in morphism.name
+
+def test_program_morphism_invalid_syntax():
+    source = "def incomplete_func("
+    morphism = ProgramMorphism(source=source)
+    
+    # tree-sitter might still "parse" it but with ERROR nodes
+    assert morphism.ast is not None
+    # ProgramObject.is_valid checks root.has_error
+    assert morphism.is_valid is False
+
+def test_program_morphism_equality():
+    source1 = "x = 1"
+    source2 = "x = 1"
+    source3 = "y = 2"
+    
+    m1 = ProgramMorphism(source=source1)
+    m2 = ProgramMorphism(source=source2)
+    m3 = ProgramMorphism(source=source3)
+    
+    assert m1 == m2
+    assert m1 != m3
+    assert hash(m1) == hash(m2)
+
+def test_program_morphism_from_file_and_classify(tmp_path):
+    p = tmp_path / 'hello.py'
+    p.write_text("print('hello world')", encoding='utf-8')
+    morphism = ProgramMorphism.from_file(p)
+    assert morphism.filepath == p
+    assert morphism.name == 'hello.py'
+    
+    from topos.logic.lattice import EvaluationValue
+    eval_val = morphism.classify()
+    assert isinstance(eval_val, EvaluationValue)
+
+def test_program_morphism_eq_not_implemented():
+    morphism = ProgramMorphism(source='x = 1')
+    assert morphism != 'not a morphism'
+
+def test_program_object_eq_not_implemented():
+    root = parse_python('x = 1')
+    obj = ProgramObject(root=root, source='x = 1')
+    assert obj != 'not a program object'

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,78 +1,86 @@
-import pytest
-from topos.core.object import ProgramObject
 from topos.core.morphism import ProgramMorphism
+from topos.core.object import ProgramObject
 from topos.utils.tree_sitter import parse_python
+
 
 def test_program_object_basic():
     source = "def hello():\n    print('world')"
     root = parse_python(source)
     obj = ProgramObject(root=root, source=source)
-    
+
     assert obj.source == source
     assert obj.language == "python"
     assert obj.is_valid is True
     assert obj.node_count > 0
     assert obj.depth > 0
 
+
 def test_program_object_traversal():
     source = "x = 1 + 2"
     root = parse_python(source)
     obj = ProgramObject(root=root, source=source)
-    
+
     nodes = list(obj.traverse())
     assert len(nodes) == obj.node_count
-    
+
     # Check for specific node types
     assignments = list(obj.nodes_of_type("assignment"))
     assert len(assignments) == 1
 
+
 def test_program_morphism_basic():
     source = "def add(a, b): return a + b"
     morphism = ProgramMorphism(source=source)
-    
+
     assert morphism.source == source
     assert morphism.is_valid is True
     assert morphism.ast is not None
     assert "add" in morphism.name or "<morphism:" in morphism.name
 
+
 def test_program_morphism_invalid_syntax():
     source = "def incomplete_func("
     morphism = ProgramMorphism(source=source)
-    
+
     # tree-sitter might still "parse" it but with ERROR nodes
     assert morphism.ast is not None
     # ProgramObject.is_valid checks root.has_error
     assert morphism.is_valid is False
 
+
 def test_program_morphism_equality():
     source1 = "x = 1"
     source2 = "x = 1"
     source3 = "y = 2"
-    
+
     m1 = ProgramMorphism(source=source1)
     m2 = ProgramMorphism(source=source2)
     m3 = ProgramMorphism(source=source3)
-    
+
     assert m1 == m2
     assert m1 != m3
     assert hash(m1) == hash(m2)
 
+
 def test_program_morphism_from_file_and_classify(tmp_path):
-    p = tmp_path / 'hello.py'
-    p.write_text("print('hello world')", encoding='utf-8')
+    p = tmp_path / "hello.py"
+    p.write_text("print('hello world')", encoding="utf-8")
     morphism = ProgramMorphism.from_file(p)
     assert morphism.filepath == p
-    assert morphism.name == 'hello.py'
-    
+    assert morphism.name == "hello.py"
+
     from topos.logic.lattice import EvaluationValue
+
     eval_val = morphism.classify()
     assert isinstance(eval_val, EvaluationValue)
 
+
 def test_program_morphism_eq_not_implemented():
-    morphism = ProgramMorphism(source='x = 1')
-    assert morphism != 'not a morphism'
+    morphism = ProgramMorphism(source="x = 1")
+    assert morphism != "not a morphism"
+
 
 def test_program_object_eq_not_implemented():
-    root = parse_python('x = 1')
-    obj = ProgramObject(root=root, source='x = 1')
-    assert obj != 'not a program object'
+    root = parse_python("x = 1")
+    obj = ProgramObject(root=root, source="x = 1")
+    assert obj != "not a program object"

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1,0 +1,106 @@
+import pytest
+from topos.logic.lattice import EvaluationValue, EvaluationLattice
+from topos.logic.omega import SubobjectClassifier
+from topos.core.morphism import ProgramMorphism
+
+def test_evaluation_value_order():
+    # Basic ordering checks if they were a total chain (they aren't, but let's check the lattice)
+    lattice = EvaluationLattice() # default uses total chain fallback or DEFAULT_COVER
+    
+    # Using the DEFAULT_COVER which is non-total
+    assert lattice.leq(EvaluationValue.INVALID, EvaluationValue.VERIFIED)
+    assert lattice.leq(EvaluationValue.COMMODITY, EvaluationValue.VERIFIED)
+    assert lattice.leq(EvaluationValue.NOISY, EvaluationValue.COMMODITY)
+    
+    # Check incomparable elements
+    # NOISY and WEAK are both <= COMMODITY but not necessarily related to each other in a simple chain
+    # In DEFAULT_COVER:
+    # INVALID -> HALLUCINATED, NOISY, WEAK, COMMODITY
+    # NOISY -> COMMODITY
+    # WEAK -> COMMODITY
+    # COMMODITY -> VERIFIED
+    
+    assert not lattice.leq(EvaluationValue.NOISY, EvaluationValue.WEAK)
+    assert not lattice.leq(EvaluationValue.WEAK, EvaluationValue.NOISY)
+
+def test_lattice_meet_join():
+    lattice = EvaluationLattice()
+    
+    # Meet (And / GLB)
+    assert lattice.meet(EvaluationValue.VERIFIED, EvaluationValue.COMMODITY) == EvaluationValue.COMMODITY
+    assert lattice.meet(EvaluationValue.NOISY, EvaluationValue.WEAK) == EvaluationValue.INVALID
+    
+    # Join (Or / LUB)
+    assert lattice.join(EvaluationValue.NOISY, EvaluationValue.WEAK) == EvaluationValue.COMMODITY
+    assert lattice.join(EvaluationValue.INVALID, EvaluationValue.VERIFIED) == EvaluationValue.VERIFIED
+
+def test_subobject_classifier_simple():
+    classifier = SubobjectClassifier()
+    
+    # Use a slightly longer piece of code to avoid high compression ratios (entropy) on tiny strings
+    source = """
+def process_data(data):
+    \"\"\"Process the input data list.\"\"\"
+    result = []
+    for item in data:
+        if item is not None:
+            result.append(item * 2)
+    return result
+"""
+    morphism = ProgramMorphism(source=source)
+    
+    result = classifier.classify_detailed(morphism)
+    assert result.is_valid is True
+    # Clean code should be VERIFIED or at least COMMODITY
+    assert result.evaluation >= EvaluationValue.COMMODITY
+
+def test_subobject_classifier_invalid():
+    classifier = SubobjectClassifier()
+    
+    source = "def broken(:"
+    morphism = ProgramMorphism(source=source)
+    
+    evaluation = classifier.classify(morphism)
+    assert evaluation == EvaluationValue.INVALID
+
+def test_classifier_aggregation():
+    classifier = SubobjectClassifier()
+    
+    # Meet of VERIFIED and NOISY should be NOISY (if they are in a chain)
+    # Wait, in our lattice NOISY <= COMMODITY <= VERIFIED.
+    # So meet(VERIFIED, NOISY) = NOISY.
+    
+    val1 = EvaluationValue.VERIFIED
+    val2 = EvaluationValue.NOISY
+    
+    combined = classifier.combine(val1, val2)
+    assert combined == EvaluationValue.NOISY
+
+from topos.logic.policies import EvaluationSection, ObservationBin, section
+
+def test_evaluation_value_properties():
+    val = EvaluationValue.VERIFIED
+    assert val.symbol == '⊤'
+    assert 'Verified' in val.description
+    assert 'VERIFIED' in str(val)
+
+def test_lattice_implies_and_negation():
+    lattice = EvaluationLattice()
+    
+    # negation = implies(val, BOTTOM)
+    # VERIFIED -> INVALID should be INVALID or similar in Heyting
+    assert lattice.negation(EvaluationValue.INVALID) == EvaluationValue.VERIFIED
+    
+    # equivalent
+    assert lattice.equivalent(EvaluationValue.COMMODITY, EvaluationValue.COMMODITY) is True
+    assert lattice.equivalent(EvaluationValue.COMMODITY, EvaluationValue.VERIFIED) is False
+
+def test_subobject_classifier_str():
+    classifier = SubobjectClassifier()
+    morphism = ProgramMorphism(source='x = 1')
+    res = classifier.classify_detailed(morphism)
+    assert 'Classification:' in str(res)
+
+def test_policies_classify_error():
+    with pytest.raises(ValueError):
+        section._classify(-100.0, section.complexity_bins)

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1,43 +1,63 @@
 import pytest
-from topos.logic.lattice import EvaluationValue, EvaluationLattice
-from topos.logic.omega import SubobjectClassifier
+
 from topos.core.morphism import ProgramMorphism
+from topos.logic.lattice import EvaluationLattice, EvaluationValue
+from topos.logic.omega import SubobjectClassifier
+from topos.logic.policies import section
+
 
 def test_evaluation_value_order():
-    # Basic ordering checks if they were a total chain (they aren't, but let's check the lattice)
-    lattice = EvaluationLattice() # default uses total chain fallback or DEFAULT_COVER
-    
+    # Basic ordering checks if they were a total chain (they aren't,
+    # but let's check the lattice)
+    lattice = EvaluationLattice()  # default uses total chain fallback or DEFAULT_COVER
+
     # Using the DEFAULT_COVER which is non-total
     assert lattice.leq(EvaluationValue.INVALID, EvaluationValue.VERIFIED)
     assert lattice.leq(EvaluationValue.COMMODITY, EvaluationValue.VERIFIED)
     assert lattice.leq(EvaluationValue.NOISY, EvaluationValue.COMMODITY)
-    
+
     # Check incomparable elements
-    # NOISY and WEAK are both <= COMMODITY but not necessarily related to each other in a simple chain
+    # NOISY and WEAK are both <= COMMODITY but not necessarily related
+    # to each other in a simple chain
     # In DEFAULT_COVER:
     # INVALID -> HALLUCINATED, NOISY, WEAK, COMMODITY
     # NOISY -> COMMODITY
     # WEAK -> COMMODITY
     # COMMODITY -> VERIFIED
-    
+
     assert not lattice.leq(EvaluationValue.NOISY, EvaluationValue.WEAK)
     assert not lattice.leq(EvaluationValue.WEAK, EvaluationValue.NOISY)
 
+
 def test_lattice_meet_join():
     lattice = EvaluationLattice()
-    
+
     # Meet (And / GLB)
-    assert lattice.meet(EvaluationValue.VERIFIED, EvaluationValue.COMMODITY) == EvaluationValue.COMMODITY
-    assert lattice.meet(EvaluationValue.NOISY, EvaluationValue.WEAK) == EvaluationValue.INVALID
-    
+    assert (
+        lattice.meet(EvaluationValue.VERIFIED, EvaluationValue.COMMODITY)
+        == EvaluationValue.COMMODITY
+    )
+    assert (
+        lattice.meet(EvaluationValue.NOISY, EvaluationValue.WEAK)
+        == EvaluationValue.INVALID
+    )
+
     # Join (Or / LUB)
-    assert lattice.join(EvaluationValue.NOISY, EvaluationValue.WEAK) == EvaluationValue.COMMODITY
-    assert lattice.join(EvaluationValue.INVALID, EvaluationValue.VERIFIED) == EvaluationValue.VERIFIED
+    assert (
+        lattice.join(EvaluationValue.NOISY, EvaluationValue.WEAK)
+        == EvaluationValue.COMMODITY
+    )
+    assert (
+        lattice.join(EvaluationValue.INVALID, EvaluationValue.VERIFIED)
+        == EvaluationValue.VERIFIED
+    )
+
 
 def test_subobject_classifier_simple():
     classifier = SubobjectClassifier()
-    
-    # Use a slightly longer piece of code to avoid high compression ratios (entropy) on tiny strings
+
+    # Use a slightly longer piece of code to avoid high compression ratios
+    # (entropy) on tiny strings
     source = """
 def process_data(data):
     \"\"\"Process the input data list.\"\"\"
@@ -48,58 +68,62 @@ def process_data(data):
     return result
 """
     morphism = ProgramMorphism(source=source)
-    
+
     result = classifier.classify_detailed(morphism)
     assert result.is_valid is True
     # Clean code should be VERIFIED or at least COMMODITY
     assert result.evaluation >= EvaluationValue.COMMODITY
 
+
 def test_subobject_classifier_invalid():
     classifier = SubobjectClassifier()
-    
+
     source = "def broken(:"
     morphism = ProgramMorphism(source=source)
-    
+
     evaluation = classifier.classify(morphism)
     assert evaluation == EvaluationValue.INVALID
 
+
 def test_classifier_aggregation():
     classifier = SubobjectClassifier()
-    
+
     # Meet of VERIFIED and NOISY should be NOISY (if they are in a chain)
     # Wait, in our lattice NOISY <= COMMODITY <= VERIFIED.
     # So meet(VERIFIED, NOISY) = NOISY.
-    
+
     val1 = EvaluationValue.VERIFIED
     val2 = EvaluationValue.NOISY
-    
+
     combined = classifier.combine(val1, val2)
     assert combined == EvaluationValue.NOISY
 
-from topos.logic.policies import EvaluationSection, ObservationBin, section
 
 def test_evaluation_value_properties():
     val = EvaluationValue.VERIFIED
-    assert val.symbol == '⊤'
-    assert 'Verified' in val.description
-    assert 'VERIFIED' in str(val)
+    assert val.symbol == "⊤"
+    assert "Verified" in val.description
+    assert "VERIFIED" in str(val)
+
 
 def test_lattice_implies_and_negation():
     lattice = EvaluationLattice()
-    
+
     # negation = implies(val, BOTTOM)
     # VERIFIED -> INVALID should be INVALID or similar in Heyting
     assert lattice.negation(EvaluationValue.INVALID) == EvaluationValue.VERIFIED
-    
+
     # equivalent
-    assert lattice.equivalent(EvaluationValue.COMMODITY, EvaluationValue.COMMODITY) is True
-    assert lattice.equivalent(EvaluationValue.COMMODITY, EvaluationValue.VERIFIED) is False
+    assert lattice.equivalent(EvaluationValue.COMMODITY, EvaluationValue.COMMODITY)
+    assert not lattice.equivalent(EvaluationValue.COMMODITY, EvaluationValue.VERIFIED)
+
 
 def test_subobject_classifier_str():
     classifier = SubobjectClassifier()
-    morphism = ProgramMorphism(source='x = 1')
+    morphism = ProgramMorphism(source="x = 1")
     res = classifier.classify_detailed(morphism)
-    assert 'Classification:' in str(res)
+    assert "Classification:" in str(res)
+
 
 def test_policies_classify_error():
     with pytest.raises(ValueError):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,139 @@
+import pytest
+from topos.metrics.complexity import (
+    calculate_cyclomatic_complexity,
+    calculate_function_complexities,
+    calculate_average_complexity
+)
+from topos.metrics.entropy import (
+    calculate_kolmogorov_proxy,
+    calculate_entropy_detailed,
+    calculate_block_entropy,
+    calculate_entropy_variance
+)
+from topos.metrics.distance import (
+    calculate_ast_distance,
+    calculate_similarity,
+    are_clones
+)
+from topos.core.object import ProgramObject
+from topos.utils.tree_sitter import parse_python
+
+def test_cyclomatic_complexity_basic():
+    source = "def foo():\n    if True:\n        pass\n    else:\n        pass"
+    root = parse_python(source)
+    ast = ProgramObject(root=root, source=source)
+    
+    # Base 1 + 1 for 'if' = 2
+    assert calculate_cyclomatic_complexity(ast) == 2
+
+def test_cyclomatic_complexity_loop():
+    source = "def foo():\n    for i in range(10):\n        while True:\n            break"
+    root = parse_python(source)
+    ast = ProgramObject(root=root, source=source)
+    
+    # Base 1 + 1 for 'for' + 1 for 'while' = 3
+    assert calculate_cyclomatic_complexity(ast) == 3
+
+def test_function_complexities():
+    source = """
+def simple():
+    pass
+
+def complex_func():
+    if True:
+        pass
+"""
+    root = parse_python(source)
+    ast = ProgramObject(root=root, source=source)
+    
+    complexities = calculate_function_complexities(ast)
+    assert complexities["simple"] == 1
+    assert complexities["complex_func"] == 2
+    assert calculate_average_complexity(ast) == 1.5
+
+def test_kolmogorov_proxy():
+    simple_source = "x = 1" * 100
+    complex_source = "".join(chr(i % 256) for i in range(400))
+    
+    simple_entropy = calculate_kolmogorov_proxy(simple_source)
+    complex_entropy = calculate_kolmogorov_proxy(complex_source)
+    
+    # Simple, repetitive source should be more compressible (lower ratio)
+    assert simple_entropy < complex_entropy
+
+def test_entropy_detailed():
+    source = "def hello():\n    print('world')"
+    result = calculate_entropy_detailed(source)
+    
+    assert result.original_size > 0
+    assert result.compressed_size > 0
+    # On very small strings, compressed size can be slightly larger than original
+    assert 0 <= result.ratio <= 2.0
+    assert isinstance(result.interpretation, str)
+
+def test_complexity_boolean_operator():
+    source = "if a and b and c: pass"
+    root = parse_python(source)
+    ast = ProgramObject(root=root, source=source)
+    # base 1 + if 1 + and 1 + and 1 = 4
+    assert calculate_cyclomatic_complexity(ast) > 1
+
+def test_average_complexity_empty():
+    source = "x = 1"
+    root = parse_python(source)
+    ast = ProgramObject(root=root, source=source)
+    assert calculate_average_complexity(ast) == 1.0
+
+def test_entropy_empty_source():
+    assert calculate_kolmogorov_proxy("") == 0.0
+    res = calculate_entropy_detailed("")
+    assert res.ratio == 0.0
+    assert res.interpretation == "empty"
+
+def test_block_entropy():
+    source = "x = 1\n" * 50
+    blocks = calculate_block_entropy(source, block_size=10)
+    assert len(blocks) > 0
+    variance = calculate_entropy_variance(source, block_size=10)
+    assert variance >= 0.0
+    
+    assert calculate_entropy_variance("") == 0.0
+
+def test_distance_metrics():
+    source1 = "x = 1"
+    source2 = "y = 2"
+    source3 = "def foo():\n    pass"
+    
+    ast1 = ProgramObject(root=parse_python(source1), source=source1)
+    ast2 = ProgramObject(root=parse_python(source2), source=source2)
+    ast3 = ProgramObject(root=parse_python(source3), source=source3)
+    
+    dist1_2 = calculate_ast_distance(ast1, ast2)
+    assert dist1_2.raw_distance >= 0
+    
+    dist1_3 = calculate_ast_distance(ast1, ast3)
+    assert dist1_3.raw_distance > dist1_2.raw_distance
+    
+    sim = calculate_similarity(ast1, ast1)
+    assert sim == 1.0
+    
+    assert are_clones(ast1, ast2, threshold=0.1) is True
+    assert are_clones(ast1, ast3, threshold=0.1) is False
+
+def test_distance_result_str():
+    from topos.metrics.distance import DistanceResult
+    res = DistanceResult(raw_distance=2, normalized_distance=0.5, operations={})
+    assert 'Distance:' in str(res)
+
+def test_entropy_result_str():
+    from topos.metrics.entropy import EntropyResult
+    res = EntropyResult(ratio=0.5, compressed_size=10, original_size=20, interpretation='normal')
+    assert 'Entropy:' in str(res)
+
+def test_distance_substitution():
+    source1 = 'x = 1'
+    source2 = 'def foo(): pass'
+    ast1 = ProgramObject(root=parse_python(source1), source=source1)
+    ast2 = ProgramObject(root=parse_python(source2), source=source2)
+    dist = calculate_ast_distance(ast1, ast2)
+    assert dist.operations.get('substitutions', 0) >= 0

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,38 +1,42 @@
-import pytest
+from topos.core.object import ProgramObject
 from topos.metrics.complexity import (
+    calculate_average_complexity,
     calculate_cyclomatic_complexity,
     calculate_function_complexities,
-    calculate_average_complexity
-)
-from topos.metrics.entropy import (
-    calculate_kolmogorov_proxy,
-    calculate_entropy_detailed,
-    calculate_block_entropy,
-    calculate_entropy_variance
 )
 from topos.metrics.distance import (
+    are_clones,
     calculate_ast_distance,
     calculate_similarity,
-    are_clones
 )
-from topos.core.object import ProgramObject
+from topos.metrics.entropy import (
+    calculate_block_entropy,
+    calculate_entropy_detailed,
+    calculate_entropy_variance,
+    calculate_kolmogorov_proxy,
+)
 from topos.utils.tree_sitter import parse_python
+
 
 def test_cyclomatic_complexity_basic():
     source = "def foo():\n    if True:\n        pass\n    else:\n        pass"
     root = parse_python(source)
     ast = ProgramObject(root=root, source=source)
-    
+
     # Base 1 + 1 for 'if' = 2
     assert calculate_cyclomatic_complexity(ast) == 2
 
+
 def test_cyclomatic_complexity_loop():
-    source = "def foo():\n    for i in range(10):\n        while True:\n            break"
+    source = (
+        "def foo():\n    for i in range(10):\n        while True:\n            break"
+    )
     root = parse_python(source)
     ast = ProgramObject(root=root, source=source)
-    
+
     # Base 1 + 1 for 'for' + 1 for 'while' = 3
     assert calculate_cyclomatic_complexity(ast) == 3
+
 
 def test_function_complexities():
     source = """
@@ -45,31 +49,34 @@ def complex_func():
 """
     root = parse_python(source)
     ast = ProgramObject(root=root, source=source)
-    
+
     complexities = calculate_function_complexities(ast)
     assert complexities["simple"] == 1
     assert complexities["complex_func"] == 2
     assert calculate_average_complexity(ast) == 1.5
 
+
 def test_kolmogorov_proxy():
     simple_source = "x = 1" * 100
     complex_source = "".join(chr(i % 256) for i in range(400))
-    
+
     simple_entropy = calculate_kolmogorov_proxy(simple_source)
     complex_entropy = calculate_kolmogorov_proxy(complex_source)
-    
+
     # Simple, repetitive source should be more compressible (lower ratio)
     assert simple_entropy < complex_entropy
+
 
 def test_entropy_detailed():
     source = "def hello():\n    print('world')"
     result = calculate_entropy_detailed(source)
-    
+
     assert result.original_size > 0
     assert result.compressed_size > 0
     # On very small strings, compressed size can be slightly larger than original
     assert 0 <= result.ratio <= 2.0
     assert isinstance(result.interpretation, str)
+
 
 def test_complexity_boolean_operator():
     source = "if a and b and c: pass"
@@ -78,11 +85,13 @@ def test_complexity_boolean_operator():
     # base 1 + if 1 + and 1 + and 1 = 4
     assert calculate_cyclomatic_complexity(ast) > 1
 
+
 def test_average_complexity_empty():
     source = "x = 1"
     root = parse_python(source)
     ast = ProgramObject(root=root, source=source)
     assert calculate_average_complexity(ast) == 1.0
+
 
 def test_entropy_empty_source():
     assert calculate_kolmogorov_proxy("") == 0.0
@@ -90,50 +99,59 @@ def test_entropy_empty_source():
     assert res.ratio == 0.0
     assert res.interpretation == "empty"
 
+
 def test_block_entropy():
     source = "x = 1\n" * 50
     blocks = calculate_block_entropy(source, block_size=10)
     assert len(blocks) > 0
     variance = calculate_entropy_variance(source, block_size=10)
     assert variance >= 0.0
-    
+
     assert calculate_entropy_variance("") == 0.0
+
 
 def test_distance_metrics():
     source1 = "x = 1"
     source2 = "y = 2"
     source3 = "def foo():\n    pass"
-    
+
     ast1 = ProgramObject(root=parse_python(source1), source=source1)
     ast2 = ProgramObject(root=parse_python(source2), source=source2)
     ast3 = ProgramObject(root=parse_python(source3), source=source3)
-    
+
     dist1_2 = calculate_ast_distance(ast1, ast2)
     assert dist1_2.raw_distance >= 0
-    
+
     dist1_3 = calculate_ast_distance(ast1, ast3)
     assert dist1_3.raw_distance > dist1_2.raw_distance
-    
+
     sim = calculate_similarity(ast1, ast1)
     assert sim == 1.0
-    
+
     assert are_clones(ast1, ast2, threshold=0.1) is True
     assert are_clones(ast1, ast3, threshold=0.1) is False
 
+
 def test_distance_result_str():
     from topos.metrics.distance import DistanceResult
+
     res = DistanceResult(raw_distance=2, normalized_distance=0.5, operations={})
-    assert 'Distance:' in str(res)
+    assert "Distance:" in str(res)
+
 
 def test_entropy_result_str():
     from topos.metrics.entropy import EntropyResult
-    res = EntropyResult(ratio=0.5, compressed_size=10, original_size=20, interpretation='normal')
-    assert 'Entropy:' in str(res)
+
+    res = EntropyResult(
+        ratio=0.5, compressed_size=10, original_size=20, interpretation="normal"
+    )
+    assert "Entropy:" in str(res)
+
 
 def test_distance_substitution():
-    source1 = 'x = 1'
-    source2 = 'def foo(): pass'
+    source1 = "x = 1"
+    source2 = "def foo(): pass"
     ast1 = ProgramObject(root=parse_python(source1), source=source1)
     ast2 = ProgramObject(root=parse_python(source2), source=source2)
     dist = calculate_ast_distance(ast1, ast2)
-    assert dist.operations.get('substitutions', 0) >= 0
+    assert dist.operations.get("substitutions", 0) >= 0

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from topos import server
+
+
+def test_compare_code_reports_validity_flags_on_parse_error() -> None:
+    response = server.compare_code(
+        source_code="x = 1\n",
+        target_code="def broken(:\n    pass\n",
+    )
+
+    assert "error" in response
+    assert response["source_valid"] is True
+    assert response["target_valid"] is False
+
+
+def test_assess_improvement_skips_distance_for_invalid_code() -> None:
+    response = server.assess_improvement(
+        current_code="x = 1\n",
+        proposed_code="def broken(:\n    pass\n",
+    )
+
+    assert "analysis" in response
+    assert response["analysis"]["distance_computed"] is False
+    assert response["analysis"]["structural_distance"] is None
+    assert response["analysis"]["similarity"] is None
+
+
+@pytest.fixture
+def isolated_file_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    monkeypatch.setattr(server, "FILE_ACCESS_ROOT", tmp_path.resolve())
+    return tmp_path
+
+
+def test_evaluate_file_rejects_path_outside_allowed_root(
+    isolated_file_root: Path,
+) -> None:
+    response = server.evaluate_file(str(Path(__file__).resolve()))
+
+    assert "error" in response
+    assert "Access denied" in response["error"]
+
+
+def test_evaluate_file_rejects_non_file_path(isolated_file_root: Path) -> None:
+    directory = isolated_file_root / "dir"
+    directory.mkdir()
+
+    response = server.evaluate_file(str(directory))
+
+    assert "error" in response
+    assert "not a file" in response["error"]
+
+
+def test_evaluate_file_handles_decode_error(isolated_file_root: Path) -> None:
+    bad_text_file = isolated_file_root / "bad.py"
+    bad_text_file.write_bytes(b"\xff\xfe")
+
+    response = server.evaluate_file(str(bad_text_file))
+
+    assert "error" in response
+    assert "not valid UTF-8" in response["error"]
+
+
+def test_compare_files_reports_target_file_error(isolated_file_root: Path) -> None:
+    source_file = isolated_file_root / "source.py"
+    source_file.write_text("x = 1\n", encoding="utf-8")
+
+    response = server.compare_files(
+        source=str(source_file),
+        target=str(isolated_file_root / "missing.py"),
+    )
+
+    assert "error" in response
+    assert response["error"].startswith("Target file error:")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,94 @@
+import pytest
+from pathlib import Path
+
+from topos.server import (
+    evaluate_code,
+    evaluate_file,
+    compare_code,
+    compare_files,
+    assess_improvement,
+    inspect_code,
+    __version__
+)
+
+def test_server_version():
+    assert isinstance(__version__, str)
+
+def test_evaluate_code():
+    code = "def foo(): pass"
+    res = evaluate_code(code)
+    assert "evaluation" in res
+    assert "symbol" in res
+    assert res.get("is_valid") is True
+
+def test_evaluate_code_error():
+    # evaluate_code won't raise Exception on parse since tree_sitter is robust,
+    # but let's test language mismatch or something to trigger error.
+    res = evaluate_code("x = 1", language="unknown")
+    assert "error" in res
+
+def test_evaluate_file(tmp_path):
+    p = tmp_path / "test.py"
+    p.write_text("x = 1", encoding="utf-8")
+    
+    res = evaluate_file(str(p))
+    assert "evaluation" in res
+
+def test_evaluate_file_not_found():
+    res = evaluate_file("does_not_exist.py")
+    assert "error" in res
+
+def test_compare_code():
+    source = "x = 1"
+    target = "y = 2"
+    res = compare_code(source, target)
+    assert "raw_distance" in res
+    assert "operations" in res
+
+def test_compare_code_error():
+    res = compare_code("x=1", "y=2", language="unknown")
+    assert "error" in res
+
+def test_compare_files(tmp_path):
+    p1 = tmp_path / "1.py"
+    p2 = tmp_path / "2.py"
+    p1.write_text("x = 1", encoding="utf-8")
+    p2.write_text("y = 2", encoding="utf-8")
+    
+    res = compare_files(str(p1), str(p2))
+    assert "raw_distance" in res
+
+def test_compare_files_not_found(tmp_path):
+    res1 = compare_files("missing.py", "target.py")
+    assert "error" in res1
+    
+    p = tmp_path / "exist.py"
+    p.write_text("x", encoding="utf-8")
+    res2 = compare_files(str(p), "missing.py")
+    assert "error" in res2
+
+def test_assess_improvement():
+    curr = "def f(x):\n    pass"
+    prop = "def f(x"
+    
+    res = assess_improvement(curr, prop)
+    assert "status" in res
+    assert "current" in res
+    assert "proposed" in res
+    assert "REGRESSION" in res["status"]
+
+def test_assess_improvement_error():
+    res = assess_improvement("x", "y", language="unknown")
+    assert "error" in res
+
+def test_inspect_code():
+    code = "def add(a, b): return a + b"
+    res = inspect_code(code)
+    assert "evaluation" in res
+    assert "ast_metrics" in res
+    assert "functions" in res
+    assert "entropy_details" in res
+
+def test_inspect_code_error():
+    res = inspect_code("x", language="unknown")
+    assert "error" in res

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -16,11 +16,13 @@ def isolated_file_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
 
 # --- Metadata & Basic Info ---
 
+
 def test_server_version() -> None:
     assert isinstance(server.__version__, str)
 
 
 # --- Code Evaluation Tools ---
+
 
 def test_evaluate_code_happy_path() -> None:
     code = "def foo(): pass"
@@ -46,6 +48,7 @@ def test_inspect_code_happy_path() -> None:
 
 # --- Structural Comparison Tools ---
 
+
 def test_compare_code_happy_path() -> None:
     res = server.compare_code(source_code="x = 1", target_code="y = 2")
     assert "raw_distance" in res
@@ -67,7 +70,7 @@ def test_compare_code_reports_validity_flags_on_parse_error() -> None:
 def test_assess_improvement_regression() -> None:
     curr = "def f(x):\n    pass"
     prop = "def f(x"  # Syntactically broken
-    
+
     res = server.assess_improvement(curr, prop)
     assert "status" in res
     assert "REGRESSION" in res["status"]
@@ -77,10 +80,11 @@ def test_assess_improvement_regression() -> None:
 
 # --- File-Based Tools & Safety ---
 
+
 def test_evaluate_file_happy_path(isolated_file_root: Path) -> None:
     p = isolated_file_root / "test.py"
     p.write_text("x = 1", encoding="utf-8")
-    
+
     res = server.evaluate_file(str(p))
     assert "evaluation" in res
 
@@ -118,7 +122,7 @@ def test_compare_files_happy_path(isolated_file_root: Path) -> None:
     p2 = isolated_file_root / "2.py"
     p1.write_text("x = 1", encoding="utf-8")
     p2.write_text("y = 2", encoding="utf-8")
-    
+
     res = server.compare_files(str(p1), str(p2))
     assert "raw_distance" in res
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,11 +1,11 @@
-import pytest
 from topos.utils.tree_sitter import (
-    parse_python,
+    PythonParser,
+    find_errors,
     node_text,
     node_to_sexp,
-    find_errors,
-    PythonParser
+    parse_python,
 )
+
 
 def test_parse_python():
     source = "x = 1 + 2"
@@ -13,37 +13,41 @@ def test_parse_python():
     assert root.type == "module"
     assert not root.has_error
 
+
 def test_node_text():
     source = "def foo(): pass"
     root = parse_python(source)
-    
+
     # The first child of module is usually the statement
     stmt = root.children[0]
     text = node_text(stmt, source)
     assert text == "def foo(): pass"
 
+
 def test_find_errors():
     source = "def broken(:"
     root = parse_python(source)
-    
+
     errors = find_errors(root)
     assert len(errors) > 0
     assert any(e.type == "ERROR" or e.is_missing for e in errors)
+
 
 def test_node_to_sexp():
     source = "x = 1"
     root = parse_python(source)
     sexp = node_to_sexp(root)
-    
+
     assert "module" in sexp
     assert "expression_statement" in sexp
     assert "assignment" in sexp
+
 
 def test_python_parser_instance():
     parser = PythonParser()
     source = "y = 42"
     root = parser.parse(source)
     assert root.type == "module"
-    
+
     root_bytes = parser.parse_bytes(source.encode("utf-8"))
     assert root_bytes.type == "module"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,49 @@
+import pytest
+from topos.utils.tree_sitter import (
+    parse_python,
+    node_text,
+    node_to_sexp,
+    find_errors,
+    PythonParser
+)
+
+def test_parse_python():
+    source = "x = 1 + 2"
+    root = parse_python(source)
+    assert root.type == "module"
+    assert not root.has_error
+
+def test_node_text():
+    source = "def foo(): pass"
+    root = parse_python(source)
+    
+    # The first child of module is usually the statement
+    stmt = root.children[0]
+    text = node_text(stmt, source)
+    assert text == "def foo(): pass"
+
+def test_find_errors():
+    source = "def broken(:"
+    root = parse_python(source)
+    
+    errors = find_errors(root)
+    assert len(errors) > 0
+    assert any(e.type == "ERROR" or e.is_missing for e in errors)
+
+def test_node_to_sexp():
+    source = "x = 1"
+    root = parse_python(source)
+    sexp = node_to_sexp(root)
+    
+    assert "module" in sexp
+    assert "expression_statement" in sexp
+    assert "assignment" in sexp
+
+def test_python_parser_instance():
+    parser = PythonParser()
+    source = "y = 42"
+    root = parser.parse(source)
+    assert root.type == "module"
+    
+    root_bytes = parser.parse_bytes(source.encode("utf-8"))
+    assert root_bytes.type == "module"


### PR DESCRIPTION
## Summary
This PR now includes three related deliverables:

1. Add FastMCP server support for Topos (`topos-mcp` entrypoint + server tools).
2. Add CLI binary install support (`install.sh`) for easier local setup.
3. Add GitHub workflows for CI and release automation.

## Included Changes
- Add MCP server implementation and tool surface in `src/topos/server.py`.
- Register CLI script entrypoint for MCP server in `pyproject.toml`.
- Add/install script for CLI binary setup in `install.sh`.
- Add GitHub Actions workflows:
  - `.github/workflows/ci.yml`
  - `.github/workflows/release.yml`
- Expand tests for CLI/core/logic/metrics/server/utils.

## Notes
- File-based MCP tool access is now constrained and validated to improve safety.
- Comparison/improvement endpoints now correctly gate AST distance on parse validity.
