### PR TITLE
[cli] Add `topos update` command and passive update notices

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,35 @@
+name: Bug Report
+description: Something isn't working
+labels: ["bug"]
+body:
+  - type: input
+    id: summary
+    attributes:
+      label: What happened?
+      placeholder: Brief description of the bug
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      placeholder: e.g. 0.3.1

--- a/.github/ISSUE_TEMPLATE/cicd.yml
+++ b/.github/ISSUE_TEMPLATE/cicd.yml
@@ -1,4 +1,4 @@
-name: "[CI/CD] Issue"
+name: "[ci/cd] Issue"
 description: Issue related to workflows, releases, or automation
 labels: ["ci/cd"]
 body:

--- a/.github/ISSUE_TEMPLATE/cicd.yml
+++ b/.github/ISSUE_TEMPLATE/cicd.yml
@@ -1,0 +1,27 @@
+name: "[CI/CD] Issue"
+description: Issue related to workflows, releases, or automation
+labels: ["ci/cd"]
+body:
+  - type: input
+    id: summary
+    attributes:
+      label: What's the issue?
+      placeholder: Brief description
+    validations:
+      required: true
+
+  - type: input
+    id: workflow
+    attributes:
+      label: Workflow / step
+      placeholder: e.g. ci.yml / build
+    validations:
+      required: true
+
+  - type: textarea
+    id: details
+    attributes:
+      label: Details
+      placeholder: Describe the problem or request
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/cli.yml
+++ b/.github/ISSUE_TEMPLATE/cli.yml
@@ -1,0 +1,27 @@
+name: "[CLI] Issue"
+description: Issue related to the topos CLI
+labels: ["cli"]
+body:
+  - type: input
+    id: summary
+    attributes:
+      label: What's the issue?
+      placeholder: Brief description
+    validations:
+      required: true
+
+  - type: input
+    id: command
+    attributes:
+      label: Command
+      placeholder: e.g. topos evaluate
+    validations:
+      required: true
+
+  - type: textarea
+    id: details
+    attributes:
+      label: Details
+      placeholder: Describe the problem or request
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/cli.yml
+++ b/.github/ISSUE_TEMPLATE/cli.yml
@@ -1,4 +1,4 @@
-name: "[CLI] Issue"
+name: "[cli] Issue"
 description: Issue related to the topos CLI
 labels: ["cli"]
 body:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,25 @@
+name: Feature Request
+description: Propose a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: input
+    id: summary
+    attributes:
+      label: What do you want?
+      placeholder: Brief description of the feature
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Why?
+      placeholder: What problem does this solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      placeholder: How should this work?

--- a/.github/ISSUE_TEMPLATE/mcp.yml
+++ b/.github/ISSUE_TEMPLATE/mcp.yml
@@ -1,0 +1,27 @@
+name: "[MCP] Issue"
+description: Issue related to the Topos MCP server or tools
+labels: ["mcp"]
+body:
+  - type: input
+    id: summary
+    attributes:
+      label: What's the issue?
+      placeholder: Brief description
+    validations:
+      required: true
+
+  - type: input
+    id: tool
+    attributes:
+      label: MCP tool / endpoint
+      placeholder: e.g. topos_get_doc
+    validations:
+      required: true
+
+  - type: textarea
+    id: details
+    attributes:
+      label: Details
+      placeholder: Describe the problem or request
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/mcp.yml
+++ b/.github/ISSUE_TEMPLATE/mcp.yml
@@ -1,4 +1,4 @@
-name: "[MCP] Issue"
+name: "[mcp] Issue"
 description: Issue related to the Topos MCP server or tools
 labels: ["mcp"]
 body:

--- a/.github/ISSUE_TEMPLATE/methods.yml
+++ b/.github/ISSUE_TEMPLATE/methods.yml
@@ -1,4 +1,4 @@
-name: "[Methods] Issue"
+name: "[methods] Issue"
 description: Issue related to graph methods, algorithms, or topology computations
 labels: ["methods"]
 body:

--- a/.github/ISSUE_TEMPLATE/methods.yml
+++ b/.github/ISSUE_TEMPLATE/methods.yml
@@ -1,0 +1,27 @@
+name: "[Methods] Issue"
+description: Issue related to graph methods, algorithms, or topology computations
+labels: ["methods"]
+body:
+  - type: input
+    id: summary
+    attributes:
+      label: What's the issue?
+      placeholder: Brief description
+    validations:
+      required: true
+
+  - type: input
+    id: method
+    attributes:
+      label: Method / function
+      placeholder: e.g. topos.graphs.nexus
+    validations:
+      required: true
+
+  - type: textarea
+    id: details
+    attributes:
+      label: Details
+      placeholder: Describe the problem or request
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -1,0 +1,25 @@
+name: Refactor
+description: Internal code improvement with no behavior change
+labels: ["refactor"]
+body:
+  - type: input
+    id: summary
+    attributes:
+      label: What needs refactoring?
+      placeholder: Brief description of the target area
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Why?
+      placeholder: What's wrong with the current code?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed approach
+      placeholder: What should change?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`topos update`** system command: channel-aware upgrades for binary installs (re-runs `install.sh` with checksum verification), PyPI installs (`uv pip` / `pip install -U topos-mcp`), and source checkouts (prints `git pull && uv pip install -e .`). Supports `--check` (exit 0 if current, 1 if outdated) and `--version` to pin a binary release. (closes [#78](https://github.com/Krv-Labs/topos/issues/78))
+- Passive update notices on interactive CLI use (at most once per 24h; skipped for `topos mcp`, CI, non-TTY, and when `TOPOS_NO_UPDATE_NOTICES=1` is set).
+- MCP edit-in-place assessment workflow for agents: snapshot and worktree-based assessment without pasting full source into tool calls. ([#76](https://github.com/Krv-Labs/topos/pull/76))
+- Documentation quickstart guide, Sphinx autodoc API reference (`docs/source/api/`), and branded docs assets (Geist fonts, lattice/medal figures, Krv logos). ([#75](https://github.com/Krv-Labs/topos/pull/75))
+- Preferences guide (`docs/source/preferences.rst`) and expanded agent workflow documentation.
+
+### Changed
+
+- **`install.sh`**: `TOPOS_UPDATE=1` fast path for in-place binary upgrades (skips banner, GitNexus prompt, and PATH setup while preserving download/checksum verification).
+- MCP assess/evaluate tools refactored into `topos/mcp/tools/assess/` and `topos/mcp/tools/evaluate/` subpackages (`core`, `render`, `snapshot`, `worktree`, `project`) to improve structure and metric scores on the Topos codebase itself. ([#76](https://github.com/Krv-Labs/topos/pull/76))
+- Updated MCP agent contract, workflow, and refactor prompt guidance for edit-in-place and preference-walk usage. ([#76](https://github.com/Krv-Labs/topos/pull/76))
+- Documentation index, installation, agents, and README aligned with current CLI/MCP behavior; copy-paste code blocks cleaned up. ([#75](https://github.com/Krv-Labs/topos/pull/75))
+
+### Fixed
+
+- `detect_install_method()` now resolves the **`topos-mcp`** PyPI distribution (was `topos`) and detects editable/source installs via `direct_url.json`.
+
 ## [0.3.4] - 2026-06-12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Install detection priority** (closes [#82](https://github.com/Krv-Labs/topos/issues/82)): `detect_install_info()` now checks live Python metadata first; binary provenance is a fallback only when no Python package is found. Fixes `topos update` running the binary upgrade path for editable/pip installs that have a stale provenance record.
 - `detect_install_method()` now resolves the **`topos-mcp`** PyPI distribution (was `topos`) and detects editable/source installs via `direct_url.json`.
+- Duplicate binary path in install layout notice output (PATH-default binary was listed twice when it also appeared in `other_bins`).
+
+### Added
+
+- **Install layout notices**: detects conflicting `topos` executables on PATH and warns on stderr (throttled to once per 24h; always shown during `topos update` and `topos uninstall`; skipped in CI, non-TTY, and `TOPOS_NO_UPDATE_NOTICES=1`).
+
+### Changed
+
+- **`topos uninstall`**: shell rc cleanup (`--prune-path-hints`) now happens by default; pass `--keep-path-hints` to skip.
+- **`topos uninstall`**: removes the full `~/.local/state/topos/` state directory (provenance file, update-check cache, install-layout cache) instead of only the provenance file. Removal is dry-run aware.
 
 ## [0.3.4] - 2026-06-12
 

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -41,9 +41,9 @@ Run ``topos depgraph generate`` only when you need COMPOSABLE metrics. Run
    .. grid-item-card:: ⚙️ System commands
       :shadow: md
 
-      Run the MCP server, generate dependency graphs, or uninstall cleanly.
+      Run the MCP server, generate dependency graphs, update, or uninstall cleanly.
       ^^^
-      ``mcp`` · ``depgraph generate`` · ``uninstall``
+      ``mcp`` · ``depgraph generate`` · ``update`` · ``uninstall``
 
 Quality commands
 ================
@@ -271,6 +271,45 @@ If ``gitnexus`` is missing, install it first:
    cd /path/to/your/repo
    topos depgraph generate
    topos evaluate src/ -r --gitnexus-dir .gitnexus/
+
+update
+------
+
+Upgrade Topos using the detected install channel (binary installer, PyPI package manager, or source checkout).
+
+.. code-block:: bash
+
+   topos update [OPTIONS]
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 72
+
+   * - Option
+     - Description
+   * - ``--check``
+     - Exit 0 if up to date, 1 if outdated (for scripts). No upgrade is performed.
+   * - ``--version VERSION``
+     - Pin a release for binary installs (maps to ``TOPOS_VERSION`` in ``install.sh``).
+
+Channel behavior:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 72
+
+   * - Install channel
+     - ``topos update`` behavior
+   * - Binary (``install.sh``)
+     - Re-runs the installer with checksum verification; preserves PATH hints.
+   * - PyPI (``uv`` / ``pip``)
+     - Runs ``uv pip install -U topos-mcp`` or ``pip install -U topos-mcp``.
+   * - Source (editable checkout)
+     - Prints instructions: ``git pull && uv pip install -e .``
+   * - Unknown
+     - Prints all supported upgrade paths.
+
+On interactive CLI use (not ``topos mcp``), Topos may print a one-line update notice at most once per 24 hours when a newer release is available. Set ``TOPOS_NO_UPDATE_NOTICES=1`` to disable.
 
 uninstall
 ---------

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -202,6 +202,34 @@ Details and troubleshooting
    involving ``libpython3.12.dylib``, upgrade to v0.3.2 or later with the
    installer. Source installs are not affected.
 
+.. dropdown:: Upgrade
+
+   Binary and PyPI installs:
+
+   .. code-block:: bash
+
+      topos update
+
+   Check for updates without upgrading (exit 0 if current, 1 if outdated):
+
+   .. code-block:: bash
+
+      topos update --check
+
+   Pin a binary release:
+
+   .. code-block:: bash
+
+      topos update --version v0.3.6
+
+   Source checkouts should use:
+
+   .. code-block:: bash
+
+      git pull && uv pip install -e .
+
+   Set ``TOPOS_NO_UPDATE_NOTICES=1`` to disable passive update notices on interactive CLI use.
+
 .. dropdown:: Clean uninstall
 
    Binary installs can be removed by Topos itself:

--- a/install.sh
+++ b/install.sh
@@ -489,13 +489,21 @@ verify_install() {
 
 # Main
 main() {
-    print_header
+    if [ "${TOPOS_UPDATE:-0}" = "1" ]; then
+        info "Updating Topos..."
+    else
+        print_header
+    fi
 
     check_dependencies
     validate_install_dir
     install_topos
-    install_optional_dependencies
-    setup_path
+
+    if [ "${TOPOS_UPDATE:-0}" != "1" ]; then
+        install_optional_dependencies
+        setup_path
+    fi
+
     write_provenance
     verify_install
 }

--- a/tests/cli/test_helpers.py
+++ b/tests/cli/test_helpers.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+from importlib.metadata import PackageNotFoundError
 from pathlib import Path
 
 from topos.cli.evaluation import collect_files
 from topos.cli.installation import (
     detect_install_info,
     detect_install_method,
+    install_layout_notice_lines,
     load_provenance,
     prune_path_hints,
 )
@@ -133,3 +135,151 @@ def test_detect_install_method_editable(monkeypatch):
         info = detect_install_info()
         assert info.method == "source"
         assert info.update_cmd == "git pull && uv pip install -e ."
+
+
+def test_detect_install_method_editable_over_stale_binary_provenance(monkeypatch):
+    from unittest.mock import MagicMock
+
+    mock_dist = MagicMock()
+    mock_dist.read_text.return_value = (
+        '{"url": "file:///src/topos", "dir_info": {"editable": true}}'
+    )
+    stale_provenance = {
+        "install_method": "binary-installer",
+        "install_path": "/home/user/.local/bin/topos",
+    }
+
+    with monkeypatch.context() as m:
+        m.setattr("importlib.metadata.distribution", lambda name: mock_dist)
+        m.setattr("topos.cli.installation.load_provenance", lambda: stale_provenance)
+
+        info = detect_install_info()
+        assert info.method == "source"
+
+
+def test_detect_install_method_pip_over_stale_binary_provenance(monkeypatch):
+    from unittest.mock import MagicMock
+
+    mock_dist = MagicMock()
+
+    def read_text(name: str) -> str:
+        if name == "direct_url.json":
+            raise FileNotFoundError
+        if name == "INSTALLER":
+            return "pip"
+        raise FileNotFoundError
+
+    mock_dist.read_text.side_effect = read_text
+    stale_provenance = {
+        "install_method": "binary-installer",
+        "install_path": "/home/user/.local/bin/topos",
+    }
+
+    with monkeypatch.context() as m:
+        m.setattr("importlib.metadata.distribution", lambda name: mock_dist)
+        m.setattr("topos.cli.installation.load_provenance", lambda: stale_provenance)
+
+        info = detect_install_info()
+        assert info.method == "package-manager"
+        assert info.installer == "pip"
+
+
+def test_detect_install_method_binary_without_python_package(monkeypatch):
+    def raise_not_found(name: str):
+        raise PackageNotFoundError
+
+    stale_provenance = {
+        "install_method": "binary-installer",
+        "install_path": "/home/user/.local/bin/topos",
+    }
+
+    with monkeypatch.context() as m:
+        m.setattr(
+            "importlib.metadata.distribution",
+            raise_not_found,
+        )
+        m.setattr("topos.cli.installation.load_provenance", lambda: stale_provenance)
+
+        info = detect_install_info()
+        assert info.method == "binary-installer"
+        assert info.provenance == stale_provenance
+
+
+def test_install_layout_notice_none_for_single_install(monkeypatch):
+    active = Path("/venv/bin/topos")
+
+    with monkeypatch.context() as m:
+        m.setattr("topos.cli.installation.active_executable", lambda: active)
+        m.setattr("topos.cli.installation.find_topos_executables_on_path", lambda: [active])
+        m.setattr("topos.cli.installation.load_provenance", lambda: None)
+        m.setattr("shutil.which", lambda name: str(active))
+
+        assert install_layout_notice_lines() is None
+
+
+def test_install_layout_notice_multiple_on_path(monkeypatch, tmp_path):
+    from topos.cli.installation import InstallInfo
+
+    # Use tmp_path so paths are already resolved — avoids macOS /home symlink issues
+    # when comparing path_bins (resolved) against shutil.which output (also resolved).
+    active = tmp_path / "venv" / "bin" / "topos"
+    other = tmp_path / "local" / "bin" / "topos"
+
+    with monkeypatch.context() as m:
+        m.setattr("topos.cli.installation.active_executable", lambda: active)
+        m.setattr(
+            "topos.cli.installation.find_topos_executables_on_path",
+            lambda: [other, active],
+        )
+        m.setattr("topos.cli.installation.load_provenance", lambda: None)
+        m.setattr("shutil.which", lambda name: str(other))
+        m.setattr(
+            "topos.cli.installation.detect_install_info",
+            lambda: InstallInfo(method="source"),
+        )
+
+        lines = install_layout_notice_lines()
+        assert lines is not None
+        joined = "\n".join(lines)
+        assert "Multiple Topos installations detected." in joined
+        assert str(active) in joined
+        assert "editable source checkout" in joined
+        assert "runs when you type `topos`" in joined
+        assert str(other) in joined
+        # The PATH-default binary must not also appear as "Also on PATH".
+        assert joined.count(str(other)) == 1
+
+
+def test_install_layout_notice_stale_binary_provenance(monkeypatch):
+    from topos.cli.installation import InstallInfo
+
+    active = Path("/src/topos/.venv/bin/topos")
+    stale_binary = Path("/home/user/.local/bin/topos")
+    stale_provenance = {
+        "install_method": "binary-installer",
+        "install_path": str(stale_binary),
+    }
+
+    def fake_exists(self: Path) -> bool:
+        return self == stale_binary
+
+    with monkeypatch.context() as m:
+        m.setattr("topos.cli.installation.active_executable", lambda: active)
+        m.setattr(
+            "topos.cli.installation.find_topos_executables_on_path",
+            lambda: [active],
+        )
+        m.setattr("topos.cli.installation.load_provenance", lambda: stale_provenance)
+        m.setattr("shutil.which", lambda name: str(active))
+        m.setattr(
+            "topos.cli.installation.detect_install_info",
+            lambda: InstallInfo(method="source"),
+        )
+        m.setattr(Path, "exists", fake_exists, raising=False)
+
+        lines = install_layout_notice_lines()
+        assert lines is not None
+        joined = "\n".join(lines)
+        assert f"Active: {active}" in joined
+        assert "Binary installer record:" in joined
+        assert ".local/bin/topos" in joined

--- a/tests/cli/test_helpers.py
+++ b/tests/cli/test_helpers.py
@@ -122,7 +122,9 @@ def test_detect_install_method_editable(monkeypatch):
     from unittest.mock import MagicMock
 
     mock_dist = MagicMock()
-    mock_dist.read_text.return_value = '{"dir": "/src/topos", "editable": true}'
+    mock_dist.read_text.return_value = (
+        '{"url": "file:///src/topos", "dir_info": {"editable": true}}'
+    )
 
     with monkeypatch.context() as m:
         m.setattr("importlib.metadata.distribution", lambda name: mock_dist)

--- a/tests/cli/test_helpers.py
+++ b/tests/cli/test_helpers.py
@@ -210,7 +210,9 @@ def test_install_layout_notice_none_for_single_install(monkeypatch):
 
     with monkeypatch.context() as m:
         m.setattr("topos.cli.installation.active_executable", lambda: active)
-        m.setattr("topos.cli.installation.find_topos_executables_on_path", lambda: [active])
+        m.setattr(
+            "topos.cli.installation.find_topos_executables_on_path", lambda: [active]
+        )
         m.setattr("topos.cli.installation.load_provenance", lambda: None)
         m.setattr("shutil.which", lambda name: str(active))
 

--- a/tests/cli/test_helpers.py
+++ b/tests/cli/test_helpers.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from topos.cli.evaluation import collect_files
 from topos.cli.installation import (
+    detect_install_info,
     detect_install_method,
     load_provenance,
     prune_path_hints,
@@ -74,7 +75,15 @@ def test_detect_install_method_pip(monkeypatch):
     from unittest.mock import MagicMock
 
     mock_dist = MagicMock()
-    mock_dist.read_text.return_value = "pip"
+
+    def read_text(name: str) -> str:
+        if name == "direct_url.json":
+            raise FileNotFoundError
+        if name == "INSTALLER":
+            return "pip"
+        raise FileNotFoundError
+
+    mock_dist.read_text.side_effect = read_text
 
     with monkeypatch.context() as m:
         m.setattr("importlib.metadata.distribution", lambda name: mock_dist)
@@ -82,4 +91,43 @@ def test_detect_install_method_pip(monkeypatch):
 
         method, prov, cmd = detect_install_method()
         assert method == "package-manager"
-        assert cmd == "pip uninstall topos"
+        assert cmd == "pip uninstall topos-mcp"
+
+
+def test_detect_install_method_uv(monkeypatch):
+    from unittest.mock import MagicMock
+
+    mock_dist = MagicMock()
+
+    def read_text(name: str) -> str:
+        if name == "direct_url.json":
+            raise FileNotFoundError
+        if name == "INSTALLER":
+            return "uv"
+        raise FileNotFoundError
+
+    mock_dist.read_text.side_effect = read_text
+
+    with monkeypatch.context() as m:
+        m.setattr("importlib.metadata.distribution", lambda name: mock_dist)
+        m.setattr("topos.cli.installation.load_provenance", lambda: None)
+
+        info = detect_install_info()
+        assert info.method == "package-manager"
+        assert info.installer == "uv"
+        assert info.update_cmd == "uv pip install -U topos-mcp"
+
+
+def test_detect_install_method_editable(monkeypatch):
+    from unittest.mock import MagicMock
+
+    mock_dist = MagicMock()
+    mock_dist.read_text.return_value = '{"dir": "/src/topos", "editable": true}'
+
+    with monkeypatch.context() as m:
+        m.setattr("importlib.metadata.distribution", lambda name: mock_dist)
+        m.setattr("topos.cli.installation.load_provenance", lambda: None)
+
+        info = detect_install_info()
+        assert info.method == "source"
+        assert info.update_cmd == "git pull && uv pip install -e ."

--- a/tests/cli/test_system.py
+++ b/tests/cli/test_system.py
@@ -95,3 +95,134 @@ def test_uninstall_binary_yes(tmp_path: Path):
         assert f"Removed binary: {binary}" in result.output
         assert not binary.exists()
         mock_remove.assert_called_once()
+
+
+@patch("topos.cli.update.subprocess.run")
+@patch("topos.cli.update.subprocess.Popen")
+def test_update_binary_invokes_install_script(mock_popen, mock_run, tmp_path: Path):
+    from unittest.mock import MagicMock
+
+    binary = tmp_path / "bin" / "topos"
+    binary.parent.mkdir(parents=True)
+    binary.touch()
+    provenance = {"install_method": "binary-installer", "install_path": str(binary)}
+
+    curl_proc = mock_popen.return_value
+    curl_proc.stdout = MagicMock()
+    mock_run.return_value.returncode = 0
+
+    with patch(
+        "topos.cli.update.detect_install_info",
+    ) as mock_detect:
+        from topos.cli.installation import InstallInfo
+
+        mock_detect.return_value = InstallInfo(
+            method="binary-installer",
+            provenance=provenance,
+        )
+        runner = CliRunner()
+        result = runner.invoke(cli, ["update"])
+        assert result.exit_code == 0
+        assert "Updating Topos via install.sh" in result.output
+
+    mock_popen.assert_called_once()
+    _, kwargs = mock_run.call_args
+    env = kwargs["env"]
+    assert env["TOPOS_UPDATE"] == "1"
+    assert env["TOPOS_INSTALL"] == str(binary.parent)
+    assert env["TOPOS_NO_MODIFY_PATH"] == "1"
+
+
+@patch("topos.cli.update.subprocess.run")
+def test_update_package_manager_uv(mock_run):
+    mock_run.return_value.returncode = 0
+
+    with patch("topos.cli.update.detect_install_info") as mock_detect:
+        from topos.cli.installation import InstallInfo
+
+        mock_detect.return_value = InstallInfo(
+            method="package-manager",
+            installer="uv",
+            update_cmd="uv pip install -U topos-mcp",
+        )
+        runner = CliRunner()
+        result = runner.invoke(cli, ["update"])
+        assert result.exit_code == 0
+        mock_run.assert_called_once_with(
+            ["uv", "pip", "install", "-U", "topos-mcp"],
+            check=False,
+        )
+
+
+@patch("topos.cli.update.subprocess.run")
+def test_update_package_manager_pip(mock_run):
+    mock_run.return_value.returncode = 0
+
+    with patch("topos.cli.update.detect_install_info") as mock_detect:
+        from topos.cli.installation import InstallInfo
+
+        mock_detect.return_value = InstallInfo(
+            method="package-manager",
+            installer="pip",
+            update_cmd="pip install -U topos-mcp",
+        )
+        runner = CliRunner()
+        result = runner.invoke(cli, ["update"])
+        assert result.exit_code == 0
+        mock_run.assert_called_once_with(
+            ["pip", "install", "-U", "topos-mcp"],
+            check=False,
+        )
+
+
+def test_update_source_prints_instructions():
+    with patch("topos.cli.update.detect_install_info") as mock_detect:
+        from topos.cli.installation import InstallInfo
+
+        mock_detect.return_value = InstallInfo(
+            method="source",
+            update_cmd="git pull && uv pip install -e .",
+        )
+        runner = CliRunner()
+        result = runner.invoke(cli, ["update"])
+        assert result.exit_code == 0
+        assert "editable/source installation" in result.output
+        assert "git pull && uv pip install -e ." in result.output
+
+
+@patch("topos.cli.update.__version__", "0.3.5")
+@patch("topos.cli.update.latest_version_for_channel", return_value="0.3.6")
+def test_update_check_outdated(mock_latest):
+    with patch("topos.cli.update.detect_install_info") as mock_detect:
+        from topos.cli.installation import InstallInfo
+
+        mock_detect.return_value = InstallInfo(method="package-manager")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["update", "--check"])
+        assert result.exit_code == 1
+        assert "Outdated: 0.3.5 → 0.3.6" in result.output
+
+
+@patch("topos.cli.update.__version__", "0.3.6")
+@patch("topos.cli.update.latest_version_for_channel", return_value="0.3.6")
+def test_update_check_current(mock_latest):
+    with patch("topos.cli.update.detect_install_info") as mock_detect:
+        from topos.cli.installation import InstallInfo
+
+        mock_detect.return_value = InstallInfo(method="binary-installer")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["update", "--check"])
+        assert result.exit_code == 0
+        assert "Up to date: 0.3.6" in result.output
+
+
+def test_update_unknown_lists_paths():
+    with patch("topos.cli.update.detect_install_info") as mock_detect:
+        from topos.cli.installation import InstallInfo
+
+        mock_detect.return_value = InstallInfo(method="unknown")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["update"])
+        assert result.exit_code == 0
+        assert "Could not determine install channel" in result.output
+        assert "uv pip install -U topos-mcp" in result.output

--- a/tests/cli/test_system.py
+++ b/tests/cli/test_system.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from click.testing import CliRunner
+from topos.cli.installation import InstallInfo
 from topos.cli.main import cli
 
 
@@ -38,8 +39,11 @@ def test_depgraph_generate_success(mock_which, mock_run):
 
 
 def test_uninstall_package_manager():
-    with patch("topos.cli.commands.system.detect_install_method") as mock_detect:
-        mock_detect.return_value = ("package-manager", None, "pip uninstall topos")
+    info = InstallInfo(method="package-manager", uninstall_cmd="pip uninstall topos")
+    with (
+        patch("topos.cli.commands.system.detect_install_info", return_value=info),
+        patch("topos.cli.commands.system.echo_install_layout_notice"),
+    ):
         runner = CliRunner()
         result = runner.invoke(cli, ["uninstall"])
         assert result.exit_code == 0
@@ -52,14 +56,21 @@ def test_uninstall_binary_dry_run(tmp_path: Path):
     binary.touch()
 
     provenance = {"install_method": "binary-installer", "install_path": str(binary)}
+    info = InstallInfo(method="binary-installer", provenance=provenance)
 
-    with patch("topos.cli.commands.system.detect_install_method") as mock_detect:
-        mock_detect.return_value = ("binary-installer", provenance, None)
+    with (
+        patch("topos.cli.commands.system.detect_install_info", return_value=info),
+        patch("topos.cli.commands.system.echo_install_layout_notice"),
+        patch("topos.cli.commands.system.remove_state_dir") as mock_remove_state,
+        patch("topos.cli.commands.system.prune_path_hints") as mock_prune,
+    ):
         runner = CliRunner()
         result = runner.invoke(cli, ["uninstall", "--dry-run"])
         assert result.exit_code == 0
         assert f"[dry-run] Would remove binary: {binary}" in result.output
         assert binary.exists()
+        mock_remove_state.assert_called_once_with(dry_run=True)
+        mock_prune.assert_called_once_with(provenance, dry_run=True)
 
 
 def test_uninstall_binary_confirm_no(tmp_path: Path):
@@ -67,15 +78,19 @@ def test_uninstall_binary_confirm_no(tmp_path: Path):
     binary.touch()
 
     provenance = {"install_method": "binary-installer", "install_path": str(binary)}
+    info = InstallInfo(method="binary-installer", provenance=provenance)
 
-    with patch("topos.cli.commands.system.detect_install_method") as mock_detect:
-        mock_detect.return_value = ("binary-installer", provenance, None)
+    with (
+        patch("topos.cli.commands.system.detect_install_info", return_value=info),
+        patch("topos.cli.commands.system.echo_install_layout_notice"),
+        patch("topos.cli.commands.system.remove_state_dir") as mock_remove_state,
+    ):
         runner = CliRunner()
-        # "n" for the confirmation prompt
         result = runner.invoke(cli, ["uninstall"], input="n\n")
         assert result.exit_code == 0
         assert "Uninstall cancelled." in result.output
         assert binary.exists()
+        mock_remove_state.assert_not_called()
 
 
 def test_uninstall_binary_yes(tmp_path: Path):
@@ -83,18 +98,70 @@ def test_uninstall_binary_yes(tmp_path: Path):
     binary.touch()
 
     provenance = {"install_method": "binary-installer", "install_path": str(binary)}
+    info = InstallInfo(method="binary-installer", provenance=provenance)
 
     with (
-        patch("topos.cli.commands.system.detect_install_method") as mock_detect,
-        patch("topos.cli.commands.system.remove_provenance_record") as mock_remove,
+        patch("topos.cli.commands.system.detect_install_info", return_value=info),
+        patch("topos.cli.commands.system.echo_install_layout_notice"),
+        patch("topos.cli.commands.system.remove_state_dir") as mock_remove_state,
+        patch("topos.cli.commands.system.prune_path_hints") as mock_prune,
     ):
-        mock_detect.return_value = ("binary-installer", provenance, None)
         runner = CliRunner()
         result = runner.invoke(cli, ["uninstall", "--yes"])
         assert result.exit_code == 0
         assert f"Removed binary: {binary}" in result.output
         assert not binary.exists()
-        mock_remove.assert_called_once()
+        mock_remove_state.assert_called_once_with(dry_run=False)
+        mock_prune.assert_called_once_with(provenance, dry_run=False)
+
+
+def test_uninstall_binary_keep_path_hints(tmp_path: Path):
+    binary = tmp_path / "topos"
+    binary.touch()
+
+    provenance = {"install_method": "binary-installer", "install_path": str(binary)}
+    info = InstallInfo(method="binary-installer", provenance=provenance)
+
+    with (
+        patch("topos.cli.commands.system.detect_install_info", return_value=info),
+        patch("topos.cli.commands.system.echo_install_layout_notice"),
+        patch("topos.cli.commands.system.remove_state_dir"),
+        patch("topos.cli.commands.system.prune_path_hints") as mock_prune,
+    ):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["uninstall", "--yes", "--keep-path-hints"])
+        assert result.exit_code == 0
+        mock_prune.assert_not_called()
+
+
+def test_uninstall_removes_state_dir(tmp_path: Path):
+    """remove_state_dir is called and removes the XDG state directory."""
+    state_dir = tmp_path / "state" / "topos"
+    state_dir.mkdir(parents=True)
+    (state_dir / "update-check.json").write_text("{}")
+    (state_dir / "install-provenance").write_text("install_method=binary-installer\n")
+
+    binary = tmp_path / "bin" / "topos"
+    binary.parent.mkdir()
+    binary.touch()
+
+    provenance = {"install_method": "binary-installer", "install_path": str(binary)}
+    info = InstallInfo(method="binary-installer", provenance=provenance)
+
+    with (
+        patch("topos.cli.commands.system.detect_install_info", return_value=info),
+        patch("topos.cli.commands.system.echo_install_layout_notice"),
+        patch("topos.cli.commands.system.prune_path_hints"),
+        patch(
+            "topos.cli.installation.topos_state_dir",
+            return_value=state_dir,
+        ),
+    ):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["uninstall", "--yes"])
+        assert result.exit_code == 0
+        assert not state_dir.exists()
+        assert "Removed state directory" in result.output
 
 
 @patch("topos.cli.update.subprocess.run")

--- a/tests/cli/test_system.py
+++ b/tests/cli/test_system.py
@@ -109,6 +109,7 @@ def test_update_binary_invokes_install_script(mock_popen, mock_run, tmp_path: Pa
 
     curl_proc = mock_popen.return_value
     curl_proc.stdout = MagicMock()
+    curl_proc.returncode = 0
     mock_run.return_value.returncode = 0
 
     with patch(
@@ -131,6 +132,36 @@ def test_update_binary_invokes_install_script(mock_popen, mock_run, tmp_path: Pa
     assert env["TOPOS_UPDATE"] == "1"
     assert env["TOPOS_INSTALL"] == str(binary.parent)
     assert env["TOPOS_NO_MODIFY_PATH"] == "1"
+
+
+@patch("topos.cli.update.subprocess.run")
+@patch("topos.cli.update.subprocess.Popen")
+def test_update_binary_fails_when_curl_fails(mock_popen, mock_run, tmp_path: Path):
+    from unittest.mock import MagicMock
+
+    binary = tmp_path / "bin" / "topos"
+    binary.parent.mkdir(parents=True)
+    binary.touch()
+    provenance = {"install_method": "binary-installer", "install_path": str(binary)}
+
+    # curl fails (e.g. network down): writes nothing, exits non-zero. sh then
+    # reads EOF and exits 0 — the update must NOT report success.
+    curl_proc = mock_popen.return_value
+    curl_proc.stdout = MagicMock()
+    curl_proc.returncode = 22
+    mock_run.return_value.returncode = 0
+
+    with patch("topos.cli.update.detect_install_info") as mock_detect:
+        from topos.cli.installation import InstallInfo
+
+        mock_detect.return_value = InstallInfo(
+            method="binary-installer",
+            provenance=provenance,
+        )
+        runner = CliRunner()
+        result = runner.invoke(cli, ["update"])
+        assert result.exit_code != 0
+        assert "Failed to download install.sh" in result.output
 
 
 @patch("topos.cli.update.subprocess.run")

--- a/tests/cli/test_update_notices.py
+++ b/tests/cli/test_update_notices.py
@@ -59,6 +59,54 @@ def test_cache_is_fresh():
     assert not cache_is_fresh(stale)
 
 
+@patch("topos.cli.update.echo_install_layout_notice", return_value=True)
+@patch("topos.cli.update.save_install_layout_notice_cache")
+@patch("topos.cli.update.load_install_layout_notice_cache", return_value=None)
+@patch("topos.cli.update.sys.stderr.isatty", return_value=True)
+def test_maybe_show_install_layout_notice_emits(
+    mock_isatty,
+    mock_load_cache,
+    mock_save_cache,
+    mock_echo_notice,
+    monkeypatch,
+):
+    from topos.cli.update import maybe_show_install_layout_notice
+
+    monkeypatch.delenv("CI", raising=False)
+    maybe_show_install_layout_notice(
+        invoked_subcommand="evaluate",
+        help_requested=False,
+    )
+    mock_echo_notice.assert_called_once()
+    mock_save_cache.assert_called_once()
+
+
+@patch("topos.cli.update.echo_install_layout_notice", return_value=True)
+@patch("topos.cli.update.save_install_layout_notice_cache")
+@patch("topos.cli.update.load_install_layout_notice_cache")
+@patch("topos.cli.update.sys.stderr.isatty", return_value=True)
+def test_maybe_show_install_layout_notice_respects_cache(
+    mock_isatty,
+    mock_load_cache,
+    mock_save_cache,
+    mock_echo_notice,
+    monkeypatch,
+):
+    from topos.cli.update import maybe_show_install_layout_notice
+
+    monkeypatch.delenv("CI", raising=False)
+    mock_load_cache.return_value = {
+        "checked_at": datetime.now(UTC).isoformat(),
+    }
+
+    maybe_show_install_layout_notice(
+        invoked_subcommand="evaluate",
+        help_requested=False,
+    )
+    mock_echo_notice.assert_not_called()
+    mock_save_cache.assert_not_called()
+
+
 @patch("topos.cli.update.is_outdated", return_value=True)
 @patch("topos.cli.update.save_update_check_cache")
 @patch("topos.cli.update.latest_version_for_channel", return_value="9.9.9")

--- a/tests/cli/test_update_notices.py
+++ b/tests/cli/test_update_notices.py
@@ -35,6 +35,11 @@ def test_should_skip_passive_notice_env(monkeypatch):
     assert should_skip_passive_notice(invoked_subcommand="evaluate", help_requested=False)
 
 
+def test_should_skip_passive_notice_ci(monkeypatch):
+    monkeypatch.setenv("CI", "true")
+    assert should_skip_passive_notice(invoked_subcommand="evaluate", help_requested=False)
+
+
 def test_cache_is_fresh():
     recent = {
         "checked_at": datetime.now(UTC).isoformat(),
@@ -64,9 +69,11 @@ def test_maybe_show_update_notice_emits(
     mock_latest,
     mock_save,
     mock_outdated,
+    monkeypatch,
 ):
     from topos.cli.installation import InstallInfo
 
+    monkeypatch.delenv("CI", raising=False)
     mock_detect.return_value = InstallInfo(method="binary-installer")
 
     maybe_show_update_notice(invoked_subcommand="evaluate", help_requested=False)
@@ -87,9 +94,11 @@ def test_maybe_show_update_notice_uses_fresh_cache(
     mock_detect,
     mock_load_cache,
     mock_latest,
+    monkeypatch,
 ):
     from topos.cli.installation import InstallInfo
 
+    monkeypatch.delenv("CI", raising=False)
     mock_detect.return_value = InstallInfo(method="binary-installer")
     mock_load_cache.return_value = {
         "checked_at": datetime.now(UTC).isoformat(),

--- a/tests/cli/test_update_notices.py
+++ b/tests/cli/test_update_notices.py
@@ -4,7 +4,6 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
 from click.testing import CliRunner
-
 from topos.cli.main import cli
 from topos.cli.update import (
     cache_is_fresh,
@@ -32,12 +31,18 @@ def test_should_skip_passive_notice_mcp():
 
 def test_should_skip_passive_notice_env(monkeypatch):
     monkeypatch.setenv("TOPOS_NO_UPDATE_NOTICES", "1")
-    assert should_skip_passive_notice(invoked_subcommand="evaluate", help_requested=False)
+    assert should_skip_passive_notice(
+        invoked_subcommand="evaluate",
+        help_requested=False,
+    )
 
 
 def test_should_skip_passive_notice_ci(monkeypatch):
     monkeypatch.setenv("CI", "true")
-    assert should_skip_passive_notice(invoked_subcommand="evaluate", help_requested=False)
+    assert should_skip_passive_notice(
+        invoked_subcommand="evaluate",
+        help_requested=False,
+    )
 
 
 def test_cache_is_fresh():
@@ -113,25 +118,26 @@ def test_maybe_show_update_notice_uses_fresh_cache(
 
 
 def test_passive_notice_skipped_for_mcp():
-    with patch("topos.mcp.server.main"):
-        with patch("topos.cli.main.maybe_show_update_notice") as mock_notice:
-            runner = CliRunner()
-            result = runner.invoke(cli, ["mcp"])
-            assert result.exit_code == 0
-            mock_notice.assert_called_once()
-            assert mock_notice.call_args.kwargs["invoked_subcommand"] == "mcp"
+    with (
+        patch("topos.mcp.server.main"),
+        patch("topos.cli.main.maybe_show_update_notice") as mock_notice,
+    ):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["mcp"])
+        assert result.exit_code == 0
+        mock_notice.assert_called_once()
+        assert mock_notice.call_args.kwargs["invoked_subcommand"] == "mcp"
 
 
 def test_passive_notice_skipped_for_update_command():
-    with patch("topos.cli.commands.system.run_update") as mock_run_update:
-        with patch("topos.cli.main.maybe_show_update_notice") as mock_notice:
-            runner = CliRunner()
-            with patch(
-                "topos.cli.update.latest_version_for_channel",
-                return_value="0.0.0",
-            ):
-                result = runner.invoke(cli, ["update", "--check"])
-            assert result.exit_code in (0, 1, 2)
-            mock_run_update.assert_called_once()
-            mock_notice.assert_called_once()
-            assert mock_notice.call_args.kwargs["invoked_subcommand"] == "update"
+    with (
+        patch("topos.cli.commands.system.run_update") as mock_run_update,
+        patch("topos.cli.main.maybe_show_update_notice") as mock_notice,
+        patch("topos.cli.update.latest_version_for_channel", return_value="0.0.0"),
+    ):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["update", "--check"])
+        assert result.exit_code in (0, 1, 2)
+        mock_run_update.assert_called_once()
+        mock_notice.assert_called_once()
+        assert mock_notice.call_args.kwargs["invoked_subcommand"] == "update"

--- a/tests/cli/test_update_notices.py
+++ b/tests/cli/test_update_notices.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from topos.cli.main import cli
+from topos.cli.update import (
+    cache_is_fresh,
+    is_outdated,
+    maybe_show_update_notice,
+    normalize_version,
+    should_skip_passive_notice,
+)
+
+
+def test_normalize_version():
+    assert normalize_version("v0.3.5") == (0, 3, 5)
+    assert normalize_version("1.2") == (1, 2, 0)
+
+
+def test_is_outdated():
+    assert is_outdated("0.3.5", "0.3.6")
+    assert not is_outdated("0.3.6", "0.3.6")
+    assert not is_outdated("0.3.7", "0.3.6")
+
+
+def test_should_skip_passive_notice_mcp():
+    assert should_skip_passive_notice(invoked_subcommand="mcp", help_requested=False)
+
+
+def test_should_skip_passive_notice_env(monkeypatch):
+    monkeypatch.setenv("TOPOS_NO_UPDATE_NOTICES", "1")
+    assert should_skip_passive_notice(invoked_subcommand="evaluate", help_requested=False)
+
+
+def test_cache_is_fresh():
+    recent = {
+        "checked_at": datetime.now(UTC).isoformat(),
+        "latest": "0.3.6",
+    }
+    assert cache_is_fresh(recent)
+
+    stale = {
+        "checked_at": (datetime.now(UTC) - timedelta(hours=25)).isoformat(),
+        "latest": "0.3.6",
+    }
+    assert not cache_is_fresh(stale)
+
+
+@patch("topos.cli.update.is_outdated", return_value=True)
+@patch("topos.cli.update.save_update_check_cache")
+@patch("topos.cli.update.latest_version_for_channel", return_value="9.9.9")
+@patch("topos.cli.update.load_update_check_cache", return_value=None)
+@patch("topos.cli.update.detect_install_info")
+@patch("topos.cli.update.click.echo")
+@patch("topos.cli.update.sys.stderr.isatty", return_value=True)
+def test_maybe_show_update_notice_emits(
+    mock_isatty,
+    mock_echo,
+    mock_detect,
+    mock_load_cache,
+    mock_latest,
+    mock_save,
+    mock_outdated,
+):
+    from topos.cli.installation import InstallInfo
+
+    mock_detect.return_value = InstallInfo(method="binary-installer")
+
+    maybe_show_update_notice(invoked_subcommand="evaluate", help_requested=False)
+
+    mock_echo.assert_called_once()
+    assert "Update available" in mock_echo.call_args[0][0]
+    assert mock_echo.call_args[1]["err"] is True
+
+
+@patch("topos.cli.update.latest_version_for_channel")
+@patch("topos.cli.update.load_update_check_cache")
+@patch("topos.cli.update.detect_install_info")
+@patch("topos.cli.update.click.echo")
+@patch("topos.cli.update.sys.stderr.isatty", return_value=True)
+def test_maybe_show_update_notice_uses_fresh_cache(
+    mock_isatty,
+    mock_echo,
+    mock_detect,
+    mock_load_cache,
+    mock_latest,
+):
+    from topos.cli.installation import InstallInfo
+
+    mock_detect.return_value = InstallInfo(method="binary-installer")
+    mock_load_cache.return_value = {
+        "checked_at": datetime.now(UTC).isoformat(),
+        "latest": "9.9.9",
+    }
+
+    with patch("topos.cli.update.is_outdated", return_value=True):
+        maybe_show_update_notice(invoked_subcommand="evaluate", help_requested=False)
+
+    mock_latest.assert_not_called()
+    mock_echo.assert_called_once()
+
+
+def test_passive_notice_skipped_for_mcp():
+    with patch("topos.mcp.server.main"):
+        with patch("topos.cli.main.maybe_show_update_notice") as mock_notice:
+            runner = CliRunner()
+            result = runner.invoke(cli, ["mcp"])
+            assert result.exit_code == 0
+            mock_notice.assert_called_once()
+            assert mock_notice.call_args.kwargs["invoked_subcommand"] == "mcp"
+
+
+def test_passive_notice_skipped_for_update_command():
+    with patch("topos.cli.commands.system.run_update") as mock_run_update:
+        with patch("topos.cli.main.maybe_show_update_notice") as mock_notice:
+            runner = CliRunner()
+            with patch(
+                "topos.cli.update.latest_version_for_channel",
+                return_value="0.0.0",
+            ):
+                result = runner.invoke(cli, ["update", "--check"])
+            assert result.exit_code in (0, 1, 2)
+            mock_run_update.assert_called_once()
+            mock_notice.assert_called_once()
+            assert mock_notice.call_args.kwargs["invoked_subcommand"] == "update"

--- a/topos/cli/commands/system.py
+++ b/topos/cli/commands/system.py
@@ -8,9 +8,10 @@ from pathlib import Path
 import click
 
 from topos.cli.installation import (
-    detect_install_method,
+    detect_install_info,
+    echo_install_layout_notice,
     prune_path_hints,
-    remove_provenance_record,
+    remove_state_dir,
 )
 from topos.cli.update import run_update
 
@@ -59,14 +60,17 @@ def _handle_binary_removal(path: Path, dry_run: bool, yes: bool) -> bool:
     help="Skip confirmation prompts.",
 )
 @click.option(
-    "--prune-path-hints",
-    "prune_path_hints_flag",
+    "--keep-path-hints",
     is_flag=True,
-    help="Remove PATH hint blocks previously added by the installer.",
+    help="Skip removal of installer-added PATH blocks from shell rc files.",
 )
-def uninstall(dry_run: bool, yes: bool, prune_path_hints_flag: bool) -> None:
+def uninstall(dry_run: bool, yes: bool, keep_path_hints: bool) -> None:
     """Safely uninstall topos based on installation provenance."""
-    method, provenance, uninstall_cmd = detect_install_method()
+    info = detect_install_info()
+    echo_install_layout_notice(info=info)
+    method = info.method
+    provenance = info.provenance
+    uninstall_cmd = info.uninstall_cmd
 
     if method == "package-manager":
         click.echo("Detected package-manager installation.")
@@ -91,18 +95,10 @@ def uninstall(dry_run: bool, yes: bool, prune_path_hints_flag: bool) -> None:
     if not _handle_binary_removal(path, dry_run, yes):
         return
 
-    if not dry_run:
-        remove_provenance_record()
+    remove_state_dir(dry_run=dry_run)
 
-    if prune_path_hints_flag:
+    if not keep_path_hints:
         prune_path_hints(provenance, dry_run=dry_run)
-    else:
-        path_hint_file = provenance.get("path_hint_file", "").strip()
-        if path_hint_file:
-            click.echo(
-                "PATH hints were left unchanged. Re-run with --prune-path-hints "
-                "to remove installer-added PATH blocks."
-            )
 
 
 @click.command()

--- a/topos/cli/commands/system.py
+++ b/topos/cli/commands/system.py
@@ -12,6 +12,7 @@ from topos.cli.installation import (
     prune_path_hints,
     remove_provenance_record,
 )
+from topos.cli.update import run_update
 
 
 def _handle_binary_removal(path: Path, dry_run: bool, yes: bool) -> bool:
@@ -77,8 +78,8 @@ def uninstall(dry_run: bool, yes: bool, prune_path_hints_flag: bool) -> None:
             "Could not determine a managed installer provenance record.",
             err=True,
         )
-        click.echo("If installed via pip: pip uninstall topos", err=True)
-        click.echo("If installed via uv: uv pip uninstall topos", err=True)
+        click.echo("If installed via pip: pip uninstall topos-mcp", err=True)
+        click.echo("If installed via uv: uv pip uninstall topos-mcp", err=True)
         sys.exit(1)
 
     install_path = provenance.get("install_path", "").strip()
@@ -102,6 +103,23 @@ def uninstall(dry_run: bool, yes: bool, prune_path_hints_flag: bool) -> None:
                 "PATH hints were left unchanged. Re-run with --prune-path-hints "
                 "to remove installer-added PATH blocks."
             )
+
+
+@click.command()
+@click.option(
+    "--check",
+    is_flag=True,
+    help="Exit 0 if up to date, 1 if outdated (for scripts).",
+)
+@click.option(
+    "--version",
+    "pin_version",
+    default=None,
+    help="Pin release version for binary installs (e.g. v0.3.6).",
+)
+def update(check: bool, pin_version: str | None) -> None:
+    """Upgrade Topos using the detected install channel."""
+    run_update(check_only=check, pin_version=pin_version)
 
 
 @click.command()
@@ -153,6 +171,7 @@ def depgraph_generate(directory: str | None) -> None:
 
 def register_system_commands(cli_group: click.Group) -> None:
     """Attach system and integration commands to the root CLI group."""
+    cli_group.add_command(update)
     cli_group.add_command(uninstall)
     cli_group.add_command(mcp)
     cli_group.add_command(depgraph)

--- a/topos/cli/installation.py
+++ b/topos/cli/installation.py
@@ -1,10 +1,25 @@
 from __future__ import annotations
 
 import importlib.metadata
+import json
 import os
+from dataclasses import dataclass
 from pathlib import Path
 
 import click
+
+_PACKAGE_NAME = "topos-mcp"
+
+
+@dataclass(frozen=True)
+class InstallInfo:
+    """Detected install channel and related commands."""
+
+    method: str
+    provenance: dict[str, str] | None = None
+    uninstall_cmd: str | None = None
+    update_cmd: str | None = None
+    installer: str | None = None
 
 
 def provenance_file() -> Path:
@@ -34,15 +49,58 @@ def load_provenance() -> dict[str, str] | None:
     return data or None
 
 
-def detect_install_method() -> tuple[str, dict[str, str] | None, str | None]:
+def _is_editable_install(dist: importlib.metadata.Distribution) -> bool:
+    try:
+        direct_url_raw = dist.read_text("direct_url.json")
+    except (FileNotFoundError, OSError, UnicodeError):
+        return False
+    if not direct_url_raw:
+        return False
+    try:
+        direct_url = json.loads(direct_url_raw)
+    except json.JSONDecodeError:
+        return False
+    return bool(direct_url.get("dir")) and bool(direct_url.get("editable"))
+
+
+def _package_manager_info(installer: str) -> InstallInfo:
+    if installer == "uv":
+        return InstallInfo(
+            method="package-manager",
+            uninstall_cmd=f"uv pip uninstall {_PACKAGE_NAME}",
+            update_cmd=f"uv pip install -U {_PACKAGE_NAME}",
+            installer="uv",
+        )
+    if installer in {"pip", ""}:
+        return InstallInfo(
+            method="package-manager",
+            uninstall_cmd=f"pip uninstall {_PACKAGE_NAME}",
+            update_cmd=f"pip install -U {_PACKAGE_NAME}",
+            installer="pip",
+        )
+    return InstallInfo(
+        method="package-manager",
+        uninstall_cmd=f"{installer} uninstall {_PACKAGE_NAME}",
+        update_cmd=f"{installer} install -U {_PACKAGE_NAME}",
+        installer=installer,
+    )
+
+
+def detect_install_info() -> InstallInfo:
     provenance = load_provenance()
     if provenance and provenance.get("install_method") == "binary-installer":
-        return "binary-installer", provenance, None
+        return InstallInfo(method="binary-installer", provenance=provenance)
 
     try:
-        dist = importlib.metadata.distribution("topos")
+        dist = importlib.metadata.distribution(_PACKAGE_NAME)
     except importlib.metadata.PackageNotFoundError:
-        return "unknown", None, None
+        return InstallInfo(method="unknown")
+
+    if _is_editable_install(dist):
+        return InstallInfo(
+            method="source",
+            update_cmd="git pull && uv pip install -e .",
+        )
 
     try:
         installer_raw = dist.read_text("INSTALLER")
@@ -50,11 +108,12 @@ def detect_install_method() -> tuple[str, dict[str, str] | None, str | None]:
         installer_raw = "pip"
 
     installer = (installer_raw or "").strip().lower()
-    if installer == "uv":
-        return "package-manager", None, "uv pip uninstall topos"
-    if installer in {"pip", ""}:
-        return "package-manager", None, "pip uninstall topos"
-    return "package-manager", None, f"{installer} uninstall topos"
+    return _package_manager_info(installer)
+
+
+def detect_install_method() -> tuple[str, dict[str, str] | None, str | None]:
+    info = detect_install_info()
+    return info.method, info.provenance, info.uninstall_cmd
 
 
 def prune_path_hints(provenance: dict[str, str], dry_run: bool) -> None:

--- a/topos/cli/installation.py
+++ b/topos/cli/installation.py
@@ -60,7 +60,7 @@ def _is_editable_install(dist: importlib.metadata.Distribution) -> bool:
         direct_url = json.loads(direct_url_raw)
     except json.JSONDecodeError:
         return False
-    return bool(direct_url.get("dir")) and bool(direct_url.get("editable"))
+    return bool((direct_url.get("dir_info") or {}).get("editable"))
 
 
 def _package_manager_info(installer: str) -> InstallInfo:

--- a/topos/cli/installation.py
+++ b/topos/cli/installation.py
@@ -222,7 +222,9 @@ def install_layout_notice_lines(info: InstallInfo | None = None) -> list[str] | 
     return lines
 
 
-def echo_install_layout_notice(*, info: InstallInfo | None = None, err: bool = True) -> bool:
+def echo_install_layout_notice(
+    *, info: InstallInfo | None = None, err: bool = True
+) -> bool:
     """Print install layout notice when relevant. Returns True if printed."""
     lines = install_layout_notice_lines(info)
     if lines is None:

--- a/topos/cli/installation.py
+++ b/topos/cli/installation.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import importlib.metadata
 import json
 import os
+import shutil
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -86,16 +88,9 @@ def _package_manager_info(installer: str) -> InstallInfo:
     )
 
 
-def detect_install_info() -> InstallInfo:
-    provenance = load_provenance()
-    if provenance and provenance.get("install_method") == "binary-installer":
-        return InstallInfo(method="binary-installer", provenance=provenance)
-
-    try:
-        dist = importlib.metadata.distribution(_PACKAGE_NAME)
-    except importlib.metadata.PackageNotFoundError:
-        return InstallInfo(method="unknown")
-
+def _install_info_from_distribution(
+    dist: importlib.metadata.Distribution,
+) -> InstallInfo:
     if _is_editable_install(dist):
         return InstallInfo(
             method="source",
@@ -111,9 +106,129 @@ def detect_install_info() -> InstallInfo:
     return _package_manager_info(installer)
 
 
+def _install_info_from_provenance(
+    provenance: dict[str, str] | None,
+) -> InstallInfo | None:
+    if provenance and provenance.get("install_method") == "binary-installer":
+        return InstallInfo(method="binary-installer", provenance=provenance)
+    return None
+
+
+def detect_install_info() -> InstallInfo:
+    provenance = load_provenance()
+
+    try:
+        dist = importlib.metadata.distribution(_PACKAGE_NAME)
+    except importlib.metadata.PackageNotFoundError:
+        binary_info = _install_info_from_provenance(provenance)
+        if binary_info is not None:
+            return binary_info
+        return InstallInfo(method="unknown")
+
+    # Active Python install metadata wins over stale binary provenance records.
+    return _install_info_from_distribution(dist)
+
+
 def detect_install_method() -> tuple[str, dict[str, str] | None, str | None]:
     info = detect_install_info()
     return info.method, info.provenance, info.uninstall_cmd
+
+
+def active_executable() -> Path:
+    """Resolved path of the executable/script running this process."""
+    return Path(sys.argv[0]).expanduser().resolve()
+
+
+def find_topos_executables_on_path() -> list[Path]:
+    """All distinct ``topos`` executables found on PATH (order preserved)."""
+    results: list[Path] = []
+    seen: set[Path] = set()
+    for entry in os.environ.get("PATH", "").split(os.pathsep):
+        entry = entry.strip()
+        if not entry:
+            continue
+        candidate = Path(entry).expanduser() / "topos"
+        try:
+            if candidate.is_file() and os.access(candidate, os.X_OK):
+                resolved = candidate.resolve()
+                if resolved not in seen:
+                    seen.add(resolved)
+                    results.append(resolved)
+        except OSError:
+            continue
+    return results
+
+
+def channel_label(info: InstallInfo) -> str:
+    if info.method == "binary-installer":
+        return "binary CLI"
+    if info.method == "source":
+        return "editable source checkout"
+    if info.method == "package-manager":
+        installer = info.installer or "pip"
+        return f"PyPI ({installer})"
+    return info.method
+
+
+def install_layout_notice_lines(info: InstallInfo | None = None) -> list[str] | None:
+    """Return notice lines when multiple installs may conflict, else None."""
+    info = info or detect_install_info()
+    active = active_executable()
+    path_bins = find_topos_executables_on_path()
+    provenance = load_provenance()
+
+    other_bins = [path for path in path_bins if path != active]
+    which_bin = shutil.which("topos")
+    which_resolved = Path(which_bin).resolve() if which_bin else None
+
+    stale_binary: Path | None = None
+    if provenance and provenance.get("install_method") == "binary-installer":
+        recorded = provenance.get("install_path", "").strip()
+        if recorded and info.method != "binary-installer":
+            recorded_path = Path(recorded).expanduser()
+            try:
+                if recorded_path.exists() and recorded_path.resolve() != active:
+                    stale_binary = recorded_path.resolve()
+            except OSError:
+                pass
+
+    path_precedence_mismatch = which_resolved is not None and which_resolved != active
+
+    if not other_bins and stale_binary is None and not path_precedence_mismatch:
+        return None
+
+    lines = [
+        "Multiple Topos installations detected.",
+        f"  Active: {active} ({channel_label(info)}) — "
+        "`topos update` / `topos uninstall` use this install.",
+    ]
+
+    if which_resolved is not None and which_resolved != active:
+        lines.append(
+            f"  PATH default: {which_resolved} "
+            "(runs when you type `topos` without a full path)"
+        )
+
+    for path in other_bins:
+        if path != which_resolved:
+            lines.append(f"  Also on PATH: {path}")
+
+    if stale_binary is not None and stale_binary not in other_bins:
+        lines.append(
+            f"  Binary installer record: {stale_binary} "
+            "(remove with that binary's `topos uninstall`, or delete manually)"
+        )
+
+    return lines
+
+
+def echo_install_layout_notice(*, info: InstallInfo | None = None, err: bool = True) -> bool:
+    """Print install layout notice when relevant. Returns True if printed."""
+    lines = install_layout_notice_lines(info)
+    if lines is None:
+        return False
+    click.echo("\n".join(lines), err=err)
+    return True
 
 
 def prune_path_hints(provenance: dict[str, str], dry_run: bool) -> None:
@@ -171,6 +286,27 @@ def prune_path_hints(provenance: dict[str, str], dry_run: bool) -> None:
         new_content += "\n"
     rc_path.write_text(new_content, encoding="utf-8")
     click.echo(f"Pruned installer PATH hints from {rc_path}")
+
+
+def topos_state_dir() -> Path:
+    state_home = Path(os.environ.get("XDG_STATE_HOME", "~/.local/state")).expanduser()
+    return state_home / "topos"
+
+
+def remove_state_dir(dry_run: bool = False) -> None:
+    """Remove the entire topos XDG state directory (caches, provenance)."""
+    state_dir = topos_state_dir()
+    if not state_dir.exists():
+        return
+    if dry_run:
+        click.echo(f"[dry-run] Would remove state directory: {state_dir}")
+        return
+    try:
+        shutil.rmtree(state_dir)
+    except OSError as exc:
+        click.echo(f"Failed to remove state directory {state_dir}: {exc}", err=True)
+        return
+    click.echo(f"Removed state directory: {state_dir}")
 
 
 def remove_provenance_record() -> None:

--- a/topos/cli/main.py
+++ b/topos/cli/main.py
@@ -11,7 +11,7 @@ import click
 from topos import __version__
 from topos.cli.commands.quality import register_quality_commands
 from topos.cli.commands.system import register_system_commands
-from topos.cli.update import maybe_show_update_notice
+from topos.cli.update import maybe_show_install_layout_notice, maybe_show_update_notice
 
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
@@ -34,6 +34,10 @@ register_system_commands(cli)
 @click.pass_context
 def _notify_updates(ctx: click.Context, result: object, **kwargs: object) -> None:
     help_requested = any(arg in sys.argv for arg in ("-h", "--help"))
+    maybe_show_install_layout_notice(
+        invoked_subcommand=ctx.invoked_subcommand,
+        help_requested=help_requested,
+    )
     maybe_show_update_notice(
         invoked_subcommand=ctx.invoked_subcommand,
         help_requested=help_requested,

--- a/topos/cli/main.py
+++ b/topos/cli/main.py
@@ -4,25 +4,40 @@ CLI entry point — root Click group and command registration.
 
 from __future__ import annotations
 
+import sys
+
 import click
 
 from topos import __version__
 from topos.cli.commands.quality import register_quality_commands
 from topos.cli.commands.system import register_system_commands
+from topos.cli.update import maybe_show_update_notice
 
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
 @click.version_option(version=__version__, prog_name="topos")
-def cli() -> None:
+@click.pass_context
+def cli(ctx: click.Context) -> None:
     """
     Topos: Category-theoretic code quality evaluation.
 
     Treating programs as morphisms in a world of structured code.
     """
+    ctx.ensure_object(dict)
 
 
 register_quality_commands(cli)
 register_system_commands(cli)
+
+
+@cli.result_callback()
+@click.pass_context
+def _notify_updates(ctx: click.Context, result: object, **kwargs: object) -> None:
+    help_requested = any(arg in sys.argv for arg in ("-h", "--help"))
+    maybe_show_update_notice(
+        invoked_subcommand=ctx.invoked_subcommand,
+        help_requested=help_requested,
+    )
 
 
 def main() -> None:

--- a/topos/cli/update.py
+++ b/topos/cli/update.py
@@ -15,7 +15,7 @@ from urllib.request import Request, urlopen
 import click
 
 from topos import __version__
-from topos.cli.installation import InstallInfo, detect_install_info
+from topos.cli.installation import InstallInfo, detect_install_info, echo_install_layout_notice
 
 _INSTALL_SCRIPT_URL = "https://docs.krv.ai/topos/install.sh"
 _GITHUB_REPO = "Krv-Labs/topos"
@@ -189,8 +189,56 @@ def _print_unknown_upgrade_paths() -> None:
     click.echo("  git pull && uv pip install -e .")
 
 
+def install_layout_notice_cache_file() -> Path:
+    override = os.environ.get("TOPOS_INSTALL_LAYOUT_NOTICE_FILE")
+    if override:
+        return Path(override).expanduser()
+    state_home = Path(os.environ.get("XDG_STATE_HOME", "~/.local/state")).expanduser()
+    return state_home / "topos" / "install-layout-notice.json"
+
+
+def load_install_layout_notice_cache() -> dict[str, str] | None:
+    path = install_layout_notice_cache_file()
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    return {str(k): str(v) for k, v in data.items()}
+
+
+def save_install_layout_notice_cache() -> None:
+    path = install_layout_notice_cache_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"checked_at": datetime.now(UTC).isoformat()}
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def maybe_show_install_layout_notice(
+    *,
+    invoked_subcommand: str | None,
+    help_requested: bool,
+) -> None:
+    if should_skip_passive_notice(
+        invoked_subcommand=invoked_subcommand,
+        help_requested=help_requested,
+    ):
+        return
+
+    cache = load_install_layout_notice_cache()
+    if cache_is_fresh(cache):
+        return
+
+    if echo_install_layout_notice():
+        save_install_layout_notice_cache()
+
+
 def run_update(*, check_only: bool, pin_version: str | None) -> None:
     info = detect_install_info()
+    echo_install_layout_notice(info=info)
     current = __version__
     latest = latest_version_for_channel(info.method)
 

--- a/topos/cli/update.py
+++ b/topos/cli/update.py
@@ -1,0 +1,272 @@
+"""Channel-aware update checks and upgrades for the Topos CLI."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+import click
+
+from topos import __version__
+from topos.cli.installation import InstallInfo, detect_install_info
+
+_INSTALL_SCRIPT_URL = "https://docs.krv.ai/topos/install.sh"
+_GITHUB_REPO = "Krv-Labs/topos"
+_PYPI_PACKAGE = "topos-mcp"
+_FETCH_TIMEOUT = 3
+_CACHE_TTL = timedelta(hours=24)
+_VERSION_RE = re.compile(
+    r"^v?(?P<major>\d+)(?:\.(?P<minor>\d+))?(?:\.(?P<patch>\d+))?"
+)
+
+
+def update_check_cache_file() -> Path:
+    override = os.environ.get("TOPOS_UPDATE_CHECK_FILE")
+    if override:
+        return Path(override).expanduser()
+    state_home = Path(os.environ.get("XDG_STATE_HOME", "~/.local/state")).expanduser()
+    return state_home / "topos" / "update-check.json"
+
+
+def normalize_version(tag: str) -> tuple[int, ...]:
+    match = _VERSION_RE.match(tag.strip())
+    if not match:
+        return (0,)
+    parts: list[int] = []
+    for key in ("major", "minor", "patch"):
+        value = match.group(key)
+        parts.append(int(value) if value is not None else 0)
+    return tuple(parts)
+
+
+def is_outdated(current: str, latest: str) -> bool:
+    return normalize_version(current) < normalize_version(latest)
+
+
+def fetch_latest_github_tag(repo: str = _GITHUB_REPO) -> str | None:
+    request = Request(
+        f"https://github.com/{repo}/releases/latest",
+        method="HEAD",
+        headers={"User-Agent": "topos-cli"},
+    )
+    try:
+        with urlopen(request, timeout=_FETCH_TIMEOUT) as response:
+            effective_url = response.geturl()
+    except (URLError, OSError, TimeoutError):
+        return None
+
+    if "/releases/tag/" not in effective_url:
+        return None
+    tag = effective_url.rsplit("/", 1)[-1].split("?")[0].split("#")[0]
+    if not tag or not _VERSION_RE.match(tag):
+        return None
+    return tag.lstrip("v") if tag.startswith("v") else tag
+
+
+def fetch_latest_pypi_version(package: str = _PYPI_PACKAGE) -> str | None:
+    request = Request(
+        f"https://pypi.org/pypi/{package}/json",
+        headers={"User-Agent": "topos-cli"},
+    )
+    try:
+        with urlopen(request, timeout=_FETCH_TIMEOUT) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except (URLError, OSError, TimeoutError, json.JSONDecodeError, KeyError):
+        return None
+    version = payload.get("info", {}).get("version")
+    return str(version) if version else None
+
+
+def latest_version_for_channel(method: str) -> str | None:
+    if method in {"package-manager", "source"}:
+        return fetch_latest_pypi_version()
+    return fetch_latest_github_tag()
+
+
+def load_update_check_cache() -> dict[str, str] | None:
+    path = update_check_cache_file()
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    return {str(k): str(v) for k, v in data.items()}
+
+
+def save_update_check_cache(latest: str, channel: str) -> None:
+    path = update_check_cache_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "checked_at": datetime.now(UTC).isoformat(),
+        "latest": latest,
+        "channel": channel,
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def cache_is_fresh(cache: dict[str, str] | None) -> bool:
+    if not cache or "checked_at" not in cache:
+        return False
+    try:
+        checked_at = datetime.fromisoformat(cache["checked_at"])
+    except ValueError:
+        return False
+    if checked_at.tzinfo is None:
+        checked_at = checked_at.replace(tzinfo=UTC)
+    return datetime.now(UTC) - checked_at < _CACHE_TTL
+
+
+def _run_binary_update(info: InstallInfo, pin_version: str | None) -> None:
+    provenance = info.provenance or {}
+    install_path = provenance.get("install_path", "").strip()
+    if not install_path:
+        click.echo("Installer provenance is missing install_path.", err=True)
+        sys.exit(1)
+
+    install_dir = str(Path(install_path).expanduser().parent)
+    env = os.environ.copy()
+    env["TOPOS_UPDATE"] = "1"
+    env["TOPOS_INSTALL"] = install_dir
+    env["TOPOS_NO_MODIFY_PATH"] = "1"
+    if pin_version:
+        env["TOPOS_VERSION"] = pin_version
+
+    click.echo("Updating Topos via install.sh...")
+    curl_proc = subprocess.Popen(
+        ["curl", "-fsSL", _INSTALL_SCRIPT_URL],
+        stdout=subprocess.PIPE,
+    )
+    try:
+        proc = subprocess.run(
+            ["sh", "-s"],
+            stdin=curl_proc.stdout,
+            env=env,
+            check=False,
+        )
+    finally:
+        if curl_proc.stdout is not None:
+            curl_proc.stdout.close()
+        curl_proc.wait()
+
+    if proc.returncode != 0:
+        sys.exit(proc.returncode)
+
+
+def _run_package_update(info: InstallInfo) -> None:
+    installer = info.installer or "pip"
+    if installer == "uv":
+        cmd = ["uv", "pip", "install", "-U", _PYPI_PACKAGE]
+    else:
+        cmd = ["pip", "install", "-U", _PYPI_PACKAGE]
+
+    click.echo(f"Running: {' '.join(cmd)}")
+    proc = subprocess.run(cmd, check=False)
+    if proc.returncode != 0:
+        sys.exit(proc.returncode)
+
+
+def _print_unknown_upgrade_paths() -> None:
+    click.echo("Could not determine install channel. Supported upgrade paths:")
+    click.echo("")
+    click.echo("  # Binary (recommended)")
+    click.echo("  curl -fsSL https://docs.krv.ai/topos/install.sh | sh")
+    click.echo("")
+    click.echo("  # PyPI")
+    click.echo("  uv pip install -U topos-mcp")
+    click.echo("")
+    click.echo("  # Source checkout")
+    click.echo("  git pull && uv pip install -e .")
+
+
+def run_update(*, check_only: bool, pin_version: str | None) -> None:
+    info = detect_install_info()
+    current = __version__
+    latest = latest_version_for_channel(info.method)
+
+    if check_only:
+        if latest is None:
+            click.echo(f"Could not determine latest version (channel: {info.method}).")
+            sys.exit(2)
+        if is_outdated(current, latest):
+            click.echo(f"Outdated: {current} → {latest}")
+            sys.exit(1)
+        click.echo(f"Up to date: {current}")
+        return
+
+    if pin_version and info.method != "binary-installer":
+        click.echo("--version is only supported for binary installs.", err=True)
+        sys.exit(1)
+
+    if info.method == "binary-installer":
+        _run_binary_update(info, pin_version)
+        return
+
+    if info.method == "package-manager":
+        _run_package_update(info)
+        return
+
+    if info.method == "source":
+        click.echo("Detected editable/source installation.")
+        click.echo(f"Run: {info.update_cmd or 'git pull && uv pip install -e .'}")
+        return
+
+    _print_unknown_upgrade_paths()
+
+
+def should_skip_passive_notice(
+    *,
+    invoked_subcommand: str | None,
+    help_requested: bool,
+) -> bool:
+    if os.environ.get("CI", "").lower() == "true":
+        return True
+    if os.environ.get("TOPOS_NO_UPDATE_NOTICES") == "1":
+        return True
+    if not sys.stderr.isatty():
+        return True
+    if help_requested:
+        return True
+    if invoked_subcommand in {"mcp", "update"}:
+        return True
+    return False
+
+
+def maybe_show_update_notice(
+    *,
+    invoked_subcommand: str | None,
+    help_requested: bool,
+) -> None:
+    if should_skip_passive_notice(
+        invoked_subcommand=invoked_subcommand,
+        help_requested=help_requested,
+    ):
+        return
+
+    info = detect_install_info()
+    cache = load_update_check_cache()
+    if cache_is_fresh(cache) and cache.get("latest"):
+        latest = cache["latest"]
+    else:
+        latest = latest_version_for_channel(info.method)
+        if latest is None:
+            return
+        save_update_check_cache(latest, info.method)
+
+    current = __version__
+    if not is_outdated(current, latest):
+        return
+
+    click.echo(
+        f"Update available: {current} → {latest}. Run: topos update",
+        err=True,
+    )

--- a/topos/cli/update.py
+++ b/topos/cli/update.py
@@ -22,9 +22,7 @@ _GITHUB_REPO = "Krv-Labs/topos"
 _PYPI_PACKAGE = "topos-mcp"
 _FETCH_TIMEOUT = 3
 _CACHE_TTL = timedelta(hours=24)
-_VERSION_RE = re.compile(
-    r"^v?(?P<major>\d+)(?:\.(?P<minor>\d+))?(?:\.(?P<patch>\d+))?"
-)
+_VERSION_RE = re.compile(r"^v?(?P<major>\d+)(?:\.(?P<minor>\d+))?(?:\.(?P<patch>\d+))?")
 
 
 def update_check_cache_file() -> Path:
@@ -236,9 +234,7 @@ def should_skip_passive_notice(
         return True
     if help_requested:
         return True
-    if invoked_subcommand in {"mcp", "update"}:
-        return True
-    return False
+    return invoked_subcommand in {"mcp", "update"}
 
 
 def maybe_show_update_notice(

--- a/topos/cli/update.py
+++ b/topos/cli/update.py
@@ -156,6 +156,9 @@ def _run_binary_update(info: InstallInfo, pin_version: str | None) -> None:
             curl_proc.stdout.close()
         curl_proc.wait()
 
+    if curl_proc.returncode != 0:
+        click.echo("Failed to download install.sh.", err=True)
+        sys.exit(curl_proc.returncode or 1)
     if proc.returncode != 0:
         sys.exit(proc.returncode)
 

--- a/topos/cli/update.py
+++ b/topos/cli/update.py
@@ -15,7 +15,11 @@ from urllib.request import Request, urlopen
 import click
 
 from topos import __version__
-from topos.cli.installation import InstallInfo, detect_install_info, echo_install_layout_notice
+from topos.cli.installation import (
+    InstallInfo,
+    detect_install_info,
+    echo_install_layout_notice,
+)
 
 _INSTALL_SCRIPT_URL = "https://docs.krv.ai/topos/install.sh"
 _GITHUB_REPO = "Krv-Labs/topos"


### PR DESCRIPTION
## Summary

- Adds **`topos update`**: channel-aware upgrades for binary installs (re-runs `install.sh`), PyPI (`uv pip` / `pip install -U`), and source checkouts (prints instructions).
- Adds **`--check`** (exit 0 if current, 1 if outdated) and **`--version`** (pin binary release).
- Adds passive update notices on interactive CLI use (at most once per 24h; skipped for `topos mcp`, CI, non-TTY, `TOPOS_NO_UPDATE_NOTICES=1`).
- Adds `TOPOS_UPDATE=1` fast path in `install.sh` (skip banner, GitNexus prompt, PATH setup on re-install).

**Fixes #82** — `detect_install_info()` now checks live Python metadata first; binary provenance is a fallback only when no Python package is found.

**Install layout notices** — detects conflicting `topos` executables on PATH and warns on stderr (throttled to once/24h; always shown during `update` and `uninstall`).

**Uninstall completeness** — shell rc cleanup now happens by default (`--keep-path-hints` to skip); `remove_state_dir()` wipes the full `~/.local/state/topos/` dir (provenance + caches), dry-run aware.

Closes #78

## Test plan

- [x] `uv run pytest tests/cli/ -q` (68 passed)
- [x] `topos update --check` on a local install
- [x] Binary update path: verify `install.sh` receives `TOPOS_UPDATE=1`, `TOPOS_NO_MODIFY_PATH=1`
- [x] Confirm no update notice on `topos mcp`
- [x] Confirm `TOPOS_NO_UPDATE_NOTICES=1` suppresses stderr notice
- [x] Confirm layout notice fires with multiple installs on PATH
- [x] Confirm `topos uninstall` removes state dir and prunes PATH hints by default


## Internal

Added new github issue templates