### PR TITLE
v0.3.4: centralize policy calibration and fix GitNexus MDG loading

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -99,8 +99,8 @@ Key property: **The three generators are pairwise incomparable.** Each can be ac
 
 | Generator | Representation | Metrics | Scoring |
 |-----------|---------------|---------|---------|
-| SIMPLE | `ControlFlowGraph` (+ `ASTRepresentation` entropy) | `cfg.cyclomatic`, `cfg.essential`, `cfg.nesting_depth`, `cfg.longest_path`, `ast.entropy` | Weighted: `1 - cyclomatic/40` + entropy bell-curve (peak at 0.5). Threshold: **0.60**. |
-| COMPOSABLE | `ModuleDependencyGraph` | `mdg.coupling`, `mdg.instability`, `mdg.fan_in`, `mdg.fan_out`, `mdg.dep_depth` | Weighted: `1 - coupling/35` + instability flat-top tent over [0.3, 0.7]. Threshold: **0.60**. |
+| SIMPLE | `ControlFlowGraph` (+ `ASTRepresentation` entropy) | `cfg.cyclomatic`, `cfg.essential`, `cfg.nesting_depth`, `cfg.longest_path`, `ast.entropy` | Weighted: `1 - cyclomatic/40` + entropy bell-curve (peak at 0.5). Threshold: **0.40**. |
+| COMPOSABLE | `ModuleDependencyGraph` | `mdg.coupling`, `mdg.instability`, `mdg.fan_in`, `mdg.fan_out`, `mdg.dep_depth` | Weighted: `1 - coupling/35` + instability flat-top tent over [0.3, 0.7]. Threshold: **0.80**. |
 | SECURE | `CodePropertyGraph` | `cpg.dangerous_calls`, `cpg.taint_flows` | Weighted exp-decay: `exp(-count / scale)` for each metric. Threshold: **0.70** (higher — security false-negatives are asymmetrically costly). |
 
 **Diagnostic (not counted toward verdict):**

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
             --collect-all tree_sitter_typescript
             --collect-all topos
             --collect-all fastmcp
-            --collect-all real-ladybug
+            --collect-all ladybug
             --copy-metadata fastmcp
           )
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.4] - 2026-06-12
+
+### Fixed
+
+- GitNexus ``.gitnexus`` stores from gitnexus 1.6.x (LadybugDB storage v41) no longer crash MDG loading; evaluation degrades gracefully when the store cannot be read. (closes [#59](https://github.com/Krv-Labs/topos/issues/59))
+
+### Changed
+
+- Replaced the frozen ``real-ladybug`` dependency with ``ladybug>=0.17.0,<0.18`` to match GitNexus 1.6.x (``@ladybugdb/core ^0.17.0``).
+
 ## [0.3.2] - 2026-06-04
 
 ### Fixed

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -217,6 +217,22 @@ Generate a module dependency graph with `GitNexus <https://github.com/abhigyanpa
 
 Writes ``.gitnexus/`` under the repo root. Re-run when imports change.
 
+**GitNexus / LadybugDB compatibility**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 30 50
+
+   * - Topos
+     - Python binding
+     - GitNexus CLI
+   * - ≤0.3.3
+     - ``real-ladybug`` 0.15 (storage v40)
+     - pin ``gitnexus@<1.6`` or omit ``--gitnexus-dir``
+   * - ≥0.3.4
+     - ``ladybug`` 0.17+ (storage v41)
+     - ``gitnexus@latest`` (tested with 1.6.7)
+
 **Example**
 
 .. code-block:: bash

--- a/docs/source/measures.rst
+++ b/docs/source/measures.rst
@@ -79,7 +79,7 @@ the "Quality Medals" reflect empirical software engineering standards.
      - ``0.40``
      - ``cyclomatic <= 15`` AND ``max_func <= 10`` AND ``entropy in [0.2, 0.8]``
    * - **COMPOSABLE**
-     - ``0.60``
+     - ``0.80``
      - ``instability in [0.3, 0.7]`` AND ``fan_in <= 15`` AND ``fan_out <= 15``
    * - **SECURE**
      - ``1.00``

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "topos-vscode",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "topos-vscode",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@types/mocha": "^10.0.6",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "topos-vscode",
   "displayName": "Topos: Code Quality Targets for Agents",
   "description": "Structural code-quality targets your coding agents can optimize toward, delivered as MCP tools for agent mode.",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "publisher": "KrvLabs",
   "icon": "icon.png",
   "license": "SEE LICENSE IN LICENSE",

--- a/extensions/vscode/workflow/publishing.md
+++ b/extensions/vscode/workflow/publishing.md
@@ -143,7 +143,7 @@ uv run --with pyinstaller pyinstaller --name topos --onefile --clean \
   --collect-all tree_sitter_typescript \
   --collect-all topos \
   --collect-all fastmcp \
-  --collect-all real-ladybug \
+  --collect-all ladybug \
   --copy-metadata fastmcp \
   topos/cli/main.py
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "click>=8.1",
     "fastmcp>=3.0.0",
     "numpy>=1.24",
-    "real-ladybug>=0.15",
+    "ladybug>=0.17.0,<0.18",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "topos"
-version = "0.3.3"
+version = "0.3.4"
 description = "Structural code quality metrics for agent-written programs."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/evaluation/test_calibration.py
+++ b/tests/evaluation/test_calibration.py
@@ -44,66 +44,94 @@ def test_coverage_and_clone_defaults_are_sane():
 
 def test_simple_achieved_boundary_uses_calibration():
     # Pass all gates
-    assert score_simple(
-        SIMPLE.max_cyclomatic - 5,
-        SIMPLE.entropy_ideal,
-        SIMPLE.max_function_complexity - 5,
-    ).achieved is True
+    assert (
+        score_simple(
+            SIMPLE.max_cyclomatic - 5,
+            SIMPLE.entropy_ideal,
+            SIMPLE.max_function_complexity - 5,
+        ).achieved
+        is True
+    )
 
     # Fail cyclomatic
-    assert score_simple(
-        SIMPLE.max_cyclomatic + 1,
-        SIMPLE.entropy_ideal,
-        SIMPLE.max_function_complexity - 5,
-    ).achieved is False
+    assert (
+        score_simple(
+            SIMPLE.max_cyclomatic + 1,
+            SIMPLE.entropy_ideal,
+            SIMPLE.max_function_complexity - 5,
+        ).achieved
+        is False
+    )
 
     # Fail entropy (high)
-    assert score_simple(
-        SIMPLE.max_cyclomatic - 5,
-        SIMPLE.max_entropy + 0.1,
-        SIMPLE.max_function_complexity - 5,
-    ).achieved is False
+    assert (
+        score_simple(
+            SIMPLE.max_cyclomatic - 5,
+            SIMPLE.max_entropy + 0.1,
+            SIMPLE.max_function_complexity - 5,
+        ).achieved
+        is False
+    )
 
     # Fail max function complexity
-    assert score_simple(
-        SIMPLE.max_cyclomatic - 5,
-        SIMPLE.entropy_ideal,
-        SIMPLE.max_function_complexity + 1,
-    ).achieved is False
+    assert (
+        score_simple(
+            SIMPLE.max_cyclomatic - 5,
+            SIMPLE.entropy_ideal,
+            SIMPLE.max_function_complexity + 1,
+        ).achieved
+        is False
+    )
 
 
 def test_secure_achieved_boundary_uses_calibration():
     assert score_secure(dangerous_calls=0, taint_flows=0).achieved is True
-    assert score_secure(
-        dangerous_calls=SECURE.max_dangerous_calls + 1, taint_flows=0
-    ).achieved is False
-    assert score_secure(
-        dangerous_calls=0, taint_flows=SECURE.max_taint_flows + 1
-    ).achieved is False
+    assert (
+        score_secure(
+            dangerous_calls=SECURE.max_dangerous_calls + 1, taint_flows=0
+        ).achieved
+        is False
+    )
+    assert (
+        score_secure(dangerous_calls=0, taint_flows=SECURE.max_taint_flows + 1).achieved
+        is False
+    )
 
 
 def test_composable_achieved_boundary_uses_calibration():
     mid_instability = (COMPOSABLE.instability_low + COMPOSABLE.instability_high) / 2
-    assert score_coupling(
-        instability=mid_instability,
-        fan_in=COMPOSABLE.max_fan_in - 5,
-        fan_out=COMPOSABLE.max_fan_out - 5,
-    ).achieved is True
+    assert (
+        score_coupling(
+            instability=mid_instability,
+            fan_in=COMPOSABLE.max_fan_in - 5,
+            fan_out=COMPOSABLE.max_fan_out - 5,
+        ).achieved
+        is True
+    )
 
-    assert score_coupling(
-        instability=COMPOSABLE.instability_low - 0.1,
-        fan_in=COMPOSABLE.max_fan_in - 5,
-        fan_out=COMPOSABLE.max_fan_out - 5,
-    ).achieved is False
+    assert (
+        score_coupling(
+            instability=COMPOSABLE.instability_low - 0.1,
+            fan_in=COMPOSABLE.max_fan_in - 5,
+            fan_out=COMPOSABLE.max_fan_out - 5,
+        ).achieved
+        is False
+    )
 
-    assert score_coupling(
-        instability=mid_instability,
-        fan_in=COMPOSABLE.max_fan_in + 1,
-        fan_out=COMPOSABLE.max_fan_out - 5,
-    ).achieved is False
+    assert (
+        score_coupling(
+            instability=mid_instability,
+            fan_in=COMPOSABLE.max_fan_in + 1,
+            fan_out=COMPOSABLE.max_fan_out - 5,
+        ).achieved
+        is False
+    )
 
-    assert score_coupling(
-        instability=mid_instability,
-        fan_in=COMPOSABLE.max_fan_in - 5,
-        fan_out=COMPOSABLE.max_fan_out + 1,
-    ).achieved is False
+    assert (
+        score_coupling(
+            instability=mid_instability,
+            fan_in=COMPOSABLE.max_fan_in - 5,
+            fan_out=COMPOSABLE.max_fan_out + 1,
+        ).achieved
+        is False
+    )

--- a/tests/evaluation/test_calibration.py
+++ b/tests/evaluation/test_calibration.py
@@ -1,0 +1,109 @@
+"""Tests for centralized policy calibration in calibration.py."""
+
+from __future__ import annotations
+
+from topos.evaluation.policies.calibration import (
+    CLONE,
+    COMPOSABLE,
+    COVERAGE,
+    SCORE_FLOORS,
+    SECURE,
+    SIMPLE,
+)
+from topos.evaluation.policies.composable import score_coupling
+from topos.evaluation.policies.secure import score_secure
+from topos.evaluation.policies.simple import score_simple
+from topos.evaluation.preferences import Generator
+
+
+def test_score_floors_cover_every_generator():
+    for g in Generator:
+        assert g in SCORE_FLOORS
+        assert 0.0 < SCORE_FLOORS[g] <= 1.0
+
+
+def test_secure_gates_are_zero_tolerance():
+    assert SECURE.max_dangerous_calls == 0.0
+    assert SECURE.max_taint_flows == 0.0
+
+
+def test_simple_entropy_band_is_ordered():
+    assert 0.0 <= SIMPLE.min_entropy < SIMPLE.entropy_ideal < SIMPLE.max_entropy <= 1.0
+
+
+def test_composable_instability_band_is_ordered():
+    assert 0.0 <= COMPOSABLE.instability_low < COMPOSABLE.instability_high <= 1.0
+
+
+def test_coverage_and_clone_defaults_are_sane():
+    assert 0.0 < COVERAGE.declaration_recall <= 1.0
+    assert COVERAGE.strong_offset > 0.0
+    assert 0.0 < COVERAGE.partial_factor < 1.0
+    assert 0.0 < CLONE.max_normalized_distance < 1.0
+
+
+def test_simple_achieved_boundary_uses_calibration():
+    # Pass all gates
+    assert score_simple(
+        SIMPLE.max_cyclomatic - 5,
+        SIMPLE.entropy_ideal,
+        SIMPLE.max_function_complexity - 5,
+    ).achieved is True
+
+    # Fail cyclomatic
+    assert score_simple(
+        SIMPLE.max_cyclomatic + 1,
+        SIMPLE.entropy_ideal,
+        SIMPLE.max_function_complexity - 5,
+    ).achieved is False
+
+    # Fail entropy (high)
+    assert score_simple(
+        SIMPLE.max_cyclomatic - 5,
+        SIMPLE.max_entropy + 0.1,
+        SIMPLE.max_function_complexity - 5,
+    ).achieved is False
+
+    # Fail max function complexity
+    assert score_simple(
+        SIMPLE.max_cyclomatic - 5,
+        SIMPLE.entropy_ideal,
+        SIMPLE.max_function_complexity + 1,
+    ).achieved is False
+
+
+def test_secure_achieved_boundary_uses_calibration():
+    assert score_secure(dangerous_calls=0, taint_flows=0).achieved is True
+    assert score_secure(
+        dangerous_calls=SECURE.max_dangerous_calls + 1, taint_flows=0
+    ).achieved is False
+    assert score_secure(
+        dangerous_calls=0, taint_flows=SECURE.max_taint_flows + 1
+    ).achieved is False
+
+
+def test_composable_achieved_boundary_uses_calibration():
+    mid_instability = (COMPOSABLE.instability_low + COMPOSABLE.instability_high) / 2
+    assert score_coupling(
+        instability=mid_instability,
+        fan_in=COMPOSABLE.max_fan_in - 5,
+        fan_out=COMPOSABLE.max_fan_out - 5,
+    ).achieved is True
+
+    assert score_coupling(
+        instability=COMPOSABLE.instability_low - 0.1,
+        fan_in=COMPOSABLE.max_fan_in - 5,
+        fan_out=COMPOSABLE.max_fan_out - 5,
+    ).achieved is False
+
+    assert score_coupling(
+        instability=mid_instability,
+        fan_in=COMPOSABLE.max_fan_in + 1,
+        fan_out=COMPOSABLE.max_fan_out - 5,
+    ).achieved is False
+
+    assert score_coupling(
+        instability=mid_instability,
+        fan_in=COMPOSABLE.max_fan_in - 5,
+        fan_out=COMPOSABLE.max_fan_out + 1,
+    ).achieved is False

--- a/tests/evaluation/test_calibration.py
+++ b/tests/evaluation/test_calibration.py
@@ -22,6 +22,12 @@ def test_score_floors_cover_every_generator():
         assert 0.0 < SCORE_FLOORS[g] <= 1.0
 
 
+def test_score_floors_match_pypi_calibration():
+    assert SCORE_FLOORS[Generator.SIMPLE] == 0.40
+    assert SCORE_FLOORS[Generator.COMPOSABLE] == 0.80
+    assert SCORE_FLOORS[Generator.SECURE] == 1.00
+
+
 def test_secure_gates_are_zero_tolerance():
     assert SECURE.max_dangerous_calls == 0.0
     assert SECURE.max_taint_flows == 0.0

--- a/tests/functors/probes/mdg/test_pdg_metrics.py
+++ b/tests/functors/probes/mdg/test_pdg_metrics.py
@@ -3,7 +3,9 @@
 import json
 import tempfile
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
+import pytest
 from topos.functors.probes.mdg.coupling import (
     CouplingResult,
     calculate_coupling,
@@ -15,6 +17,7 @@ from topos.functors.probes.mdg.fan import FanResult, calculate_fan_in_out
 from topos.graphs.mdg.object import (
     GraphNode,
     GraphRelationship,
+    LadybugSchemaMismatchError,
     ModuleDependencyGraph,
 )
 
@@ -705,8 +708,6 @@ def test_coupling_counts_nested_method_imports():
 
 def test_from_gitnexus_dir_malformed_json():
     """A JSON file with invalid content raises json.JSONDecodeError."""
-    import pytest
-
     with tempfile.TemporaryDirectory() as tmp:
         base = Path(tmp)
         lbug = base / "lbug"
@@ -715,6 +716,51 @@ def test_from_gitnexus_dir_malformed_json():
 
         with pytest.raises(json.JSONDecodeError):
             ModuleDependencyGraph.from_gitnexus_dir(base, target_file="foo.py")
+
+
+def test_from_ladybugdb_schema_mismatch_raises_actionable_error() -> None:
+    """Binary lbug with newer storage version yields LadybugSchemaMismatchError."""
+    mismatch = RuntimeError(
+        "Runtime exception: Trying to read a database file with a different version. "
+        "Database file version: 41, Current build storage version: 40"
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        base = Path(tmp)
+        lbug_file = base / "lbug"
+        lbug_file.write_bytes(b"\x00")
+
+        mock_lb = MagicMock()
+        mock_lb.Database.side_effect = mismatch
+        with (
+            patch.dict("sys.modules", {"ladybug": mock_lb}),
+            pytest.raises(LadybugSchemaMismatchError, match="ladybug 0.17\\+"),
+        ):
+            ModuleDependencyGraph.from_gitnexus_dir(base, target_file="foo.py")
+
+
+def test_load_dep_graph_returns_none_on_schema_mismatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from topos.mcp import evaluation as mcp_evaluation
+
+    monkeypatch.setattr(
+        mcp_evaluation,
+        "dep_graph_for",
+        MagicMock(
+            side_effect=LadybugSchemaMismatchError(
+                "LadybugDB storage version mismatch while loading .gitnexus/lbug."
+            )
+        ),
+    )
+    mcp_evaluation.clear_dep_graph_error()
+    gitnexus_dir = tmp_path / ".gitnexus"
+    gitnexus_dir.mkdir()
+
+    result = mcp_evaluation.load_dep_graph(gitnexus_dir, "foo.py")
+
+    assert result is None
+    assert mcp_evaluation.last_dep_graph_error() is not None
+    assert "storage version mismatch" in mcp_evaluation.last_dep_graph_error().lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/mcp/test_evaluate.py
+++ b/tests/mcp/test_evaluate.py
@@ -113,6 +113,38 @@ def test_evaluate_file_warns_without_gitnexus(
     assert "mdg.unavailable" in r.pillars["composable"].interpretation
 
 
+def test_gitnexus_warnings_surface_schema_mismatch(tmp_path: Path) -> None:
+    from topos.mcp.evaluation import (
+        clear_dep_graph_error,
+        gitnexus_warnings,
+        load_dep_graph,
+    )
+    from topos.graphs.mdg.object import LadybugSchemaMismatchError
+
+    gitnexus_dir = tmp_path / ".gitnexus"
+    gitnexus_dir.mkdir()
+    (gitnexus_dir / "lbug").write_bytes(b"\x00")
+
+    clear_dep_graph_error()
+    with patch(
+        "topos.mcp.evaluation.dep_graph_for",
+        side_effect=LadybugSchemaMismatchError(
+            "LadybugDB storage version mismatch while loading .gitnexus/lbug. "
+            "Upgrade Topos to v0.3.4+."
+        ),
+    ):
+        dep_graph = load_dep_graph(gitnexus_dir, "module.py")
+
+    assert dep_graph is None
+    warnings = gitnexus_warnings(
+        str(gitnexus_dir),
+        tmp_path,
+        gitnexus_dir,
+        dep_graph_loaded=False,
+    )
+    assert any("storage version mismatch" in w.lower() for w in warnings)
+
+
 def test_evaluate_file_reports_security_findings(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/mcp/test_evaluate.py
+++ b/tests/mcp/test_evaluate.py
@@ -114,12 +114,12 @@ def test_evaluate_file_warns_without_gitnexus(
 
 
 def test_gitnexus_warnings_surface_schema_mismatch(tmp_path: Path) -> None:
+    from topos.graphs.mdg.object import LadybugSchemaMismatchError
     from topos.mcp.evaluation import (
         clear_dep_graph_error,
         gitnexus_warnings,
         load_dep_graph,
     )
-    from topos.graphs.mdg.object import LadybugSchemaMismatchError
 
     gitnexus_dir = tmp_path / ".gitnexus"
     gitnexus_dir.mkdir()

--- a/topos/__init__.py
+++ b/topos/__init__.py
@@ -30,7 +30,7 @@ from topos.graphs.cpg.object import CodePropertyGraph
 from topos.graphs.mdg.object import ModuleDependencyGraph
 from topos.graphs.pdg.object import ProgramDependenceGraph
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"
 
 __all__ = [
     # Categorical primitives

--- a/topos/evaluation/policies/__init__.py
+++ b/topos/evaluation/policies/__init__.py
@@ -3,9 +3,9 @@ Policy translators and auxiliary decision helpers.
 
 **Quality generators (Ω):** ``score_simple``, ``score_coupling``, and
 ``score_secure`` each map probe metrics to a :class:`ScoredDecision`.
-``achieved`` is the AND of per-metric **raw** thresholds defined in those
-modules; the characteristic morphism combines the three booleans into
-an element of Ω = H(G_qual).
+``achieved`` is the AND of per-metric **raw** gates from
+:mod:`topos.evaluation.policies.calibration`; the characteristic morphism
+combines the three booleans into an element of Ω = H(G_qual).
 
 **Outside Ω:** ``are_clones`` (pairwise AST distance) and
 ``score_declaration_coverage`` (structural test coverage) apply the same
@@ -31,6 +31,14 @@ from topos.evaluation.policies.simple import (
     describe_entropy_ratio,
     score_simple,
 )
+from topos.evaluation.policies.calibration import (
+    CLONE,
+    COMPOSABLE,
+    COVERAGE,
+    SCORE_FLOORS,
+    SECURE,
+    SIMPLE,
+)
 
 __all__ = [
     "Priority",
@@ -45,4 +53,10 @@ __all__ = [
     "score_secure",
     "describe_entropy_ratio",
     "build_omega",
+    "SIMPLE",
+    "COMPOSABLE",
+    "SECURE",
+    "COVERAGE",
+    "CLONE",
+    "SCORE_FLOORS",
 ]

--- a/topos/evaluation/policies/__init__.py
+++ b/topos/evaluation/policies/__init__.py
@@ -19,6 +19,14 @@ from topos.evaluation.policies.base import (
     ScoredDecision,
     WeightProfile,
 )
+from topos.evaluation.policies.calibration import (
+    CLONE,
+    COMPOSABLE,
+    COVERAGE,
+    SCORE_FLOORS,
+    SECURE,
+    SIMPLE,
+)
 from topos.evaluation.policies.clones import are_clones
 from topos.evaluation.policies.composable import score_coupling
 from topos.evaluation.policies.coverage import (
@@ -30,14 +38,6 @@ from topos.evaluation.policies.simple import (
     build_omega,
     describe_entropy_ratio,
     score_simple,
-)
-from topos.evaluation.policies.calibration import (
-    CLONE,
-    COMPOSABLE,
-    COVERAGE,
-    SCORE_FLOORS,
-    SECURE,
-    SIMPLE,
 )
 
 __all__ = [

--- a/topos/evaluation/policies/base.py
+++ b/topos/evaluation/policies/base.py
@@ -8,16 +8,17 @@ characteristic morphism (:mod:`topos.evaluation.characteristic_morphism`)
 reads each decision's ``achieved`` flag and assembles the 8-element
 verdict in Ω via :func:`topos.core.omega.verdict_from_generators`.
 
-This module defines the shared types; the decisive thresholds live in
-each Φᵢ module:
+This module defines the shared types; all numeric calibration lives in
+:mod:`topos.evaluation.policies.calibration`:
 
 - :class:`ScoredDecision` — output of one Φᵢ (score + achieved + text).
 - :class:`Priority`       — legacy single-generator emphasis (signature
                             compatibility only; Φᵢ do not use it today).
 - :class:`WeightProfile`  — legacy intra-Φᵢ metric weights (same).
-- :data:`THRESHOLDS`      — optional score-floor helpers for tools that
-                            aggregate normalized scores without re-running
-                            a full Φᵢ.
+- :data:`THRESHOLDS`      — re-export of score-floor helpers from
+                            :data:`~topos.evaluation.policies.calibration.SCORE_FLOORS`
+                            for tools that aggregate normalized scores
+                            without re-running a full Φᵢ.
 
 There is exactly one ``Φᵢ`` per generator::
 
@@ -79,6 +80,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import StrEnum
 
+from topos.evaluation.policies.calibration import SCORE_FLOORS
 from topos.evaluation.preferences import Generator
 
 # ---------------------------------------------------------------------------
@@ -89,13 +91,10 @@ from topos.evaluation.preferences import Generator
 # score floors are for :func:`meet_satisfied` and other callers that
 # already aggregated scores without re-invoking a Φᵢ.
 #
-# Defaults are v0 placeholders pending corpus calibration.
+# Defined in :mod:`topos.evaluation.policies.calibration`; re-exported here
+# for backward compatibility.
 
-THRESHOLDS: dict[Generator, float] = {
-    Generator.SIMPLE: 0.40,
-    Generator.COMPOSABLE: 0.60,
-    Generator.SECURE: 1.00,
-}
+THRESHOLDS: dict[Generator, float] = SCORE_FLOORS
 
 
 def threshold(generator: Generator) -> float:
@@ -115,8 +114,8 @@ def meet_satisfied(scores: dict[Generator, float]) -> dict[Generator, bool]:
     :func:`topos.core.omega.verdict_from_generators` for the Ω element.
 
     Prefer each ``Φᵢ``'s ``ScoredDecision.achieved`` when probe metrics are
-    available — that path applies raw-metric thresholds defined in
-    :mod:`topos.evaluation.policies.simple`, ``composable``, and ``secure``.
+    available — that path applies raw-metric gates from
+    :mod:`topos.evaluation.policies.calibration`.
     """
     return {g: is_satisfied(g, scores.get(g, 0.0)) for g in Generator}
 

--- a/topos/evaluation/policies/calibration.py
+++ b/topos/evaluation/policies/calibration.py
@@ -1,0 +1,103 @@
+"""
+Policy calibration — central hub for evaluation gates and scoring constants.
+
+Edit the module-level singletons (``SIMPLE``, ``COMPOSABLE``, ``SECURE``,
+``COVERAGE``, ``CLONE``) and ``SCORE_FLOORS`` when updating from experimental
+data. All policy translators import from this module; nothing else should
+define pass/fail or normalization numbers.
+
+Sections
+--------
+**Raw-metric gates** — drive ``ScoredDecision.achieved`` (AND semantics).
+Each ``Φᵢ`` compares probe values against these fields; they are the decisive
+pass/fail criteria for the three quality generators in Ω.
+
+**Normalization caps/scales** — map raw metrics to ``[0, 1]`` quality scores
+for reporting and multi-file aggregation. They do **not** gate ``achieved``.
+
+**Score floors** — alternate path via :func:`~topos.evaluation.policies.base.meet_satisfied`
+and multi-file :class:`~topos.evaluation.characteristic_morphism.CharacteristicMorphism`
+meets. Live ``Φᵢ`` translators do not use these for ``achieved``.
+
+**Auxiliary** — clone detection and declaration-coverage defaults (outside Ω).
+
+Calibration provenance: v0 defaults — update from corpus experiments.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from topos.evaluation.preferences import Generator
+
+
+@dataclass(frozen=True)
+class SimplePolicyThresholds:
+    """Φ_SIMPLE gates and normalization."""
+
+    # Gates (achieved)
+    max_cyclomatic: float = 15.0
+    max_function_complexity: float = 10.0
+    min_entropy: float = 0.2
+    max_entropy: float = 0.8
+    # Normalization (score only)
+    max_cyclomatic_cap: float = 40.0
+    max_function_complexity_cap: float = 20.0
+    entropy_ideal: float = 0.5
+
+
+@dataclass(frozen=True)
+class ComposablePolicyThresholds:
+    """Φ_COMPOSABLE gates and normalization."""
+
+    # Gates (achieved)
+    instability_low: float = 0.3
+    instability_high: float = 0.7
+    max_fan_in: float = 15.0
+    max_fan_out: float = 15.0
+    # Normalization (score only)
+    max_fan_in_cap: float = 40.0
+    max_fan_out_cap: float = 40.0
+
+
+@dataclass(frozen=True)
+class SecurePolicyThresholds:
+    """Φ_SECURE gates and normalization."""
+
+    # Gates (achieved) — strict zero-tolerance security
+    max_dangerous_calls: float = 0.0
+    max_taint_flows: float = 0.0
+    # Normalization (score only) — exponential decay scales
+    danger_scale: float = 3.0
+    taint_scale: float = 3.0
+
+
+@dataclass(frozen=True)
+class CoveragePolicyThresholds:
+    """Structural test-coverage policy (outside Ω)."""
+
+    declaration_recall: float = 0.5
+    strong_offset: float = 0.25  # "strong" band above gate
+    partial_factor: float = 0.5  # "partial" band = gate × this
+
+
+@dataclass(frozen=True)
+class ClonePolicyThresholds:
+    """Pairwise clone detection (outside Ω)."""
+
+    max_normalized_distance: float = 0.1
+
+
+# Module-level singletons — edit these after experiments.
+SIMPLE = SimplePolicyThresholds()
+COMPOSABLE = ComposablePolicyThresholds()
+SECURE = SecurePolicyThresholds()
+COVERAGE = CoveragePolicyThresholds()
+CLONE = ClonePolicyThresholds()
+
+# Score-floor alternate path (meet_satisfied + multi-file CharacteristicMorphism).
+SCORE_FLOORS: dict[Generator, float] = {
+    Generator.SIMPLE: 0.40,
+    Generator.COMPOSABLE: 0.60,
+    Generator.SECURE: 1.00,
+}

--- a/topos/evaluation/policies/calibration.py
+++ b/topos/evaluation/policies/calibration.py
@@ -22,7 +22,8 @@ meets. Live ``Φᵢ`` translators do not use these for ``achieved``.
 
 **Auxiliary** — clone detection and declaration-coverage defaults (outside Ω).
 
-Calibration provenance: v0 defaults — update from corpus experiments.
+Calibration provenance: PyPI corpus ECDF calibration (June 2026).
+See topos-leaderboard/CALIBRATION_REPORT.md and calibration.json.
 """
 
 from __future__ import annotations
@@ -99,6 +100,6 @@ CLONE = ClonePolicyThresholds()
 # Score-floor alternate path (meet_satisfied + multi-file CharacteristicMorphism).
 SCORE_FLOORS: dict[Generator, float] = {
     Generator.SIMPLE: 0.40,
-    Generator.COMPOSABLE: 0.60,
+    Generator.COMPOSABLE: 0.80,
     Generator.SECURE: 1.00,
 }

--- a/topos/evaluation/policies/calibration.py
+++ b/topos/evaluation/policies/calibration.py
@@ -15,8 +15,9 @@ pass/fail criteria for the three quality generators in Ω.
 **Normalization caps/scales** — map raw metrics to ``[0, 1]`` quality scores
 for reporting and multi-file aggregation. They do **not** gate ``achieved``.
 
-**Score floors** — alternate path via :func:`~topos.evaluation.policies.base.meet_satisfied`
-and multi-file :class:`~topos.evaluation.characteristic_morphism.CharacteristicMorphism`
+**Score floors** — alternate path via
+:func:`~topos.evaluation.policies.base.meet_satisfied` and multi-file
+:class:`~topos.evaluation.characteristic_morphism.CharacteristicMorphism`
 meets. Live ``Φᵢ`` translators do not use these for ``achieved``.
 
 **Auxiliary** — clone detection and declaration-coverage defaults (outside Ω).

--- a/topos/evaluation/policies/clones.py
+++ b/topos/evaluation/policies/clones.py
@@ -4,13 +4,15 @@ Clone detection policy (pairwise, outside Ω).
 
 Functors compute normalized AST distance; this module applies the
 clone threshold.  Not a ``Φᵢ`` translator — does not participate in the
-SIMPLE / COMPOSABLE / SECURE lattice.
+SIMPLE / COMPOSABLE / SECURE lattice. Default lives in
+:mod:`topos.evaluation.policies.calibration`.
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from topos.evaluation.policies.calibration import CLONE
 from topos.functors.profunctors.ast.compare import calculate_ast_distance
 
 if TYPE_CHECKING:
@@ -20,7 +22,7 @@ if TYPE_CHECKING:
 def are_clones(
     source: ProgramObject,
     target: ProgramObject,
-    threshold: float = 0.1,
+    threshold: float = CLONE.max_normalized_distance,
 ) -> bool:
     """
     Check if two programs are structural clones.

--- a/topos/evaluation/policies/composable.py
+++ b/topos/evaluation/policies/composable.py
@@ -8,16 +8,17 @@ fan-in, fan-out) into a :class:`~topos.evaluation.policies.base.ScoredDecision`.
 ``score`` is ``min(per-metric qualities)`` for reporting only.
 
 Quality functions:
-    instability_quality = piecewise flat-top tent over [0.3, 0.7]:
-                            instability in [0.3, 0.7] → 1.0 (optimal range)
-                            instability < 0.3           → linear from 0.0 to 1.0
-                            instability > 0.7           → linear from 1.0 to 0.0
+    instability_quality = piecewise flat-top tent over [low, high]:
+                            instability in band → 1.0 (optimal range)
+                            instability < low   → linear from 0.0 to 1.0
+                            instability > high  → linear from 1.0 to 0.0
 
-    fan_quality         = 1 - min(fan / MAX_FAN_CAP, 1.0)
+    fan_quality         = 1 - min(fan / cap, 1.0)
                           Linear fall from 1.0 to 0.0 at the cap.
 
 The COMPOSABLE badge is achieved if all three metrics pass their
-independent thresholds (AND logic).
+independent thresholds (AND logic). Thresholds live in
+:mod:`topos.evaluation.policies.calibration`.
 """
 
 from __future__ import annotations
@@ -26,16 +27,7 @@ from topos.evaluation.policies.base import (
     Priority,
     ScoredDecision,
 )
-
-# Normalization caps (for [0, 1] mapping)
-MAX_FAN_IN_CAP: float = 40.0
-MAX_FAN_OUT_CAP: float = 40.0
-
-# Independent Raw Thresholds (Policy Decisions)
-INSTABILITY_LOW: float = 0.3
-INSTABILITY_HIGH: float = 0.7
-MAX_FAN_IN_THRESHOLD: float = 15.0
-MAX_FAN_OUT_THRESHOLD: float = 15.0
+from topos.evaluation.policies.calibration import COMPOSABLE
 
 
 def score_coupling(
@@ -67,23 +59,23 @@ def score_coupling(
     if instability is not None:
         quality = _instability_tent(instability)
         qualities.append(quality)
-        if not (INSTABILITY_LOW <= instability <= INSTABILITY_HIGH):
+        if not (COMPOSABLE.instability_low <= instability <= COMPOSABLE.instability_high):
             achieved = False
         interp["mdg.instability"] = _instability_interpretation(instability, quality)
 
     # 2. Fan-In
     if fan_in is not None:
-        quality = 1.0 - min(fan_in / MAX_FAN_IN_CAP, 1.0)
+        quality = 1.0 - min(fan_in / COMPOSABLE.max_fan_in_cap, 1.0)
         qualities.append(quality)
-        if fan_in > MAX_FAN_IN_THRESHOLD:
+        if fan_in > COMPOSABLE.max_fan_in:
             achieved = False
         interp["mdg.fan_in"] = _fan_interpretation("in", fan_in, quality)
 
     # 3. Fan-Out
     if fan_out is not None:
-        quality = 1.0 - min(fan_out / MAX_FAN_OUT_CAP, 1.0)
+        quality = 1.0 - min(fan_out / COMPOSABLE.max_fan_out_cap, 1.0)
         qualities.append(quality)
-        if fan_out > MAX_FAN_OUT_THRESHOLD:
+        if fan_out > COMPOSABLE.max_fan_out:
             achieved = False
         interp["mdg.fan_out"] = _fan_interpretation("out", fan_out, quality)
 
@@ -108,25 +100,29 @@ def score_coupling(
 
 def _instability_tent(instability: float) -> float:
     """
-    Flat-top tent function over [INSTABILITY_LOW, INSTABILITY_HIGH].
+    Flat-top tent function over [instability_low, instability_high].
 
     Returns 1.0 in the optimal range and falls linearly to 0.0 outside it.
     """
-    if INSTABILITY_LOW <= instability <= INSTABILITY_HIGH:
+    low = COMPOSABLE.instability_low
+    high = COMPOSABLE.instability_high
+    if low <= instability <= high:
         return 1.0
-    if instability < INSTABILITY_LOW:
-        return instability / INSTABILITY_LOW
-    # instability > INSTABILITY_HIGH
-    return max(0.0, (1.0 - instability) / (1.0 - INSTABILITY_HIGH))
+    if instability < low:
+        return instability / low
+    # instability > high
+    return max(0.0, (1.0 - instability) / (1.0 - high))
 
 
 def _instability_interpretation(instability: float, quality: float) -> str:
-    if INSTABILITY_LOW <= instability <= INSTABILITY_HIGH:
+    low = COMPOSABLE.instability_low
+    high = COMPOSABLE.instability_high
+    if low <= instability <= high:
         return (
             f"instability ({instability:.2f}) within balanced range "
-            f"[{INSTABILITY_LOW}, {INSTABILITY_HIGH}]"
+            f"[{low}, {high}]"
         )
-    if instability < INSTABILITY_LOW:
+    if instability < low:
         return f"instability ({instability:.2f}) is too low (module is too stable)"
     return (
         f"instability ({instability:.2f}) is too high "
@@ -135,7 +131,7 @@ def _instability_interpretation(instability: float, quality: float) -> str:
 
 
 def _fan_interpretation(direction: str, raw: float, quality: float) -> str:
-    threshold = MAX_FAN_IN_THRESHOLD if direction == "in" else MAX_FAN_OUT_THRESHOLD
-    if raw <= threshold:
-        return f"fan-{direction} ({raw:.0f}) within threshold (<= {threshold})"
-    return f"fan-{direction} ({raw:.0f}) exceeds threshold (> {threshold})"
+    gate = COMPOSABLE.max_fan_in if direction == "in" else COMPOSABLE.max_fan_out
+    if raw <= gate:
+        return f"fan-{direction} ({raw:.0f}) within threshold (<= {gate})"
+    return f"fan-{direction} ({raw:.0f}) exceeds threshold (> {gate})"

--- a/topos/evaluation/policies/composable.py
+++ b/topos/evaluation/policies/composable.py
@@ -59,7 +59,8 @@ def score_coupling(
     if instability is not None:
         quality = _instability_tent(instability)
         qualities.append(quality)
-        if not (COMPOSABLE.instability_low <= instability <= COMPOSABLE.instability_high):
+        low, high = COMPOSABLE.instability_low, COMPOSABLE.instability_high
+        if not (low <= instability <= high):
             achieved = False
         interp["mdg.instability"] = _instability_interpretation(instability, quality)
 
@@ -118,10 +119,7 @@ def _instability_interpretation(instability: float, quality: float) -> str:
     low = COMPOSABLE.instability_low
     high = COMPOSABLE.instability_high
     if low <= instability <= high:
-        return (
-            f"instability ({instability:.2f}) within balanced range "
-            f"[{low}, {high}]"
-        )
+        return f"instability ({instability:.2f}) within balanced range [{low}, {high}]"
     if instability < low:
         return f"instability ({instability:.2f}) is too low (module is too stable)"
     return (

--- a/topos/evaluation/policies/coverage.py
+++ b/topos/evaluation/policies/coverage.py
@@ -6,13 +6,15 @@ The UAST profunctor emits a raw
 :class:`~topos.functors.profunctors.uast.structural_test_coverage.DeclarationCoverageReport`;
 this module threshold-classifies it into a :class:`CoverageDecision`
 (mean recall, F2, uncovered declarations).  Independent of the three
-quality generators in Ω.
+quality generators in Ω. Defaults live in
+:mod:`topos.evaluation.policies.calibration`.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from topos.evaluation.policies.calibration import COVERAGE
 from topos.functors.profunctors.uast.structural_test_coverage import (
     DeclarationCoverageReport,
 )
@@ -38,7 +40,7 @@ class CoverageDecision:
 def score_declaration_coverage(
     report: DeclarationCoverageReport,
     *,
-    threshold: float = 0.5,
+    threshold: float = COVERAGE.declaration_recall,
 ) -> CoverageDecision:
     """Threshold-classify a raw coverage report (mean recall vs ``threshold``)."""
     best_recall = tuple(report.best_declaration_recall)
@@ -86,10 +88,10 @@ def score_declaration_coverage(
 
 
 def _coverage_interpretation(score: float, threshold: float) -> str:
-    if score >= threshold + 0.25:
+    if score >= threshold + COVERAGE.strong_offset:
         return "coverage is strong"
     if score >= threshold:
         return "coverage meets the policy threshold"
-    if score >= threshold * 0.5:
+    if score >= threshold * COVERAGE.partial_factor:
         return "coverage is partial"
     return "coverage is weak"

--- a/topos/evaluation/policies/secure.py
+++ b/topos/evaluation/policies/secure.py
@@ -94,10 +94,7 @@ def _danger_interpretation(count: float, quality: float) -> str:
 
 def _taint_interpretation(count: float, quality: float) -> str:
     if count <= SECURE.max_taint_flows:
-        return (
-            f"no source→sink taint paths ({count:.0f} <= {SECURE.max_taint_flows})"
-        )
+        return f"no source→sink taint paths ({count:.0f} <= {SECURE.max_taint_flows})"
     return (
-        f"{int(count)} taint flow path(s) exceeds threshold "
-        f"({SECURE.max_taint_flows})"
+        f"{int(count)} taint flow path(s) exceeds threshold ({SECURE.max_taint_flows})"
     )

--- a/topos/evaluation/policies/secure.py
+++ b/topos/evaluation/policies/secure.py
@@ -8,11 +8,12 @@ Maps CPG-based security observations into a
 ``score`` is ``min(per-metric qualities)`` for reporting only.
 
 Quality functions:
-    danger_quality = exp(-dangerous_calls / DANGER_SCALE)
-    taint_quality  = exp(-taint_flows / TAINT_SCALE)
+    danger_quality = exp(-dangerous_calls / danger_scale)
+    taint_quality  = exp(-taint_flows / taint_scale)
 
 The SECURE badge is achieved if and only if there are zero dangerous calls
-and zero taint flows (strict security).
+and zero taint flows (strict security). Thresholds live in
+:mod:`topos.evaluation.policies.calibration`.
 """
 
 from __future__ import annotations
@@ -23,14 +24,7 @@ from topos.evaluation.policies.base import (
     Priority,
     ScoredDecision,
 )
-
-# Normalization scales (for [0, 1] mapping via exponential decay)
-DANGER_SCALE: float = 3.0
-TAINT_SCALE: float = 3.0
-
-# Independent Raw Thresholds (Policy Decisions)
-MAX_DANGEROUS_CALLS_THRESHOLD: float = 0.0
-MAX_TAINT_FLOWS_THRESHOLD: float = 0.0
+from topos.evaluation.policies.calibration import SECURE
 
 
 def score_secure(
@@ -58,17 +52,17 @@ def score_secure(
 
     # 1. Dangerous API Calls
     if dangerous_calls is not None:
-        quality = exp(-max(dangerous_calls, 0.0) / DANGER_SCALE)
+        quality = exp(-max(dangerous_calls, 0.0) / SECURE.danger_scale)
         qualities.append(quality)
-        if dangerous_calls > MAX_DANGEROUS_CALLS_THRESHOLD:
+        if dangerous_calls > SECURE.max_dangerous_calls:
             achieved = False
         interp["cpg.dangerous_calls"] = _danger_interpretation(dangerous_calls, quality)
 
     # 2. Taint Flows
     if taint_flows is not None:
-        quality = exp(-max(taint_flows, 0.0) / TAINT_SCALE)
+        quality = exp(-max(taint_flows, 0.0) / SECURE.taint_scale)
         qualities.append(quality)
-        if taint_flows > MAX_TAINT_FLOWS_THRESHOLD:
+        if taint_flows > SECURE.max_taint_flows:
             achieved = False
         interp["cpg.taint_flows"] = _taint_interpretation(taint_flows, quality)
 
@@ -87,23 +81,23 @@ def score_secure(
 
 
 def _danger_interpretation(count: float, quality: float) -> str:
-    if count <= MAX_DANGEROUS_CALLS_THRESHOLD:
+    if count <= SECURE.max_dangerous_calls:
         return (
             f"no reachable dangerous-API calls "
-            f"({count:.0f} <= {MAX_DANGEROUS_CALLS_THRESHOLD})"
+            f"({count:.0f} <= {SECURE.max_dangerous_calls})"
         )
     return (
         f"{int(count)} dangerous-API call site(s) exceeds threshold "
-        f"({MAX_DANGEROUS_CALLS_THRESHOLD})"
+        f"({SECURE.max_dangerous_calls})"
     )
 
 
 def _taint_interpretation(count: float, quality: float) -> str:
-    if count <= MAX_TAINT_FLOWS_THRESHOLD:
+    if count <= SECURE.max_taint_flows:
         return (
-            f"no source→sink taint paths ({count:.0f} <= {MAX_TAINT_FLOWS_THRESHOLD})"
+            f"no source→sink taint paths ({count:.0f} <= {SECURE.max_taint_flows})"
         )
     return (
         f"{int(count)} taint flow path(s) exceeds threshold "
-        f"({MAX_TAINT_FLOWS_THRESHOLD})"
+        f"({SECURE.max_taint_flows})"
     )

--- a/topos/evaluation/policies/simple.py
+++ b/topos/evaluation/policies/simple.py
@@ -6,11 +6,12 @@ Maps CFG and AST observations into a
 :class:`~topos.evaluation.policies.base.ScoredDecision`.
 
     Φ_SIMPLE(metrics) → ScoredDecision
-    achieved = (cyclomatic ≤ 15) ∧ (0.2 ≤ entropy ≤ 0.8) ∧ (max_func ≤ 10)
+    achieved = (cyclomatic ≤ gate) ∧ (entropy in band) ∧ (max_func ≤ gate)
     score      = min(per-metric qualities)   # reporting only; does not gate achieved
 
 This is the categorical formulation of the math spec §3 "Policy
-Translation". All decisions (thresholds, combinations) are centralized here.
+Translation". Thresholds and normalization caps live in
+:mod:`topos.evaluation.policies.calibration`.
 """
 
 from __future__ import annotations
@@ -20,17 +21,7 @@ from topos.evaluation.policies.base import (
     Priority,
     ScoredDecision,
 )
-
-# Normalization caps (for [0, 1] mapping)
-MAX_CYCLOMATIC_CAP: float = 40.0
-ENTROPY_IDEAL: float = 0.5
-MAX_FUNCTION_COMPLEXITY_CAP: float = 20.0
-
-# Independent Raw Thresholds (Policy Decisions)
-MAX_CYCLOMATIC_THRESHOLD: float = 15.0
-MAX_FUNCTION_COMPLEXITY_THRESHOLD: float = 10.0
-MIN_ENTROPY_THRESHOLD: float = 0.2
-MAX_ENTROPY_THRESHOLD: float = 0.8
+from topos.evaluation.policies.calibration import SIMPLE
 
 
 def score_simple(
@@ -60,25 +51,27 @@ def score_simple(
 
     # 1. CFG Cyclomatic Complexity
     if cyclomatic is not None:
-        quality = 1.0 - min(cyclomatic / MAX_CYCLOMATIC_CAP, 1.0)
+        quality = 1.0 - min(cyclomatic / SIMPLE.max_cyclomatic_cap, 1.0)
         qualities.append(quality)
-        if cyclomatic > MAX_CYCLOMATIC_THRESHOLD:
+        if cyclomatic > SIMPLE.max_cyclomatic:
             achieved = False
         interp["cfg.cyclomatic"] = _cyclomatic_interpretation(cyclomatic, quality)
 
     # 2. AST Entropy
     if entropy is not None:
-        quality = max(0.0, 1.0 - 2.0 * abs(entropy - ENTROPY_IDEAL))
+        quality = max(0.0, 1.0 - 2.0 * abs(entropy - SIMPLE.entropy_ideal))
         qualities.append(quality)
-        if not (MIN_ENTROPY_THRESHOLD <= entropy <= MAX_ENTROPY_THRESHOLD):
+        if not (SIMPLE.min_entropy <= entropy <= SIMPLE.max_entropy):
             achieved = False
         interp["ast.entropy"] = _entropy_interpretation(entropy, quality)
 
     # 3. AST Max Function Complexity
     if max_function_complexity is not None:
-        quality = 1.0 - min(max_function_complexity / MAX_FUNCTION_COMPLEXITY_CAP, 1.0)
+        quality = 1.0 - min(
+            max_function_complexity / SIMPLE.max_function_complexity_cap, 1.0
+        )
         qualities.append(quality)
-        if max_function_complexity > MAX_FUNCTION_COMPLEXITY_THRESHOLD:
+        if max_function_complexity > SIMPLE.max_function_complexity:
             achieved = False
         interp["ast.max_function_complexity"] = _max_func_interpretation(
             max_function_complexity, quality
@@ -105,7 +98,7 @@ def build_omega() -> Omega:
 
 def describe_entropy_ratio(entropy: float) -> str:
     """Describe a raw AST entropy ratio using SIMPLE policy language."""
-    quality = max(0.0, 1.0 - 2.0 * abs(entropy - ENTROPY_IDEAL))
+    quality = max(0.0, 1.0 - 2.0 * abs(entropy - SIMPLE.entropy_ideal))
     return _entropy_interpretation(entropy, quality)
 
 
@@ -115,35 +108,35 @@ def describe_entropy_ratio(entropy: float) -> str:
 
 
 def _cyclomatic_interpretation(raw: float, quality: float) -> str:
-    if raw <= MAX_CYCLOMATIC_THRESHOLD:
+    if raw <= SIMPLE.max_cyclomatic:
         return (
             f"cyclomatic complexity ({raw:.0f}) within threshold "
-            f"(<= {MAX_CYCLOMATIC_THRESHOLD})"
+            f"(<= {SIMPLE.max_cyclomatic})"
         )
     return (
         f"cyclomatic complexity ({raw:.0f}) exceeds threshold "
-        f"(> {MAX_CYCLOMATIC_THRESHOLD})"
+        f"(> {SIMPLE.max_cyclomatic})"
     )
 
 
 def _max_func_interpretation(raw: float, quality: float) -> str:
-    if raw <= MAX_FUNCTION_COMPLEXITY_THRESHOLD:
+    if raw <= SIMPLE.max_function_complexity:
         return (
             f"max function complexity ({raw:.0f}) within threshold "
-            f"(<= {MAX_FUNCTION_COMPLEXITY_THRESHOLD})"
+            f"(<= {SIMPLE.max_function_complexity})"
         )
     return (
         f"max function complexity ({raw:.0f}) exceeds threshold "
-        f"(> {MAX_FUNCTION_COMPLEXITY_THRESHOLD})"
+        f"(> {SIMPLE.max_function_complexity})"
     )
 
 
 def _entropy_interpretation(entropy: float, quality: float) -> str:
-    if MIN_ENTROPY_THRESHOLD <= entropy <= MAX_ENTROPY_THRESHOLD:
+    if SIMPLE.min_entropy <= entropy <= SIMPLE.max_entropy:
         return (
             f"entropy ({entropy:.2f}) within structured range "
-            f"[{MIN_ENTROPY_THRESHOLD}, {MAX_ENTROPY_THRESHOLD}]"
+            f"[{SIMPLE.min_entropy}, {SIMPLE.max_entropy}]"
         )
-    if entropy < MIN_ENTROPY_THRESHOLD:
+    if entropy < SIMPLE.min_entropy:
         return f"entropy ({entropy:.2f}) is too low; code may be repetitive or trivial"
     return f"entropy ({entropy:.2f}) is too high; code may be unstructured"

--- a/topos/graphs/mdg/object.py
+++ b/topos/graphs/mdg/object.py
@@ -62,6 +62,27 @@ NodeLabel = Literal[
     "Constructor",
 ]
 
+class LadybugSchemaMismatchError(RuntimeError):
+    """Raised when ``.gitnexus/lbug`` storage version exceeds embedded ladybug."""
+
+    def __init__(self, message: str, *, original: Exception | None = None) -> None:
+        super().__init__(message)
+        self.original = original
+
+
+def _raise_schema_mismatch(exc: BaseException) -> None:
+    msg = str(exc).lower()
+    if "different version" not in msg and "storage version" not in msg:
+        raise exc
+    raise LadybugSchemaMismatchError(
+        "LadybugDB storage version mismatch while loading .gitnexus/lbug. "
+        "Upgrade Topos to v0.3.4+ (bundles ladybug 0.17+) or re-run "
+        "'topos depgraph generate' after upgrading. "
+        "GitNexus 1.6.x requires ladybug 0.17+.",
+        original=exc if isinstance(exc, Exception) else None,
+    ) from exc
+
+
 RelationshipType = Literal[
     "CONTAINS",
     "CALLS",
@@ -180,7 +201,8 @@ class ModuleDependencyGraph:
 
         Raises:
             FileNotFoundError: If the graph store cannot be found.
-            ImportError: If ``real-ladybug`` is not installed for binary format.
+            ImportError: If ``ladybug`` is not installed for binary format.
+            LadybugSchemaMismatchError: If the store version exceeds embedded ladybug.
         """
         base = Path(gitnexus_dir)
         lbug_path = base / "lbug"
@@ -202,10 +224,13 @@ class ModuleDependencyGraph:
         cls, lbug_path: Path, target_file: str
     ) -> ModuleDependencyGraph:
         """Load from the binary LadybugDB format produced by GitNexus ≥ 1.5."""
-        import real_ladybug as lb
+        import ladybug as lb
 
         graph = cls(target_file=target_file)
-        db = lb.Database(str(lbug_path), read_only=True)
+        try:
+            db = lb.Database(str(lbug_path), read_only=True)
+        except RuntimeError as exc:
+            _raise_schema_mismatch(exc)
         conn = lb.Connection(db)
 
         # Discover node tables at runtime so we're not tied to a fixed schema.

--- a/topos/graphs/mdg/object.py
+++ b/topos/graphs/mdg/object.py
@@ -62,6 +62,7 @@ NodeLabel = Literal[
     "Constructor",
 ]
 
+
 class LadybugSchemaMismatchError(RuntimeError):
     """Raised when ``.gitnexus/lbug`` storage version exceeds embedded ladybug."""
 

--- a/topos/mcp/evaluation.py
+++ b/topos/mcp/evaluation.py
@@ -23,9 +23,22 @@ from topos.evaluation.characteristic_morphism import (
 )
 from topos.evaluation.policies.base import Priority
 from topos.graphs.base import Representation
-from topos.graphs.mdg.object import ModuleDependencyGraph
+from topos.graphs.mdg.object import LadybugSchemaMismatchError, ModuleDependencyGraph
 
 from .cache import dep_graph_for
+
+_last_dep_graph_error: str | None = None
+
+
+def last_dep_graph_error() -> str | None:
+    """Return the most recent MDG load failure message, if any."""
+    return _last_dep_graph_error
+
+
+def clear_dep_graph_error() -> None:
+    """Reset the stored MDG load failure message (primarily for tests)."""
+    global _last_dep_graph_error
+    _last_dep_graph_error = None
 
 
 def resolve_gitnexus_dir(
@@ -78,11 +91,22 @@ def gitnexus_warnings(
         ]
 
     if gitnexus_dir is not None and not dep_graph_loaded:
-        warnings.append(
-            "COMPOSABLE not scored — .gitnexus exists but the dependency graph could "
-            "not be loaded; re-run 'topos depgraph generate' and ensure GitNexus "
-            "dependencies are installed."
-        )
+        load_error = last_dep_graph_error()
+        if load_error and (
+            "storage version" in load_error.lower()
+            or "different version" in load_error.lower()
+            or "ladybug" in load_error.lower()
+        ):
+            warnings.append(
+                "COMPOSABLE not scored — LadybugDB storage version mismatch: "
+                f"{load_error}"
+            )
+        else:
+            warnings.append(
+                "COMPOSABLE not scored — .gitnexus exists but the dependency graph "
+                "could not be loaded; re-run 'topos depgraph generate' and ensure "
+                "GitNexus dependencies are installed."
+            )
     if gitnexus_dir is not None:
         stale = _stale_gitnexus_warning(project_root, gitnexus_dir)
         if stale:
@@ -138,12 +162,25 @@ def load_dep_graph(
     gitnexus_dir: Path | None, target_file: str
 ) -> ModuleDependencyGraph | None:
     """Load the cached dep graph for a file, or None if not available."""
+    global _last_dep_graph_error
     if gitnexus_dir is None:
+        _last_dep_graph_error = None
         return None
     try:
-        return dep_graph_for(gitnexus_dir, target_file)
-    except (FileNotFoundError, ImportError, OSError):
-        # Silently degrade when gitnexus can't load — CFG and CPG still run.
+        graph = dep_graph_for(gitnexus_dir, target_file)
+        _last_dep_graph_error = None
+        return graph
+    except LadybugSchemaMismatchError as exc:
+        _last_dep_graph_error = str(exc)
+        return None
+    except RuntimeError as exc:
+        msg = str(exc).lower()
+        if "different version" in msg or "storage version" in msg:
+            _last_dep_graph_error = str(exc)
+            return None
+        raise
+    except (FileNotFoundError, ImportError, OSError) as exc:
+        _last_dep_graph_error = str(exc)
         return None
 
 

--- a/topos/mcp/resources/content/metrics.md
+++ b/topos/mcp/resources/content/metrics.md
@@ -3,51 +3,73 @@
 Every metric key, the graph it lives on, and how it rolls into a generator
 of `H(G_qual) = { SIMPLE, COMPOSABLE, SECURE }`.
 
+**Calibration source of truth:** `topos/evaluation/policies/calibration.py`.
+Edit that file when tuning gates or normalization from experimental data.
+
 ## SIMPLE generator (← CFG + AST entropy)
 
 Computed from the Control Flow Graph built on UAST.  Always available.
 
-| Key | Source | What it measures | Good range |
+| Key | Source | What it measures | Gate / good range |
 |---|---|---|---|
-| `cfg.cyclomatic`   | CFG | McCabe complexity `E - N + 2P`.        | ≤ 40 per file |
-| `cfg.essential`    | CFG | Cabe 1989 essential complexity.        | Low |
-| `cfg.nesting_depth`| CFG | Max static nesting depth.              | ≤ 4 |
-| `cfg.longest_path` | CFG | Longest acyclic entry-to-exit path.    | — |
-| `ast.entropy`      | AST | Source-text compression ratio.         | around 0.5 |
+| `cfg.cyclomatic`   | CFG | McCabe complexity `E - N + 2P`.        | **≤ 15** (achieved gate) |
+| `cfg.essential`    | CFG | Cabe 1989 essential complexity.        | Diagnostic |
+| `cfg.nesting_depth`| CFG | Max static nesting depth.              | Diagnostic |
+| `cfg.longest_path` | CFG | Longest acyclic entry-to-exit path.    | Diagnostic |
+| `ast.entropy`      | AST | Source-text compression ratio.         | **[0.2, 0.8]** (achieved gate) |
+| `ast.max_function_complexity` | AST | Max McCabe of any single function. | **≤ 10** (achieved gate) |
 
-`Φ_SIMPLE` = weighted average of `1 - cyclomatic/40` and the entropy bell
-curve (peak at 0.5).  Threshold to satisfy SIMPLE: **0.6**.
+`Φ_SIMPLE` maps metrics to `[0, 1]` quality scores (cyclomatic cap 40,
+max-function cap 20, entropy bell peak at 0.5). **`achieved`** is the AND
+of the raw gates above — not a single score floor.
 
 ## COMPOSABLE generator (← Dependency Graph)
 
 Requires a `ModuleDependencyGraph` parsed from `.gitnexus/`.  Only populated when
 `gitnexus_dir` is provided or auto-detected.
 
-| Key | What it measures | Good range |
+| Key | What it measures | Gate / good range |
 |---|---|---|
-| `mdg.coupling`    | Ca + Ce (afferent + efferent coupling).  | ≤ 35 |
-| `mdg.instability` | `Ce / (Ca + Ce)`.                        | 0.3 – 0.7 |
-| `mdg.fan_in`      | Incoming `CALLS` edges.                  | — |
-| `mdg.fan_out`     | Outgoing `CALLS` edges.                  | — |
-| `mdg.dep_depth`   | Longest `IMPORTS` chain.                 | — |
+| `mdg.coupling`    | Ca + Ce (afferent + efferent coupling).  | Diagnostic |
+| `mdg.instability` | `Ce / (Ca + Ce)`.                        | **[0.3, 0.7]** (achieved gate) |
+| `mdg.fan_in`      | Incoming `CALLS` edges.                  | **≤ 15** (achieved gate) |
+| `mdg.fan_out`     | Outgoing `CALLS` edges.                  | **≤ 15** (achieved gate) |
+| `mdg.dep_depth`   | Longest `IMPORTS` chain.                 | Diagnostic |
 
-`Φ_COMPOSABLE` = weighted average of `1 - coupling/35` and the instability
-tent over `[0.3, 0.7]`.  Threshold: **0.6**.
+`Φ_COMPOSABLE` uses fan caps of 40 for score normalization. **`achieved`**
+is the AND of instability band + fan-in + fan-out gates.
 
 ## SECURE generator (← Code Property Graph)
 
 Computed from a CPG fused over AST + CFG + DDG + CDG (Yamaguchi et al.,
 arxiv:1909.03496).  Always available.
 
-| Key | What it measures |
-|---|---|
-| `cpg.dangerous_calls` | Count of reachable call sites whose callee matches the per-language dangerous-API registry (Python: `eval`, `exec`, `pickle.loads`, `subprocess.*(shell=True)`, ...; C++: `gets`, `strcpy`, ...). |
-| `cpg.taint_flows`     | DDG paths from any taint source (e.g. `input`, `request.args`) to any dangerous-API sink. |
+| Key | What it measures | Gate |
+|---|---|---|
+| `cpg.dangerous_calls` | Count of reachable call sites whose callee matches the per-language dangerous-API registry (Python: `eval`, `exec`, `pickle.loads`, `subprocess.*(shell=True)`, ...; C++: `gets`, `strcpy`, ...). | **0** (strict) |
+| `cpg.taint_flows`     | DDG paths from any taint source (e.g. `input`, `request.args`) to any dangerous-API sink. | **0** (strict) |
 
-`Φ_SECURE` decays exponentially in both counts.  Threshold: **0.6**.
+`Φ_SECURE` decays exponentially in both counts (scale 3.0 each) for the
+reported score. **`achieved`** requires zero dangerous calls and zero taint flows.
+
 File-level MCP tools also surface `security_findings` with `kind`, `callee`,
 `line`, and `snippet` when SECURE fails.  Project scans keep this off by default
 unless `include_security_findings=true`.
+
+## Score floors (alternate path)
+
+When callers already hold normalized scores without re-running a `Φᵢ`, the
+score-floor dict in `calibration.py` (`SCORE_FLOORS`, re-exported as
+`THRESHOLDS` from `policies.base`) applies:
+
+| Generator | Floor |
+|---|---|
+| SIMPLE | 0.40 |
+| COMPOSABLE | 0.60 |
+| SECURE | 1.00 |
+
+The live `CharacteristicMorphism` path uses each `Φᵢ`'s `ScoredDecision.achieved`
+(raw-metric AND gates), not these floors.
 
 ## Diagnostic-only metrics (academic PDG)
 

--- a/topos/mcp/resources/content/metrics.md
+++ b/topos/mcp/resources/content/metrics.md
@@ -65,7 +65,7 @@ score-floor dict in `calibration.py` (`SCORE_FLOORS`, re-exported as
 | Generator | Floor |
 |---|---|
 | SIMPLE | 0.40 |
-| COMPOSABLE | 0.60 |
+| COMPOSABLE | 0.80 |
 | SECURE | 1.00 |
 
 The live `CharacteristicMorphism` path uses each `Φᵢ`'s `ScoredDecision.achieved`


### PR DESCRIPTION
## Summary

This PR prepares **v0.3.4** with two main changes:

### Policy calibration centralization

- Add `topos/evaluation/policies/calibration.py` as the single hub for all policy numbers: raw-metric gates, normalization caps/scales, score floors, and auxiliary defaults (coverage, clones).
- Refactor `simple`, `composable`, `secure`, `coverage`, and `clones` translators to import from `calibration` — they now contain logic only.
- Re-export `SCORE_FLOORS` as `base.THRESHOLDS` and expose calibration singletons from `policies.__init__` for discoverability.
- Align calibration with the latest PyPI corpus ECDF study (June 2026).
- Update MCP metrics docs to reference `calibration.py` and document actual raw-metric AND gates (replacing stale 0.6 score-floor language).

### GitNexus / LadybugDB compatibility (fixes #59)

Topos v0.3.0–0.3.3 bundled `real-ladybug` 0.15 (LadybugDB storage **v40**). GitNexus 1.6.x writes storage **v41**, causing MDG load failures and PyInstaller crashes when CI installs `gitnexus@latest`.

- Replace `real-ladybug` with `ladybug>=0.17.0,<0.18` to match GitNexus 1.6.x (`@ladybugdb/core ^0.17.0`).
- Add `LadybugSchemaMismatchError` with actionable remediation when the embedded reader cannot open `.gitnexus/lbug`.
- Degrade gracefully in MCP/CLI evaluation when MDG load fails (SIMPLE/SECURE still run; COMPOSABLE warns instead of crashing).
- Bundle `ladybug` in PyInstaller release builds.
- Document GitNexus / LadybugDB compatibility in CLI docs and CHANGELOG.

| Topos | Python binding | GitNexus CLI |
|-------|----------------|--------------|
| ≤0.3.3 | `real-ladybug` 0.15 (storage v40) | pin `gitnexus@<1.6` or omit `--gitnexus-dir` |
| ≥0.3.4 | `ladybug` 0.17+ (storage v41) | `gitnexus@latest` (tested with 1.6.7) |

## Test plan

- [x] `pytest` (296 tests)
- [x] `pytest tests/evaluation/test_calibration.py tests/evaluation/test_policies_base.py tests/evaluation/test_logic.py tests/functors/probes/mdg/test_pdg_metrics.py`
- [x] Schema mismatch unit tests for MDG loader and MCP warnings
- [x] `topos evaluate topos/graphs/mdg/object.py --gitnexus-dir .gitnexus -v` — COMPOSABLE/MDG metrics load with gitnexus 1.6.x store
- [x] Confirm no behavior change on representative `topos evaluate` / MCP evaluate runs (policy path)
- [x] Review `calibration.py` field names and defaults against current experimental baseline
- [x] Verify PyInstaller binary on release workflow (bundles `ladybug` instead of `real-ladybug`)