### PR TITLE
Make `topos mcp` accessible from cli binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ topos compare before.py after.py                    # AST edit distance
 Connect Topos to Claude, Cursor, or Windsurf to let them evaluate their own work:
 
 ```bash
-topos-mcp
+topos mcp
 ```
 
 ---

--- a/docs/source/agents.rst
+++ b/docs/source/agents.rst
@@ -133,7 +133,7 @@ conversation.
 
 .. code-block:: bash
 
-   topos-mcp
+   topos mcp
 
 **For Claude Desktop**, add this to your config:
 
@@ -142,7 +142,8 @@ conversation.
    {
      "mcpServers": {
        "topos": {
-         "command": "topos-mcp"
+         "command": "topos",
+         "args": ["mcp"]
        }
      }
    }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,6 +27,7 @@ extensions = [
     "sphinx.ext.todo",
     "sphinx.ext.githubpages",
     "sphinxcontrib.mermaid",
+    "sphinx_copybutton",
 ]
 
 autosectionlabel_prefix_document = True

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -23,8 +23,7 @@ Topos is designed to be accessible as either a standalone binary or by building 
 
          curl -sSL https://raw.githubusercontent.com/Krv-Labs/topos/main/install.sh | sh
 
-      .. card:: 
-         :header: **What happens during installation?**
+      .. card:: **What happens during installation?**
 
          1. The latest release binary is downloaded to ``~/.local/bin``.
          2. An embedded Python environment is configured.
@@ -38,7 +37,7 @@ Topos is designed to be accessible as either a standalone binary or by building 
       .. code-block:: bash
 
          topos --version
-         topos-mcp --help
+         topos mcp --help
 
    .. tab-item:: 🐍 Building from Source
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
 
 [project.scripts]
 topos = "topos.main:cli"
-topos-mcp = "topos.server:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,4 +63,5 @@ docs = [
     "sphinx-design>=0.6.1",
     "sphinxcontrib-mermaid>=0.9.2",
     "nbsphinx>=0.9.5",
+    "sphinx-copybutton>=0.5.2",
 ]

--- a/src/topos/main.py
+++ b/src/topos/main.py
@@ -375,6 +375,14 @@ def uninstall(dry_run: bool, yes: bool, prune_path_hints: bool) -> None:
             )
 
 
+@cli.command()
+def mcp() -> None:
+    """Run the Topos MCP server."""
+    from topos.server import main as mcp_main
+
+    mcp_main()
+
+
 @cli.group()
 def depgraph() -> None:
     """Commands for working with dependency graphs."""


### PR DESCRIPTION
Introduce a command to run the Topos MCP server in the CLI. Update the README and agents documentation to reflect the new command syntax. Also, enhance installation documentation.