### PR TITLE
P0: split mapper_common into language-aware mappers

### DIFF
--- a/src/topos/graphs/ast/uast/mapper_common.py
+++ b/src/topos/graphs/ast/uast/mapper_common.py
@@ -1,68 +1,18 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from tree_sitter import Node
 
 from topos.graphs.ast.uast.models import NativeRef, SourceSpan, UASTNode
 
 PARSER_VERSION = "tree-sitter>=0.23"
 
-_DECLARATION_TYPES = {
-    "function_definition": "FunctionDecl",
-    "class_definition": "TypeDecl",
-    "struct_item": "TypeDecl",
-    "enum_item": "TypeDecl",
-    "impl_item": "TypeDecl",
-    "function_item": "FunctionDecl",
-    "method_definition": "MethodDecl",
-    "lexical_declaration": "VarDecl",
-    "variable_declaration": "VarDecl",
-}
-
-_STATEMENT_TYPES = {
-    "if_statement": "IfStmt",
-    "for_statement": "ForStmt",
-    "while_statement": "WhileStmt",
-    "match_statement": "MatchStmt",
-    "return_statement": "ReturnStmt",
-    "break_statement": "BreakStmt",
-    "continue_statement": "ContinueStmt",
-    "throw_statement": "ThrowStmt",
-    "try_statement": "TryStmt",
-    "expression_statement": "ExprStmt",
-}
-
-_EXPRESSION_TYPES = {
-    "assignment": "AssignExpr",
-    "augmented_assignment": "AssignExpr",
-    "binary_expression": "BinaryExpr",
-    "boolean_operator": "BinaryExpr",
-    "unary_expression": "UnaryExpr",
-    "call_expression": "CallExpr",
-    "member_expression": "MemberExpr",
-    "field_expression": "MemberExpr",
-    "subscript": "MemberExpr",
-}
-
-
-def map_node_kind(node: Node) -> str:
-    if node.type in _DECLARATION_TYPES:
-        return _DECLARATION_TYPES[node.type]
-    if node.type in _STATEMENT_TYPES:
-        return _STATEMENT_TYPES[node.type]
-    if node.type in _EXPRESSION_TYPES:
-        return _EXPRESSION_TYPES[node.type]
-    if node.type == "identifier":
-        return "Identifier"
-    if node.type.endswith("literal") or node.type in {"string", "integer", "float"}:
-        return "Literal"
-    if node.type in {"module", "program", "translation_unit", "source_file"}:
-        return "File"
-    return "Unknown"
-
 
 def map_tree_sitter_to_uast(
     root: Node,
     language: str,
+    map_node_kind: Callable[[Node], str],
     parser_name: str = "tree-sitter",
     parser_version: str = PARSER_VERSION,
     file: str | None = None,

--- a/src/topos/graphs/ast/uast/mapper_cpp.py
+++ b/src/topos/graphs/ast/uast/mapper_cpp.py
@@ -5,6 +5,64 @@ from tree_sitter import Node
 from topos.graphs.ast.uast.mapper_common import map_tree_sitter_to_uast
 from topos.graphs.ast.uast.models import UASTNode
 
+_DECLARATION_TYPES = {
+    "function_definition": "FunctionDecl",
+    "class_definition": "TypeDecl",
+    "struct_item": "TypeDecl",
+    "enum_item": "TypeDecl",
+    "impl_item": "TypeDecl",
+    "function_item": "FunctionDecl",
+    "method_definition": "MethodDecl",
+    "lexical_declaration": "VarDecl",
+    "variable_declaration": "VarDecl",
+}
+
+_STATEMENT_TYPES = {
+    "if_statement": "IfStmt",
+    "for_statement": "ForStmt",
+    "while_statement": "WhileStmt",
+    "match_statement": "MatchStmt",
+    "return_statement": "ReturnStmt",
+    "break_statement": "BreakStmt",
+    "continue_statement": "ContinueStmt",
+    "throw_statement": "ThrowStmt",
+    "try_statement": "TryStmt",
+    "expression_statement": "ExprStmt",
+}
+
+_EXPRESSION_TYPES = {
+    "assignment": "AssignExpr",
+    "augmented_assignment": "AssignExpr",
+    "binary_expression": "BinaryExpr",
+    "boolean_operator": "BinaryExpr",
+    "unary_expression": "UnaryExpr",
+    "call_expression": "CallExpr",
+    "member_expression": "MemberExpr",
+    "field_expression": "MemberExpr",
+    "subscript": "MemberExpr",
+}
+
+
+def map_node_kind(node: Node) -> str:
+    if node.type in _DECLARATION_TYPES:
+        return _DECLARATION_TYPES[node.type]
+    if node.type in _STATEMENT_TYPES:
+        return _STATEMENT_TYPES[node.type]
+    if node.type in _EXPRESSION_TYPES:
+        return _EXPRESSION_TYPES[node.type]
+    if node.type == "identifier":
+        return "Identifier"
+    if node.type.endswith("literal") or node.type in {"string", "integer", "float"}:
+        return "Literal"
+    if node.type in {"module", "program", "translation_unit", "source_file"}:
+        return "File"
+    return "Unknown"
+
 
 def map_cpp_tree_to_uast(root: Node, file: str | None = None) -> UASTNode:
-    return map_tree_sitter_to_uast(root=root, language="cpp", file=file)
+    return map_tree_sitter_to_uast(
+        root=root,
+        language="cpp",
+        map_node_kind=map_node_kind,
+        file=file,
+    )

--- a/src/topos/graphs/ast/uast/mapper_javascript.py
+++ b/src/topos/graphs/ast/uast/mapper_javascript.py
@@ -5,6 +5,64 @@ from tree_sitter import Node
 from topos.graphs.ast.uast.mapper_common import map_tree_sitter_to_uast
 from topos.graphs.ast.uast.models import UASTNode
 
+_DECLARATION_TYPES = {
+    "function_definition": "FunctionDecl",
+    "class_definition": "TypeDecl",
+    "struct_item": "TypeDecl",
+    "enum_item": "TypeDecl",
+    "impl_item": "TypeDecl",
+    "function_item": "FunctionDecl",
+    "method_definition": "MethodDecl",
+    "lexical_declaration": "VarDecl",
+    "variable_declaration": "VarDecl",
+}
+
+_STATEMENT_TYPES = {
+    "if_statement": "IfStmt",
+    "for_statement": "ForStmt",
+    "while_statement": "WhileStmt",
+    "match_statement": "MatchStmt",
+    "return_statement": "ReturnStmt",
+    "break_statement": "BreakStmt",
+    "continue_statement": "ContinueStmt",
+    "throw_statement": "ThrowStmt",
+    "try_statement": "TryStmt",
+    "expression_statement": "ExprStmt",
+}
+
+_EXPRESSION_TYPES = {
+    "assignment": "AssignExpr",
+    "augmented_assignment": "AssignExpr",
+    "binary_expression": "BinaryExpr",
+    "boolean_operator": "BinaryExpr",
+    "unary_expression": "UnaryExpr",
+    "call_expression": "CallExpr",
+    "member_expression": "MemberExpr",
+    "field_expression": "MemberExpr",
+    "subscript": "MemberExpr",
+}
+
+
+def map_node_kind(node: Node) -> str:
+    if node.type in _DECLARATION_TYPES:
+        return _DECLARATION_TYPES[node.type]
+    if node.type in _STATEMENT_TYPES:
+        return _STATEMENT_TYPES[node.type]
+    if node.type in _EXPRESSION_TYPES:
+        return _EXPRESSION_TYPES[node.type]
+    if node.type == "identifier":
+        return "Identifier"
+    if node.type.endswith("literal") or node.type in {"string", "integer", "float"}:
+        return "Literal"
+    if node.type in {"module", "program", "translation_unit", "source_file"}:
+        return "File"
+    return "Unknown"
+
 
 def map_javascript_tree_to_uast(root: Node, file: str | None = None) -> UASTNode:
-    return map_tree_sitter_to_uast(root=root, language="javascript", file=file)
+    return map_tree_sitter_to_uast(
+        root=root,
+        language="javascript",
+        map_node_kind=map_node_kind,
+        file=file,
+    )

--- a/src/topos/graphs/ast/uast/mapper_python.py
+++ b/src/topos/graphs/ast/uast/mapper_python.py
@@ -5,6 +5,64 @@ from tree_sitter import Node
 from topos.graphs.ast.uast.mapper_common import map_tree_sitter_to_uast
 from topos.graphs.ast.uast.models import UASTNode
 
+_DECLARATION_TYPES = {
+    "function_definition": "FunctionDecl",
+    "class_definition": "TypeDecl",
+    "struct_item": "TypeDecl",
+    "enum_item": "TypeDecl",
+    "impl_item": "TypeDecl",
+    "function_item": "FunctionDecl",
+    "method_definition": "MethodDecl",
+    "lexical_declaration": "VarDecl",
+    "variable_declaration": "VarDecl",
+}
+
+_STATEMENT_TYPES = {
+    "if_statement": "IfStmt",
+    "for_statement": "ForStmt",
+    "while_statement": "WhileStmt",
+    "match_statement": "MatchStmt",
+    "return_statement": "ReturnStmt",
+    "break_statement": "BreakStmt",
+    "continue_statement": "ContinueStmt",
+    "throw_statement": "ThrowStmt",
+    "try_statement": "TryStmt",
+    "expression_statement": "ExprStmt",
+}
+
+_EXPRESSION_TYPES = {
+    "assignment": "AssignExpr",
+    "augmented_assignment": "AssignExpr",
+    "binary_expression": "BinaryExpr",
+    "boolean_operator": "BinaryExpr",
+    "unary_expression": "UnaryExpr",
+    "call_expression": "CallExpr",
+    "member_expression": "MemberExpr",
+    "field_expression": "MemberExpr",
+    "subscript": "MemberExpr",
+}
+
+
+def map_node_kind(node: Node) -> str:
+    if node.type in _DECLARATION_TYPES:
+        return _DECLARATION_TYPES[node.type]
+    if node.type in _STATEMENT_TYPES:
+        return _STATEMENT_TYPES[node.type]
+    if node.type in _EXPRESSION_TYPES:
+        return _EXPRESSION_TYPES[node.type]
+    if node.type == "identifier":
+        return "Identifier"
+    if node.type.endswith("literal") or node.type in {"string", "integer", "float"}:
+        return "Literal"
+    if node.type in {"module", "program", "translation_unit", "source_file"}:
+        return "File"
+    return "Unknown"
+
 
 def map_python_tree_to_uast(root: Node, file: str | None = None) -> UASTNode:
-    return map_tree_sitter_to_uast(root=root, language="python", file=file)
+    return map_tree_sitter_to_uast(
+        root=root,
+        language="python",
+        map_node_kind=map_node_kind,
+        file=file,
+    )

--- a/src/topos/graphs/ast/uast/mapper_rust.py
+++ b/src/topos/graphs/ast/uast/mapper_rust.py
@@ -5,6 +5,64 @@ from tree_sitter import Node
 from topos.graphs.ast.uast.mapper_common import map_tree_sitter_to_uast
 from topos.graphs.ast.uast.models import UASTNode
 
+_DECLARATION_TYPES = {
+    "function_definition": "FunctionDecl",
+    "class_definition": "TypeDecl",
+    "struct_item": "TypeDecl",
+    "enum_item": "TypeDecl",
+    "impl_item": "TypeDecl",
+    "function_item": "FunctionDecl",
+    "method_definition": "MethodDecl",
+    "lexical_declaration": "VarDecl",
+    "variable_declaration": "VarDecl",
+}
+
+_STATEMENT_TYPES = {
+    "if_statement": "IfStmt",
+    "for_statement": "ForStmt",
+    "while_statement": "WhileStmt",
+    "match_statement": "MatchStmt",
+    "return_statement": "ReturnStmt",
+    "break_statement": "BreakStmt",
+    "continue_statement": "ContinueStmt",
+    "throw_statement": "ThrowStmt",
+    "try_statement": "TryStmt",
+    "expression_statement": "ExprStmt",
+}
+
+_EXPRESSION_TYPES = {
+    "assignment": "AssignExpr",
+    "augmented_assignment": "AssignExpr",
+    "binary_expression": "BinaryExpr",
+    "boolean_operator": "BinaryExpr",
+    "unary_expression": "UnaryExpr",
+    "call_expression": "CallExpr",
+    "member_expression": "MemberExpr",
+    "field_expression": "MemberExpr",
+    "subscript": "MemberExpr",
+}
+
+
+def map_node_kind(node: Node) -> str:
+    if node.type in _DECLARATION_TYPES:
+        return _DECLARATION_TYPES[node.type]
+    if node.type in _STATEMENT_TYPES:
+        return _STATEMENT_TYPES[node.type]
+    if node.type in _EXPRESSION_TYPES:
+        return _EXPRESSION_TYPES[node.type]
+    if node.type == "identifier":
+        return "Identifier"
+    if node.type.endswith("literal") or node.type in {"string", "integer", "float"}:
+        return "Literal"
+    if node.type in {"module", "program", "translation_unit", "source_file"}:
+        return "File"
+    return "Unknown"
+
 
 def map_rust_tree_to_uast(root: Node, file: str | None = None) -> UASTNode:
-    return map_tree_sitter_to_uast(root=root, language="rust", file=file)
+    return map_tree_sitter_to_uast(
+        root=root,
+        language="rust",
+        map_node_kind=map_node_kind,
+        file=file,
+    )


### PR DESCRIPTION
Closes #25

## Summary

Pure refactor that moves the language-specific dispatch tables (`_DECLARATION_TYPES`, `_STATEMENT_TYPES`, `_EXPRESSION_TYPES`) and `map_node_kind` out of `mapper_common.py` and into each `mapper_<lang>.py`. The agnostic walker now takes `map_node_kind` as a callable parameter; each language mapper passes its own.

- `mapper_common.py` keeps only the language-agnostic walker (span, native-ref, child traversal, generic `to_uast`).
- `mapper_python.py`, `mapper_rust.py`, `mapper_javascript.py`, `mapper_cpp.py` each own their own dispatch dicts and `map_node_kind`.
- No external imports of the moved symbols exist; `tree_sitter_provider.py` is unchanged.

## Behavior preservation

This PR intentionally seeds each per-language dispatch with a verbatim copy of the prior union table, so UAST kind histograms for the binarytrees benchmark are bit-identical before and after. Diverging the per-language tables (to fix issues like Python emitting ` binary_operator` while the table only knows `binary_expression`) is follow-up work, as the issue body anticipates ("kind sets may grow as coverage improves").

## Test Plan

- [x] `uv run ruff format --check .` passes
- [x] `uv run ruff check .` passes
- [x] `uv run pytest tests/ -q` passes (168 tests)
- [x] `uv run python demos/binarytrees/compare_asts.py` produces identical UAST kind histograms vs the base branch (verified via `uast_kind_histogram` over all four languages). Dict-key ordering in `comparison.json`'s `control_flow_delta` varies between runs because `CONTROL_FLOW_KINDS` is a `frozenset` (hash randomization); values are unchanged.

Made with [Cursor](https://cursor.com)