### PR TITLE
Register as MCP Extension in VSCode Marketplace

### DIFF
--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -12,7 +12,7 @@ On supported platforms the extension bundles the Topos runtime, so there's nothi
 2. `⌘⇧I` → **Agent mode:** *"Use Topos to evaluate the code quality of this project."*
 3. `⌘⇧P` → **Topos: Generate Dependency Graph** *(optional; required for GOLD)*.
 
-Topos MCP tools are lazy-loaded and will auto-start when requested by an agent. No MCP is needed for **Topos: Evaluate Project** in the Command Palette.
+Topos registers an MCP server with VS Code and can start on demand when an agent requests its tools. VS Code may ask you to trust the local server the first time it starts. No MCP is needed for **Topos: Evaluate Project** in the Command Palette.
 
 ## How scoring works
 
@@ -59,7 +59,8 @@ COMPOSABLE additionally needs a dependency graph produced by [GitNexus](https://
 To pass the Marketplace's automated Agentic Risk Assessment, Topos declares the following requirements for its MCP tools:
 
 - **Filesystem Read Access:** Topos requires read access to your workspace files to perform static analysis (AST and Control-Flow Graph construction) and to build dependency graphs via GitNexus.
-- **No Network Egress:** The Topos MCP server runs entirely locally and does not transmit code or metadata to external servers.
+- **Local Analysis:** The Topos MCP server runs locally and does not transmit analyzed source code or project metadata to external services.
+- **Controlled Network Use:** If no bundled, cached, or local Topos runtime is available and `topos.autoDownload` is enabled, the extension can fetch the signed release manifest and download a SHA-256-verified runtime. If GitNexus is missing, the extension can launch `npm install -g gitnexus` in a visible terminal only after you choose that action.
 
 ## Requirements
 
@@ -73,7 +74,7 @@ Install and MCP are separate requirements. The extension checks MCP at runtime (
 
 **Command Palette** workflows (**Topos: Evaluate Project**, **Topos: Generate Dependency Graph**) can work without MCP. Agent MCP tools require a host that exposes `vscode.lm` / `McpStdioServerDefinition`.
 
-Topos MCP tools will auto-start on demand. For COMPOSABLE scoring (and GOLD medals), run **Topos: Generate Dependency Graph** to create the `.gitnexus/` store.
+Topos MCP tools can start on demand after VS Code trusts the local server. For COMPOSABLE scoring (and GOLD medals), run **Topos: Generate Dependency Graph** to create the `.gitnexus/` store.
 
 Cursor 2.0.x (reports VS Code API 1.99.x) does not satisfy the install engine and is unsupported.
 

--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -9,11 +9,10 @@ On supported platforms the extension bundles the Topos runtime, so there's nothi
 ## Try it in 60 seconds
 
 1. Install and open a workspace.
-2. `⌘⇧P` → **MCP: List Servers** → **Topos** → Start.
+2. `⌘⇧I` → **Agent mode:** *"Use Topos to evaluate the code quality of this project."*
 3. `⌘⇧P` → **Topos: Generate Dependency Graph** *(optional; required for GOLD)*.
-4. `⌘⇧I` → **Agent mode:** *"Use Topos to evaluate the code quality of this project."*
 
-No MCP needed for **Topos: Evaluate Project** in the Command Palette.
+Topos MCP tools are lazy-loaded and will auto-start when requested by an agent. No MCP is needed for **Topos: Evaluate Project** in the Command Palette.
 
 ## How scoring works
 
@@ -55,6 +54,13 @@ COMPOSABLE additionally needs a dependency graph produced by [GitNexus](https://
 2. Run **Topos: Generate Dependency Graph** to build the `.gitnexus/` store for your workspace.
 3. Re-run it when imports change (new modules, renames, restructures).
 
+## Agentic Security & Permissions
+
+To pass the Marketplace's automated Agentic Risk Assessment, Topos declares the following requirements for its MCP tools:
+
+- **Filesystem Read Access:** Topos requires read access to your workspace files to perform static analysis (AST and Control-Flow Graph construction) and to build dependency graphs via GitNexus.
+- **No Network Egress:** The Topos MCP server runs entirely locally and does not transmit code or metadata to external servers.
+
 ## Requirements
 
 Install and MCP are separate requirements. The extension checks MCP at runtime (not via `engines.vscode`).
@@ -65,9 +71,9 @@ Install and MCP are separate requirements. The extension checks MCP at runtime (
 | **MCP tools** (agent mode) | 1.120+ | 2.1+ **and** **Topos** output shows `Topos MCP Server Provider registered successfully` |
 | **Install method** | Marketplace | Marketplace or platform VSIX from [releases](https://github.com/Krv-Labs/topos/releases) |
 
-**Command Palette** workflows (**Topos: Evaluate Project**, **Topos: Generate Dependency Graph**) can work without MCP. Agent MCP tools require a host that exposes `vscode.lm` / `McpStdioServerDefinition`; if not, the extension logs the missing surfaces in the **Topos** output channel and shows a warning instead of failing silently.
+**Command Palette** workflows (**Topos: Evaluate Project**, **Topos: Generate Dependency Graph**) can work without MCP. Agent MCP tools require a host that exposes `vscode.lm` / `McpStdioServerDefinition`.
 
-Before agent mode can call Topos tools, start the MCP server: Command Palette → **MCP: List Servers** → **Topos** → Start. You need to do this once per session (or after reloading the window). For COMPOSABLE scoring (and GOLD medals), also run **Topos: Generate Dependency Graph** to create the `.gitnexus/` store.
+Topos MCP tools will auto-start on demand. For COMPOSABLE scoring (and GOLD medals), run **Topos: Generate Dependency Graph** to create the `.gitnexus/` store.
 
 Cursor 2.0.x (reports VS Code API 1.99.x) does not satisfy the install engine and is unsupported.
 

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "topos-vscode",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "topos-vscode",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@types/mocha": "^10.0.6",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -27,22 +27,33 @@
     "model-context-protocol",
     "copilot",
     "agents",
+    "ai-tools",
+    "agentic",
     "code-quality",
     "static-analysis",
     "topos"
   ],
   "categories": [
+    "AI",
     "Linters",
     "Machine Learning",
     "Other"
   ],
   "activationEvents": [
     "onStartupFinished",
+    "onMcpServerRequested:topos-mcp",
     "onCommand:topos.generateDependencyGraph",
     "onCommand:topos.evaluateProject"
   ],
   "main": "./dist/extension.js",
   "contributes": {
+    "mcpServers": [
+      {
+        "id": "topos-mcp",
+        "label": "Topos",
+        "description": "Exposes code structure and quality metrics to AI agents via MCP."
+      }
+    ],
     "mcpServerDefinitionProviders": [
       {
         "id": "topos-mcp",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "topos-vscode",
   "displayName": "Topos: Code Quality Targets for Agents",
   "description": "Structural code-quality targets your coding agents can optimize toward, delivered as MCP tools for agent mode.",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "publisher": "KrvLabs",
   "icon": "icon.png",
   "license": "SEE LICENSE IN LICENSE",
@@ -47,13 +47,6 @@
   ],
   "main": "./dist/extension.js",
   "contributes": {
-    "mcpServers": [
-      {
-        "id": "topos-mcp",
-        "label": "Topos",
-        "description": "Exposes code structure and quality metrics to AI agents via MCP."
-      }
-    ],
     "mcpServerDefinitionProviders": [
       {
         "id": "topos-mcp",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "topos"
-version = "0.3.2"
+version = "0.3.3"
 description = "Structural code quality metrics for agent-written programs."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/topos/__init__.py
+++ b/topos/__init__.py
@@ -30,7 +30,7 @@ from topos.graphs.cpg.object import CodePropertyGraph
 from topos.graphs.mdg.object import ModuleDependencyGraph
 from topos.graphs.pdg.object import ProgramDependenceGraph
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 
 __all__ = [
     # Categorical primitives


### PR DESCRIPTION
> [!NOTE]
> Last step in the `Topos` Launch!

PR title is self explanatory... main addition is the `onMcpServerRequested:topos-mcp` to the `package.json` + documentation in the readme to adhere to VSCode's requirements for MCP server extensions