### PR TITLE
P1: set NativeRef.parser to real parser identity per language

### DIFF
--- a/src/topos/graphs/ast/providers/native_provider.py
+++ b/src/topos/graphs/ast/providers/native_provider.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from topos.graphs.ast.providers.tree_sitter_provider import TreeSitterProvider
 from topos.graphs.ast.types import ParseResult, ParserProvenance
+from topos.graphs.ast.uast.mapper_common import parser_identity
 
 
 @dataclass
@@ -18,7 +19,6 @@ class NativeAstProvider:
     """
 
     name: str = "native"
-    parser_version: str = "python-stdlib-ast"
 
     def __post_init__(self) -> None:
         self._fallback_provider = TreeSitterProvider()
@@ -32,14 +32,12 @@ class NativeAstProvider:
         fallback = self._fallback_provider.parse(source, language=language, file=file)
 
         native_ast: Any | None = None
-        parser_name = "tree-sitter"
-        parser_version = fallback.provenance.parser_version
+        parser_name, parser_version = parser_identity(language)
 
         if language == "python":
             try:
                 native_ast = py_ast.parse(source)
-                parser_name = "cpython-ast"
-                parser_version = self.parser_version
+                parser_name, parser_version = parser_identity(language, native=True)
             except SyntaxError:
                 # Keep working artifact path even on syntax errors.
                 native_ast = None

--- a/src/topos/graphs/ast/providers/tree_sitter_provider.py
+++ b/src/topos/graphs/ast/providers/tree_sitter_provider.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from topos.graphs.ast.types import ParseResult, ParserProvenance
+from topos.graphs.ast.uast.mapper_common import parser_identity
 from topos.graphs.ast.uast.mapper_cpp import map_cpp_tree_to_uast
 from topos.graphs.ast.uast.mapper_javascript import map_javascript_tree_to_uast
 from topos.graphs.ast.uast.mapper_python import map_python_tree_to_uast
@@ -32,7 +33,6 @@ _TREE_SITTER_UAST = {
 @dataclass
 class TreeSitterProvider:
     name: str = "tree-sitter"
-    parser_version: str = "tree-sitter>=0.23"
 
     def supports(self, language: str) -> bool:
         return language in _TREE_SITTER_PARSE
@@ -43,9 +43,10 @@ class TreeSitterProvider:
 
         root = _TREE_SITTER_PARSE[language](source)
         uast_root = _TREE_SITTER_UAST[language](root, file=file)
+        parser_name, parser_version = parser_identity(language)
         provenance = ParserProvenance(
-            parser=self.name,
-            parser_version=self.parser_version,
+            parser=parser_name,
+            parser_version=parser_version,
             node_kind=root.type,
         )
         return ParseResult(

--- a/src/topos/graphs/ast/uast/mapper_common.py
+++ b/src/topos/graphs/ast/uast/mapper_common.py
@@ -1,22 +1,53 @@
 from __future__ import annotations
 
+import sys
 from collections.abc import Callable
+from importlib.metadata import PackageNotFoundError, version
 
 from tree_sitter import Node
 
 from topos.graphs.ast.uast.models import NativeRef, SourceSpan, UASTNode
 
-PARSER_VERSION = "tree-sitter>=0.23"
+_TREE_SITTER_PACKAGE = {
+    "python": "tree-sitter-python",
+    "rust": "tree-sitter-rust",
+    "javascript": "tree-sitter-javascript",
+    "cpp": "tree-sitter-cpp",
+}
+
+
+def parser_identity(language: str, *, native: bool = False) -> tuple[str, str]:
+    """
+    Return the canonical `(parser_name, parser_version)` for a language.
+
+    `native=True` selects the language's native parser identity (currently
+    only CPython's stdlib `ast` for Python); otherwise the tree-sitter
+    grammar identity is returned. Unknown languages fall back to
+    `("tree-sitter", "unknown")`.
+    """
+    if native and language == "python":
+        return (
+            "cpython-ast",
+            f"python-{sys.version_info.major}.{sys.version_info.minor}",
+        )
+
+    package = _TREE_SITTER_PACKAGE.get(language)
+    if package is None:
+        return "tree-sitter", "unknown"
+    try:
+        return package, version(package)
+    except PackageNotFoundError:
+        return package, "unknown"
 
 
 def map_tree_sitter_to_uast(
     root: Node,
     language: str,
     map_node_kind: Callable[[Node], str],
-    parser_name: str = "tree-sitter",
-    parser_version: str = PARSER_VERSION,
     file: str | None = None,
 ) -> UASTNode:
+    parser_name, parser_version = parser_identity(language)
+
     def to_uast(node: Node) -> UASTNode:
         start_point = node.start_point
         end_point = node.end_point

--- a/tests/test_multilang_ast.py
+++ b/tests/test_multilang_ast.py
@@ -26,7 +26,7 @@ def test_parse_source_rust_hybrid_falls_back_to_tree_sitter():
     )
     assert result.native_ast is None
     assert result.uast_root is not None
-    assert result.provenance.parser == "tree-sitter"
+    assert result.provenance.parser == "tree-sitter-rust"
 
 
 def test_program_morphism_supports_multiple_languages():
@@ -51,6 +51,27 @@ def test_capability_matrix_tracks_native_and_uast_support():
     assert matrix["rust"]["supports_native"] is False
     assert matrix["javascript"]["supports_uast"] is True
     assert matrix["cpp"]["supports_tree_sitter"] is True
+
+
+def test_native_ref_parser_identity_per_language():
+    cases = [
+        ("python", "def add(a, b):\n    return a + b\n", "cpython-ast"),
+        ("rust", "fn main() {}", "tree-sitter-rust"),
+        ("javascript", "function x() { return 1; }", "tree-sitter-javascript"),
+        ("cpp", "int main() { return 0; }", "tree-sitter-cpp"),
+    ]
+    for language, source, expected_parser in cases:
+        result = parse_source(source, language=language)
+        assert result.provenance.parser == expected_parser
+        assert result.provenance.parser_version
+        assert result.provenance.parser_version != "unknown"
+        parsers_seen = {node.native.parser for node in _walk_uast(result.uast_root)}
+        # UAST nodes always carry the tree-sitter grammar identity, even when
+        # the top-level provenance reflects the native parser (e.g. cpython-ast).
+        expected_uast_parser = (
+            "tree-sitter-python" if language == "python" else expected_parser
+        )
+        assert expected_uast_parser in parsers_seen
 
 
 def test_binarytrees_sources_produce_minimum_uast_invariants():


### PR DESCRIPTION
Closes #29

## Summary

`NativeRef.parser` and `ParserProvenance.parser` previously hardcoded the literal string `\"tree-sitter\"` everywhere. This PR sets them to the canonical per-language parser identity required by the UAST Parser Provider Contract (`docs/uast-industry-standards.md`):

| Language | `parser` value | `parser_version` source |
|---|---|---|
| python (CPython native) | `cpython-ast` | `python-{major}.{minor}` |
| python (tree-sitter fallback) | `tree-sitter-python` | `importlib.metadata.version` |
| rust | `tree-sitter-rust` | `importlib.metadata.version` |
| javascript | `tree-sitter-javascript` | `importlib.metadata.version` |
| cpp | `tree-sitter-cpp` | `importlib.metadata.version` |

Lookup is centralized in a single helper, `parser_identity(language, *, native=False)`, in `src/topos/graphs/ast/uast/mapper_common.py`. It uses `importlib.metadata.version(pkg)` with a `PackageNotFoundError` fallback to `\"unknown\"`. Both `TreeSitterProvider` and `NativeAstProvider` call the helper so the `ParseResult.provenance` string and every `UASTNode.native.parser` match the parser that actually produced the artifact.

## Scope

Surgical: 65 lines added, 12 removed across 4 files. No UAST kinds or other behavior changed beyond the provenance strings.

## Test Plan

- [x] \`uv run ruff format --check .\` passes
- [x] \`uv run ruff check .\` passes
- [x] \`uv run pytest tests/ -q\` passes (169 tests, all green)
- [x] New test \`test_native_ref_parser_identity_per_language\` asserts the expected \`provenance.parser\` value and a non-\"unknown\" \`parser_version\` for python/rust/javascript/cpp, and that UAST nodes carry the matching tree-sitter grammar identity.
- [x] Existing \`test_parse_source_rust_hybrid_falls_back_to_tree_sitter\` updated to expect \`tree-sitter-rust\` (was \`tree-sitter\`).

Made with [Cursor](https://cursor.com)