### PR TITLE
Add dependencies for PyInstaller

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,8 @@ jobs:
             --clean \
             --collect-all tree_sitter \
             --collect-all tree_sitter_python \
+            --collect-all fastmcp \
+            --collect-all real-ladybug \
             src/topos/main.py
 
       - name: Rename binary with platform suffix

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -339,7 +339,8 @@ def test_uninstall_prune_path_hints_requires_matching_markers(tmp_path, monkeypa
     assert "Malformed" not in updated
 
 
-def test_detect_install_method_falls_back_when_installer_metadata_missing(monkeypatch):
+def test_detect_install_method_falls_back_when_installer_metadata_missing(tmp_path, monkeypatch):
+    monkeypatch.setenv("TOPOS_PROVENANCE_FILE", str(tmp_path / "nonexistent"))
     from topos import main as main_module
 
     class DummyDist:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -339,7 +339,9 @@ def test_uninstall_prune_path_hints_requires_matching_markers(tmp_path, monkeypa
     assert "Malformed" not in updated
 
 
-def test_detect_install_method_falls_back_when_installer_metadata_missing(tmp_path, monkeypatch):
+def test_detect_install_method_falls_back_when_installer_metadata_missing(
+    tmp_path, monkeypatch
+):
     monkeypatch.setenv("TOPOS_PROVENANCE_FILE", str(tmp_path / "nonexistent"))
     from topos import main as main_module
 


### PR DESCRIPTION
Include additional dependencies for the PyInstaller binary build and modify the test for detecting the installation method to use a temporary path for environment variables.