### PR TITLE
fix `topos depgraph generate` command

### DIFF
--- a/tests/cli/test_system.py
+++ b/tests/cli/test_system.py
@@ -32,7 +32,7 @@ def test_depgraph_generate_success(mock_which, mock_run):
     assert result.exit_code == 0
     assert "Using GitNexus" in result.output
     mock_run.assert_called_once_with(
-        ["gitnexus", "analyze", "--index-only"],
+        ["gitnexus", "analyze", "--skip-agents-md"],
         cwd=Path.cwd(),
     )
 

--- a/topos/cli/commands/system.py
+++ b/topos/cli/commands/system.py
@@ -140,9 +140,9 @@ def depgraph_generate(directory: str | None) -> None:
         "Using GitNexus (https://github.com/abhigyanpatwari/GitNexus) "
         "to generate dependency graph...\n"
     )
-    click.echo("  $ gitnexus analyze --index-only\n")
+    click.echo("  $ gitnexus analyze --skip-agents-md\n")
 
-    proc = subprocess.run(["gitnexus", "analyze", "--index-only"], cwd=target_dir)
+    proc = subprocess.run(["gitnexus", "analyze", "--skip-agents-md"], cwd=target_dir)
     if proc.returncode != 0:
         sys.exit(proc.returncode)
 


### PR DESCRIPTION
`topos depgraph generate` command was using a depreciated arg.

Update gitNexus `--index-only` flag --> `--skip-agents-md`