### PR TITLE
fix(release): sign embedded macOS libraries during PyInstaller build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,27 +49,7 @@ jobs:
       - name: Install dependencies
         run: uv sync --group dev --python 3.12
 
-      - name: Build binary with PyInstaller
-        run: |
-          uv run --with pyinstaller pyinstaller --name topos \
-            --onefile \
-            --clean \
-            --collect-all tree_sitter \
-            --collect-all tree_sitter_python \
-            --collect-all tree_sitter_rust \
-            --collect-all tree_sitter_javascript \
-            --collect-all tree_sitter_cpp \
-            --collect-all tree_sitter_typescript \
-            --collect-all topos \
-            --collect-all fastmcp \
-            --collect-all real-ladybug \
-            --copy-metadata fastmcp \
-            topos/cli/main.py
-
-      - name: Rename binary with platform suffix
-        run: mv dist/topos dist/topos-${{ matrix.target }}
-
-      - name: Sign macOS binary
+      - name: Prepare macOS code signing keychain
         if: runner.os == 'macOS' && github.event_name != 'pull_request'
         env:
           CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_P12_BASE64 }}
@@ -89,7 +69,54 @@ jobs:
           security unlock-keychain -p "" "$KEYCHAIN_PATH"
           security import "$CERTIFICATE_PATH" -P "$CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
           security list-keychains -d user -s "$KEYCHAIN_PATH"
-          codesign --force --options runtime --timestamp --sign "$CODESIGN_IDENTITY" "dist/topos-${{ matrix.target }}"
+          echo "CODESIGN_IDENTITY=${CODESIGN_IDENTITY}" >> "$GITHUB_ENV"
+
+      - name: Build binary with PyInstaller
+        env:
+          CODESIGN_IDENTITY: ${{ env.CODESIGN_IDENTITY }}
+        run: |
+          PYINSTALLER_ARGS=(
+            --name topos
+            --onefile
+            --clean
+            --collect-all tree_sitter
+            --collect-all tree_sitter_python
+            --collect-all tree_sitter_rust
+            --collect-all tree_sitter_javascript
+            --collect-all tree_sitter_cpp
+            --collect-all tree_sitter_typescript
+            --collect-all topos
+            --collect-all fastmcp
+            --collect-all real-ladybug
+            --copy-metadata fastmcp
+          )
+
+          # onefile embeds dylibs in the archive; they must be signed during
+          # collection with the same Developer ID as the outer executable.
+          if [ "$(uname -s)" = "Darwin" ] && [ -n "${CODESIGN_IDENTITY:-}" ]; then
+            PYINSTALLER_ARGS+=(
+              --codesign-identity "${CODESIGN_IDENTITY}"
+              --osx-entitlements-file packaging/macos-entitlements.plist
+            )
+          fi
+
+          uv run --with pyinstaller pyinstaller "${PYINSTALLER_ARGS[@]}" topos/cli/main.py
+
+      - name: Rename binary with platform suffix
+        run: mv dist/topos dist/topos-${{ matrix.target }}
+
+      - name: Sign macOS binary
+        if: runner.os == 'macOS' && github.event_name != 'pull_request'
+        env:
+          CODESIGN_IDENTITY: ${{ env.CODESIGN_IDENTITY }}
+        run: |
+          if [ -z "${CODESIGN_IDENTITY:-}" ]; then
+            exit 0
+          fi
+
+          codesign --force --options runtime --timestamp \
+            --entitlements packaging/macos-entitlements.plist \
+            --sign "$CODESIGN_IDENTITY" "dist/topos-${{ matrix.target }}"
           codesign --verify --strict --verbose=2 "dist/topos-${{ matrix.target }}"
 
       - name: Notarize macOS binary archive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2026-06-04
+
+### Fixed
+
+- macOS onefile CLI: sign embedded dylibs (including `libpython3.12.dylib`) during PyInstaller collect with the same Developer ID as the outer binary, fixing `topos --version` failures after curl install (`PYI-82977` / different Team IDs). ([#54](https://github.com/Krv-Labs/topos/pull/54), closes [#55](https://github.com/Krv-Labs/topos/issues/55))
+
+### Security
+
+- Bumped `pyo3` from `0.22` to `0.24.1` to remediate [GHSA-pph8-gcv7-4qj5](https://github.com/advisories/GHSA-pph8-gcv7-4qj5) (`PyString::from_object` buffer overflow). Contributed via [#53](https://github.com/Krv-Labs/topos/pull/53).
+
 ## [0.3.0] - 2026-06-03
 
 Consolidates the work previously published under the mis-tagged releases v1.0.0–v1.1.1.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name = "topos_functors"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.22", features = ["extension-module"] }
+pyo3 = { version = "0.24.1", features = ["extension-module"] }
 tree-sitter = "0.23"
 petgraph = "0.6"
 serde = { version = "1.0", features = ["derive"] }

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -44,7 +44,7 @@ Topos is designed to be accessible as either a standalone binary or by building 
          topos mcp   # prints the FastMCP banner and waits on stdin; Ctrl-C to exit
 
       .. note::
-         **macOS ``different Team IDs`` error (v0.3.1 and earlier):** If ``topos --version`` fails with a PyInstaller error about ``libpython3.12.dylib`` and mismatched Team IDs, the published binary was signed incorrectly. Reinstall after a fixed release, or use the **Building from Source** tab until then.
+         **macOS ``different Team IDs`` error (v0.3.1 and earlier):** If ``topos --version`` fails with a PyInstaller error about ``libpython3.12.dylib`` and mismatched Team IDs, upgrade to **v0.3.2** or later via ``install.sh``, or use the **Building from Source** tab. See `issue #55 <https://github.com/Krv-Labs/topos/issues/55>`_ for details.
 
    .. tab-item:: 🐍 Building from Source
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -43,6 +43,9 @@ Topos is designed to be accessible as either a standalone binary or by building 
          topos --version
          topos mcp   # prints the FastMCP banner and waits on stdin; Ctrl-C to exit
 
+      .. note::
+         **macOS ``different Team IDs`` error (v0.3.1 and earlier):** If ``topos --version`` fails with a PyInstaller error about ``libpython3.12.dylib`` and mismatched Team IDs, the published binary was signed incorrectly. Reinstall after a fixed release, or use the **Building from Source** tab until then.
+
    .. tab-item:: 🐍 Building from Source
 
       If you want to contribute, use the latest development version, or integrate Topos into your Python pipelines:

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "topos-vscode",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "topos-vscode",
-      "version": "0.3.0",
+      "version": "0.3.2",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@types/mocha": "^10.0.6",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "topos-vscode",
   "displayName": "Topos: Code Quality Targets for Agents",
   "description": "Structural code-quality targets your coding agents can optimize toward, delivered as MCP tools for agent mode.",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "publisher": "KrvLabs",
   "icon": "icon.png",
   "license": "SEE LICENSE IN LICENSE",

--- a/extensions/vscode/workflow/publishing.md
+++ b/extensions/vscode/workflow/publishing.md
@@ -391,6 +391,8 @@ Until Apple credentials are configured:
 
 Once Apple credentials are configured, the same workflow signs and notarizes macOS binaries automatically.
 
+For PyInstaller `onefile` builds, macOS signing must happen **during** collection (`--codesign-identity` / `--osx-entitlements-file`), not only on the outer executable afterward. Post-hoc signing of the wrapper alone leaves embedded `libpython` adhoc-signed and causes runtime `different Team IDs` errors under hardened runtime.
+
 </details>
 
 ## GitHub Actions Flow

--- a/extensions/vscode/workflow/publishing.md
+++ b/extensions/vscode/workflow/publishing.md
@@ -391,7 +391,7 @@ Until Apple credentials are configured:
 
 Once Apple credentials are configured, the same workflow signs and notarizes macOS binaries automatically.
 
-For PyInstaller `onefile` builds, macOS signing must happen **during** collection (`--codesign-identity` / `--osx-entitlements-file`), not only on the outer executable afterward. Post-hoc signing of the wrapper alone leaves embedded `libpython` adhoc-signed and causes runtime `different Team IDs` errors under hardened runtime.
+For PyInstaller `onefile` builds, macOS signing must happen **during** collection (`--codesign-identity` / `--osx-entitlements-file`), not only on the outer executable afterward. Post-hoc signing of the wrapper alone leaves embedded `libpython` adhoc-signed and causes runtime `different Team IDs` errors under hardened runtime. Fixed in v0.3.2 ([#54](https://github.com/Krv-Labs/topos/pull/54)).
 
 </details>
 

--- a/packaging/macos-entitlements.plist
+++ b/packaging/macos-entitlements.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+</dict>
+</plist>

--- a/packaging/macos-entitlements.plist
+++ b/packaging/macos-entitlements.plist
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+</dict>
 </plist>

--- a/packaging/macos-entitlements.plist
+++ b/packaging/macos-entitlements.plist
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>com.apple.security.cs.allow-jit</key>
-	<true/>
-	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-	<true/>
-</dict>
+<dict/>
 </plist>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "topos"
-version = "0.3.1"
+version = "0.3.2"
 description = "Structural code quality metrics for agent-written programs."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/topos/__init__.py
+++ b/topos/__init__.py
@@ -30,7 +30,7 @@ from topos.graphs.cpg.object import CodePropertyGraph
 from topos.graphs.mdg.object import ModuleDependencyGraph
 from topos.graphs.pdg.object import ProgramDependenceGraph
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 __all__ = [
     # Categorical primitives


### PR DESCRIPTION
## Summary

Release **v0.3.2** with two changes on this branch:

1. **macOS onefile codesign fix** — Fixes curl installs where `topos --version` fails with `PYI-82977` / embedded `libpython3.12.dylib` **different Team IDs** (v0.3.1). Moves Apple keychain setup before PyInstaller and signs collected dylibs during `onefile` build via `--codesign-identity` and `--osx-entitlements-file`, then final `codesign` on the executable. Adds `packaging/macos-entitlements.plist`. Closes #55.

2. **PyO3 security bump** ([#53](https://github.com/Krv-Labs/topos/pull/53)) — Updates `pyo3` from `0.22` to `0.24.1` for [GHSA-pph8-gcv7-4qj5](https://github.com/advisories/GHSA-pph8-gcv7-4qj5).

Also bumps `pyproject.toml`, `topos/__init__.py`, and `extensions/vscode` to **0.3.2** and updates installation/publishing docs.

## Root cause (macOS)

The release workflow signed only the outer `topos` executable after PyInstaller finished. Embedded `libpython3.12.dylib` inside the onefile archive stayed adhoc-signed while the wrapper used Developer ID + hardened runtime — macOS rejects that Team ID mismatch at runtime.

## Test plan

- [x] PR CI: `Build and Release` workflow completes for all matrix targets (macOS unsigned on PRs is expected).
- [x] After merge: tag `v0.3.2` and publish release assets.
- [x] Reinstall via `curl -fsSL https://docs.krv.ai/topos/install.sh | sh`
- [ ] `topos --version` succeeds on Apple Silicon macOS
- [x] Optional: extract `libpython3.12.dylib` from the binary; confirm `TeamIdentifier=44KR4YZBHJ`, not `adhoc`
- [x] Rust extension builds/tests pass with PyO3 0.24.1

## Follow-up

Tag **v0.3.2** after merge so `install.sh` serves fixed macOS binaries.