### PR TITLE
P2: add stable id field to UASTNode

### DIFF
--- a/src/topos/graphs/ast/uast/mapper_common.py
+++ b/src/topos/graphs/ast/uast/mapper_common.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import sys
 from collections.abc import Callable
 from importlib.metadata import PackageNotFoundError, version
@@ -40,6 +41,17 @@ def parser_identity(language: str, *, native: bool = False) -> tuple[str, str]:
         return package, "unknown"
 
 
+def _compute_node_id(
+    lang: str,
+    node_kind: str,
+    start_byte: int,
+    end_byte: int,
+    parent_id: str,
+) -> str:
+    payload = f"{lang}|{node_kind}|{start_byte}|{end_byte}|{parent_id}".encode()
+    return hashlib.blake2b(payload, digest_size=8).hexdigest()
+
+
 def map_tree_sitter_to_uast(
     root: Node,
     language: str,
@@ -48,7 +60,7 @@ def map_tree_sitter_to_uast(
 ) -> UASTNode:
     parser_name, parser_version = parser_identity(language)
 
-    def to_uast(node: Node) -> UASTNode:
+    def to_uast(node: Node, parent_id: str = "") -> UASTNode:
         start_point = node.start_point
         end_point = node.end_point
         span = SourceSpan(
@@ -65,7 +77,18 @@ def map_tree_sitter_to_uast(
             parser_version=parser_version,
             node_kind=node.type,
         )
-        children = [to_uast(child) for child in node.children if child.is_named]
+        node_id = _compute_node_id(
+            lang=language,
+            node_kind=native.node_kind,
+            start_byte=span.start_byte,
+            end_byte=span.end_byte,
+            parent_id=parent_id,
+        )
+        children = [
+            to_uast(child, parent_id=node_id)
+            for child in node.children
+            if child.is_named
+        ]
         return UASTNode(
             kind=map_node_kind(node),
             lang=language,
@@ -73,6 +96,7 @@ def map_tree_sitter_to_uast(
             native=native,
             attributes={"named": node.is_named},
             children=children,
+            id=node_id,
         )
 
     return to_uast(root)

--- a/src/topos/graphs/ast/uast/models.py
+++ b/src/topos/graphs/ast/uast/models.py
@@ -29,6 +29,16 @@ class UASTNode:
 
     The `kind` values intentionally follow the industry-standard reference
     in docs/uast-industry-standards.md.
+
+    `id` is a deterministic 16-hex-char identifier required by the
+    `UNodeBase` schema for referential integrity (diffs, refactor links,
+    cross-tool references). It is a blake2b hash of
+    `(lang, native.node_kind, span.start_byte, span.end_byte, parent_id)`;
+    chaining the parent's id encodes the full path from the root, which
+    disambiguates identical-span sibling nodes without needing an explicit
+    sibling index. The mapper walker is responsible for populating it; if
+    a node is constructed directly (e.g. in tests) and no id is supplied,
+    it defaults to the empty string.
     """
 
     kind: str
@@ -37,3 +47,4 @@ class UASTNode:
     native: NativeRef
     attributes: dict[str, Any] = field(default_factory=dict)
     children: list[UASTNode] = field(default_factory=list)
+    id: str = ""

--- a/tests/test_uast_comparison.py
+++ b/tests/test_uast_comparison.py
@@ -91,6 +91,40 @@ def test_structural_summary_counts_declarations():
     assert summary.declaration_count >= 3  # two functions + one class
 
 
+def _collect_ids(node) -> list[str]:
+    ids = [node.id]
+    for child in node.children:
+        ids.extend(_collect_ids(child))
+    return ids
+
+
+def test_uast_node_id_is_deterministic():
+    source = "def f(x):\n    return x + 1\n"
+    root_a = _parse(source, language="python")
+    root_b = _parse(source, language="python")
+
+    ids_a = _collect_ids(root_a)
+    ids_b = _collect_ids(root_b)
+
+    assert ids_a == ids_b
+    assert all(len(node_id) == 16 for node_id in ids_a)
+
+
+def test_uast_node_id_is_unique_within_tree():
+    source = Path("demos/binarytrees/src/binarytrees.py").read_text()
+    root = _parse(source, language="python")
+
+    ids = _collect_ids(root)
+    assert len(ids) == len(set(ids))
+
+
+def test_uast_node_id_differs_across_languages():
+    py_root = _parse("x = 1\n", language="python")
+    js_root = _parse("x = 1\n", language="javascript")
+
+    assert py_root.id != js_root.id
+
+
 def test_compare_uast_handles_empty_uast_node():
     span = SourceSpan(
         file=None,


### PR DESCRIPTION
## Summary

- Adds a deterministic `id: str` field to `UASTNode` so the model conforms to the `UNodeBase` schema in `docs/uast-industry-standards.md` (referential integrity for diffs, refactor links, and cross-tool references).
- `id` is a 16-hex-char `blake2b` hash of `(lang, native.node_kind, span.start_byte, span.end_byte, parent_id)`. Chaining the parent's id encodes the full path-from-root, which disambiguates identical-span sibling nodes without needing an explicit sibling index. Strategy is documented in the `UASTNode` docstring.
- Populated in `mapper_common.to_uast` (the single walker every language mapper flows through). Existing serializers (`get_asts.py`, `compare_asts.py`) keep working — `id` just appears in JSON output.

Closes #32

## Test Plan

- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run pytest tests/ -q` (171 passed)
- [x] `test_uast_node_id_is_deterministic` — same source produces identical id walks across runs
- [x] `test_uast_node_id_is_unique_within_tree` — non-trivial program (`binarytrees.py`) has no duplicate ids
- [x] `test_uast_node_id_differs_across_languages` — same logical snippet in python vs javascript yields different root ids

Made with [Cursor](https://cursor.com)