### PR TITLE
[release] v0.3.6

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -58,3 +58,65 @@ commit permission. `SUSPICIOUS_NO_STRUCTURAL_CHANGE` blocks acceptance.
 ### Escape Hatches
 - **Score plateaus**: Split file. Extract high-complexity functions identified by `topos_inspect_code`.
 - **SIMPLE improves, COMPOSABLE regresses**: Abstraction is just relocation. Verify whole project rollup.
+
+## Releases
+
+Use a **lightweight release PR** when shipping a tagged version. Feature work lands in separate PRs first (`[cli]`, `[mcp]`, etc.); the release PR only bumps versions, finalizes the changelog, and applies any small docs touch-ups tied to the version string.
+
+### Branch and PR naming
+
+| Item | Convention | Example |
+|------|------------|---------|
+| Branch | `release/v<semver>` | `release/v0.3.6` |
+| PR title | `[release] v<semver>` | `[release] v0.3.6` |
+
+This matches the scoped prefixes used elsewhere (`[cli]`, `[mcp]`). Do **not** mix feature work into a release branch unless it is a hotfix that must ship in the same tag.
+
+When a feature PR itself carries the release (e.g. last change before tag), you may use `v<semver>: <summary>` in the title instead — but prefer a dedicated `[release]` PR for version-only diffs.
+
+### Version source of truth
+
+**`Cargo.toml`** (`[package].version`) is canonical. Maturin publishes that version to PyPI; `topos._version` reads it for editable installs.
+
+Also bump (must stay in sync):
+
+- `extensions/vscode/package.json` → `"version"`
+
+Run before opening the PR:
+
+```bash
+python scripts/check_versions.py   # CI enforces this
+```
+
+Python `__version__` and Sphinx `release` are derived from `Cargo.toml` at runtime — no manual edit in `topos/_version.py` or `docs/source/conf.py`.
+
+### Release PR checklist
+
+1. **CHANGELOG.md** — move `[Unreleased]` entries into `## [X.Y.Z] - YYYY-MM-DD`; leave an empty `[Unreleased]` section at the top.
+2. **Cargo.toml** — bump `[package].version` (semver: patch for fixes, minor for features while on 0.x).
+3. **extensions/vscode/package.json** — same semver string.
+4. **Docs** — only if needed (version called out in prose, install examples, etc.). API docs pick up version from `__version__` automatically.
+5. **`python scripts/check_versions.py`** — must pass.
+6. **PR body** — short summary of what ships; link merged feature PRs if helpful.
+
+No new features, refactors, or unrelated doc edits in a release PR.
+
+### Tag and publish
+
+After the release PR merges to `main`:
+
+```bash
+git checkout main && git pull
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+Tags use a **`v` prefix** (`v0.3.6`). Pushing the tag triggers `.github/workflows/release.yml` (GitHub release assets, PyPI, VS Code marketplace).
+
+Optional manual dispatch: Actions → **Build and Release** → `workflow_dispatch` with `version: vX.Y.Z`.
+
+### Agent workflow summary
+
+```
+feature PRs → merge to main → [release] PR (version + changelog) → merge → tag vX.Y.Z → CI release
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`topos update`** system command: channel-aware upgrades for binary installs (re-runs `install.sh` with checksum verification), PyPI installs (`uv pip` / `pip install -U topos-mcp`), and source checkouts (prints `git pull && uv pip install -e .`). Supports `--check` (exit 0 if current, 1 if outdated) and `--version` to pin a binary release. (closes [#78](https://github.com/Krv-Labs/topos/issues/78))
+- Passive update notices on interactive CLI use (at most once per 24h; skipped for `topos mcp`, CI, non-TTY, and when `TOPOS_NO_UPDATE_NOTICES=1` is set).
+- MCP edit-in-place assessment workflow for agents: snapshot and worktree-based assessment without pasting full source into tool calls. ([#76](https://github.com/Krv-Labs/topos/pull/76))
+- Documentation quickstart guide, Sphinx autodoc API reference (`docs/source/api/`), and branded docs assets (Geist fonts, lattice/medal figures, Krv logos). ([#75](https://github.com/Krv-Labs/topos/pull/75))
+- Preferences guide (`docs/source/preferences.rst`) and expanded agent workflow documentation.
+
+### Changed
+
+- **`install.sh`**: `TOPOS_UPDATE=1` fast path for in-place binary upgrades (skips banner, GitNexus prompt, and PATH setup while preserving download/checksum verification).
+- MCP assess/evaluate tools refactored into `topos/mcp/tools/assess/` and `topos/mcp/tools/evaluate/` subpackages (`core`, `render`, `snapshot`, `worktree`, `project`) to improve structure and metric scores on the Topos codebase itself. ([#76](https://github.com/Krv-Labs/topos/pull/76))
+- Updated MCP agent contract, workflow, and refactor prompt guidance for edit-in-place and preference-walk usage. ([#76](https://github.com/Krv-Labs/topos/pull/76))
+- Documentation index, installation, agents, and README aligned with current CLI/MCP behavior; copy-paste code blocks cleaned up. ([#75](https://github.com/Krv-Labs/topos/pull/75))
+
+### Fixed
+
+- `detect_install_method()` now resolves the **`topos-mcp`** PyPI distribution (was `topos`) and detects editable/source installs via `direct_url.json`.
+
 ## [0.3.4] - 2026-06-12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.6] - 2026-06-27
+
 ### Added
 
 - **`topos update`** system command: channel-aware upgrades for binary installs (re-runs `install.sh` with checksum verification), PyPI installs (`uv pip` / `pip install -U topos-mcp`), and source checkouts (prints `git pull && uv pip install -e .`). Supports `--check` (exit 0 if current, 1 if outdated) and `--version` to pin a binary release. (closes [#78](https://github.com/Krv-Labs/topos/issues/78))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topos-functors"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2021"
 
 [lib]

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -41,9 +41,9 @@ Run ``topos depgraph generate`` only when you need COMPOSABLE metrics. Run
    .. grid-item-card:: ⚙️ System commands
       :shadow: md
 
-      Run the MCP server, generate dependency graphs, or uninstall cleanly.
+      Run the MCP server, generate dependency graphs, update, or uninstall cleanly.
       ^^^
-      ``mcp`` · ``depgraph generate`` · ``uninstall``
+      ``mcp`` · ``depgraph generate`` · ``update`` · ``uninstall``
 
 Quality commands
 ================
@@ -271,6 +271,45 @@ If ``gitnexus`` is missing, install it first:
    cd /path/to/your/repo
    topos depgraph generate
    topos evaluate src/ -r --gitnexus-dir .gitnexus/
+
+update
+------
+
+Upgrade Topos using the detected install channel (binary installer, PyPI package manager, or source checkout).
+
+.. code-block:: bash
+
+   topos update [OPTIONS]
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 72
+
+   * - Option
+     - Description
+   * - ``--check``
+     - Exit 0 if up to date, 1 if outdated (for scripts). No upgrade is performed.
+   * - ``--version VERSION``
+     - Pin a release for binary installs (maps to ``TOPOS_VERSION`` in ``install.sh``).
+
+Channel behavior:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 72
+
+   * - Install channel
+     - ``topos update`` behavior
+   * - Binary (``install.sh``)
+     - Re-runs the installer with checksum verification; preserves PATH hints.
+   * - PyPI (``uv`` / ``pip``)
+     - Runs ``uv pip install -U topos-mcp`` or ``pip install -U topos-mcp``.
+   * - Source (editable checkout)
+     - Prints instructions: ``git pull && uv pip install -e .``
+   * - Unknown
+     - Prints all supported upgrade paths.
+
+On interactive CLI use (not ``topos mcp``), Topos may print a one-line update notice at most once per 24 hours when a newer release is available. Set ``TOPOS_NO_UPDATE_NOTICES=1`` to disable.
 
 uninstall
 ---------

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -202,6 +202,34 @@ Details and troubleshooting
    involving ``libpython3.12.dylib``, upgrade to v0.3.2 or later with the
    installer. Source installs are not affected.
 
+.. dropdown:: Upgrade
+
+   Binary and PyPI installs:
+
+   .. code-block:: bash
+
+      topos update
+
+   Check for updates without upgrading (exit 0 if current, 1 if outdated):
+
+   .. code-block:: bash
+
+      topos update --check
+
+   Pin a binary release:
+
+   .. code-block:: bash
+
+      topos update --version v0.3.6
+
+   Source checkouts should use:
+
+   .. code-block:: bash
+
+      git pull && uv pip install -e .
+
+   Set ``TOPOS_NO_UPDATE_NOTICES=1`` to disable passive update notices on interactive CLI use.
+
 .. dropdown:: Clean uninstall
 
    Binary installs can be removed by Topos itself:

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "topos-vscode",
   "displayName": "Topos: Code Quality Targets for Agents",
   "description": "Structural code-quality targets your coding agents can optimize toward, delivered as MCP tools for agent mode.",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "publisher": "KrvLabs",
   "icon": "icon.png",
   "license": "SEE LICENSE IN LICENSE",

--- a/install.sh
+++ b/install.sh
@@ -489,13 +489,21 @@ verify_install() {
 
 # Main
 main() {
-    print_header
+    if [ "${TOPOS_UPDATE:-0}" = "1" ]; then
+        info "Updating Topos..."
+    else
+        print_header
+    fi
 
     check_dependencies
     validate_install_dir
     install_topos
-    install_optional_dependencies
-    setup_path
+
+    if [ "${TOPOS_UPDATE:-0}" != "1" ]; then
+        install_optional_dependencies
+        setup_path
+    fi
+
     write_provenance
     verify_install
 }

--- a/tests/cli/test_helpers.py
+++ b/tests/cli/test_helpers.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from topos.cli.evaluation import collect_files
 from topos.cli.installation import (
+    detect_install_info,
     detect_install_method,
     load_provenance,
     prune_path_hints,
@@ -74,7 +75,15 @@ def test_detect_install_method_pip(monkeypatch):
     from unittest.mock import MagicMock
 
     mock_dist = MagicMock()
-    mock_dist.read_text.return_value = "pip"
+
+    def read_text(name: str) -> str:
+        if name == "direct_url.json":
+            raise FileNotFoundError
+        if name == "INSTALLER":
+            return "pip"
+        raise FileNotFoundError
+
+    mock_dist.read_text.side_effect = read_text
 
     with monkeypatch.context() as m:
         m.setattr("importlib.metadata.distribution", lambda name: mock_dist)
@@ -82,4 +91,43 @@ def test_detect_install_method_pip(monkeypatch):
 
         method, prov, cmd = detect_install_method()
         assert method == "package-manager"
-        assert cmd == "pip uninstall topos"
+        assert cmd == "pip uninstall topos-mcp"
+
+
+def test_detect_install_method_uv(monkeypatch):
+    from unittest.mock import MagicMock
+
+    mock_dist = MagicMock()
+
+    def read_text(name: str) -> str:
+        if name == "direct_url.json":
+            raise FileNotFoundError
+        if name == "INSTALLER":
+            return "uv"
+        raise FileNotFoundError
+
+    mock_dist.read_text.side_effect = read_text
+
+    with monkeypatch.context() as m:
+        m.setattr("importlib.metadata.distribution", lambda name: mock_dist)
+        m.setattr("topos.cli.installation.load_provenance", lambda: None)
+
+        info = detect_install_info()
+        assert info.method == "package-manager"
+        assert info.installer == "uv"
+        assert info.update_cmd == "uv pip install -U topos-mcp"
+
+
+def test_detect_install_method_editable(monkeypatch):
+    from unittest.mock import MagicMock
+
+    mock_dist = MagicMock()
+    mock_dist.read_text.return_value = '{"dir": "/src/topos", "editable": true}'
+
+    with monkeypatch.context() as m:
+        m.setattr("importlib.metadata.distribution", lambda name: mock_dist)
+        m.setattr("topos.cli.installation.load_provenance", lambda: None)
+
+        info = detect_install_info()
+        assert info.method == "source"
+        assert info.update_cmd == "git pull && uv pip install -e ."

--- a/tests/cli/test_system.py
+++ b/tests/cli/test_system.py
@@ -95,3 +95,134 @@ def test_uninstall_binary_yes(tmp_path: Path):
         assert f"Removed binary: {binary}" in result.output
         assert not binary.exists()
         mock_remove.assert_called_once()
+
+
+@patch("topos.cli.update.subprocess.run")
+@patch("topos.cli.update.subprocess.Popen")
+def test_update_binary_invokes_install_script(mock_popen, mock_run, tmp_path: Path):
+    from unittest.mock import MagicMock
+
+    binary = tmp_path / "bin" / "topos"
+    binary.parent.mkdir(parents=True)
+    binary.touch()
+    provenance = {"install_method": "binary-installer", "install_path": str(binary)}
+
+    curl_proc = mock_popen.return_value
+    curl_proc.stdout = MagicMock()
+    mock_run.return_value.returncode = 0
+
+    with patch(
+        "topos.cli.update.detect_install_info",
+    ) as mock_detect:
+        from topos.cli.installation import InstallInfo
+
+        mock_detect.return_value = InstallInfo(
+            method="binary-installer",
+            provenance=provenance,
+        )
+        runner = CliRunner()
+        result = runner.invoke(cli, ["update"])
+        assert result.exit_code == 0
+        assert "Updating Topos via install.sh" in result.output
+
+    mock_popen.assert_called_once()
+    _, kwargs = mock_run.call_args
+    env = kwargs["env"]
+    assert env["TOPOS_UPDATE"] == "1"
+    assert env["TOPOS_INSTALL"] == str(binary.parent)
+    assert env["TOPOS_NO_MODIFY_PATH"] == "1"
+
+
+@patch("topos.cli.update.subprocess.run")
+def test_update_package_manager_uv(mock_run):
+    mock_run.return_value.returncode = 0
+
+    with patch("topos.cli.update.detect_install_info") as mock_detect:
+        from topos.cli.installation import InstallInfo
+
+        mock_detect.return_value = InstallInfo(
+            method="package-manager",
+            installer="uv",
+            update_cmd="uv pip install -U topos-mcp",
+        )
+        runner = CliRunner()
+        result = runner.invoke(cli, ["update"])
+        assert result.exit_code == 0
+        mock_run.assert_called_once_with(
+            ["uv", "pip", "install", "-U", "topos-mcp"],
+            check=False,
+        )
+
+
+@patch("topos.cli.update.subprocess.run")
+def test_update_package_manager_pip(mock_run):
+    mock_run.return_value.returncode = 0
+
+    with patch("topos.cli.update.detect_install_info") as mock_detect:
+        from topos.cli.installation import InstallInfo
+
+        mock_detect.return_value = InstallInfo(
+            method="package-manager",
+            installer="pip",
+            update_cmd="pip install -U topos-mcp",
+        )
+        runner = CliRunner()
+        result = runner.invoke(cli, ["update"])
+        assert result.exit_code == 0
+        mock_run.assert_called_once_with(
+            ["pip", "install", "-U", "topos-mcp"],
+            check=False,
+        )
+
+
+def test_update_source_prints_instructions():
+    with patch("topos.cli.update.detect_install_info") as mock_detect:
+        from topos.cli.installation import InstallInfo
+
+        mock_detect.return_value = InstallInfo(
+            method="source",
+            update_cmd="git pull && uv pip install -e .",
+        )
+        runner = CliRunner()
+        result = runner.invoke(cli, ["update"])
+        assert result.exit_code == 0
+        assert "editable/source installation" in result.output
+        assert "git pull && uv pip install -e ." in result.output
+
+
+@patch("topos.cli.update.__version__", "0.3.5")
+@patch("topos.cli.update.latest_version_for_channel", return_value="0.3.6")
+def test_update_check_outdated(mock_latest):
+    with patch("topos.cli.update.detect_install_info") as mock_detect:
+        from topos.cli.installation import InstallInfo
+
+        mock_detect.return_value = InstallInfo(method="package-manager")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["update", "--check"])
+        assert result.exit_code == 1
+        assert "Outdated: 0.3.5 → 0.3.6" in result.output
+
+
+@patch("topos.cli.update.__version__", "0.3.6")
+@patch("topos.cli.update.latest_version_for_channel", return_value="0.3.6")
+def test_update_check_current(mock_latest):
+    with patch("topos.cli.update.detect_install_info") as mock_detect:
+        from topos.cli.installation import InstallInfo
+
+        mock_detect.return_value = InstallInfo(method="binary-installer")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["update", "--check"])
+        assert result.exit_code == 0
+        assert "Up to date: 0.3.6" in result.output
+
+
+def test_update_unknown_lists_paths():
+    with patch("topos.cli.update.detect_install_info") as mock_detect:
+        from topos.cli.installation import InstallInfo
+
+        mock_detect.return_value = InstallInfo(method="unknown")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["update"])
+        assert result.exit_code == 0
+        assert "Could not determine install channel" in result.output
+        assert "uv pip install -U topos-mcp" in result.output

--- a/tests/cli/test_update_notices.py
+++ b/tests/cli/test_update_notices.py
@@ -35,6 +35,11 @@ def test_should_skip_passive_notice_env(monkeypatch):
     assert should_skip_passive_notice(invoked_subcommand="evaluate", help_requested=False)
 
 
+def test_should_skip_passive_notice_ci(monkeypatch):
+    monkeypatch.setenv("CI", "true")
+    assert should_skip_passive_notice(invoked_subcommand="evaluate", help_requested=False)
+
+
 def test_cache_is_fresh():
     recent = {
         "checked_at": datetime.now(UTC).isoformat(),
@@ -64,9 +69,11 @@ def test_maybe_show_update_notice_emits(
     mock_latest,
     mock_save,
     mock_outdated,
+    monkeypatch,
 ):
     from topos.cli.installation import InstallInfo
 
+    monkeypatch.delenv("CI", raising=False)
     mock_detect.return_value = InstallInfo(method="binary-installer")
 
     maybe_show_update_notice(invoked_subcommand="evaluate", help_requested=False)
@@ -87,9 +94,11 @@ def test_maybe_show_update_notice_uses_fresh_cache(
     mock_detect,
     mock_load_cache,
     mock_latest,
+    monkeypatch,
 ):
     from topos.cli.installation import InstallInfo
 
+    monkeypatch.delenv("CI", raising=False)
     mock_detect.return_value = InstallInfo(method="binary-installer")
     mock_load_cache.return_value = {
         "checked_at": datetime.now(UTC).isoformat(),

--- a/tests/cli/test_update_notices.py
+++ b/tests/cli/test_update_notices.py
@@ -4,7 +4,6 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
 from click.testing import CliRunner
-
 from topos.cli.main import cli
 from topos.cli.update import (
     cache_is_fresh,
@@ -32,12 +31,18 @@ def test_should_skip_passive_notice_mcp():
 
 def test_should_skip_passive_notice_env(monkeypatch):
     monkeypatch.setenv("TOPOS_NO_UPDATE_NOTICES", "1")
-    assert should_skip_passive_notice(invoked_subcommand="evaluate", help_requested=False)
+    assert should_skip_passive_notice(
+        invoked_subcommand="evaluate",
+        help_requested=False,
+    )
 
 
 def test_should_skip_passive_notice_ci(monkeypatch):
     monkeypatch.setenv("CI", "true")
-    assert should_skip_passive_notice(invoked_subcommand="evaluate", help_requested=False)
+    assert should_skip_passive_notice(
+        invoked_subcommand="evaluate",
+        help_requested=False,
+    )
 
 
 def test_cache_is_fresh():
@@ -113,25 +118,26 @@ def test_maybe_show_update_notice_uses_fresh_cache(
 
 
 def test_passive_notice_skipped_for_mcp():
-    with patch("topos.mcp.server.main"):
-        with patch("topos.cli.main.maybe_show_update_notice") as mock_notice:
-            runner = CliRunner()
-            result = runner.invoke(cli, ["mcp"])
-            assert result.exit_code == 0
-            mock_notice.assert_called_once()
-            assert mock_notice.call_args.kwargs["invoked_subcommand"] == "mcp"
+    with (
+        patch("topos.mcp.server.main"),
+        patch("topos.cli.main.maybe_show_update_notice") as mock_notice,
+    ):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["mcp"])
+        assert result.exit_code == 0
+        mock_notice.assert_called_once()
+        assert mock_notice.call_args.kwargs["invoked_subcommand"] == "mcp"
 
 
 def test_passive_notice_skipped_for_update_command():
-    with patch("topos.cli.commands.system.run_update") as mock_run_update:
-        with patch("topos.cli.main.maybe_show_update_notice") as mock_notice:
-            runner = CliRunner()
-            with patch(
-                "topos.cli.update.latest_version_for_channel",
-                return_value="0.0.0",
-            ):
-                result = runner.invoke(cli, ["update", "--check"])
-            assert result.exit_code in (0, 1, 2)
-            mock_run_update.assert_called_once()
-            mock_notice.assert_called_once()
-            assert mock_notice.call_args.kwargs["invoked_subcommand"] == "update"
+    with (
+        patch("topos.cli.commands.system.run_update") as mock_run_update,
+        patch("topos.cli.main.maybe_show_update_notice") as mock_notice,
+        patch("topos.cli.update.latest_version_for_channel", return_value="0.0.0"),
+    ):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["update", "--check"])
+        assert result.exit_code in (0, 1, 2)
+        mock_run_update.assert_called_once()
+        mock_notice.assert_called_once()
+        assert mock_notice.call_args.kwargs["invoked_subcommand"] == "update"

--- a/tests/cli/test_update_notices.py
+++ b/tests/cli/test_update_notices.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from topos.cli.main import cli
+from topos.cli.update import (
+    cache_is_fresh,
+    is_outdated,
+    maybe_show_update_notice,
+    normalize_version,
+    should_skip_passive_notice,
+)
+
+
+def test_normalize_version():
+    assert normalize_version("v0.3.5") == (0, 3, 5)
+    assert normalize_version("1.2") == (1, 2, 0)
+
+
+def test_is_outdated():
+    assert is_outdated("0.3.5", "0.3.6")
+    assert not is_outdated("0.3.6", "0.3.6")
+    assert not is_outdated("0.3.7", "0.3.6")
+
+
+def test_should_skip_passive_notice_mcp():
+    assert should_skip_passive_notice(invoked_subcommand="mcp", help_requested=False)
+
+
+def test_should_skip_passive_notice_env(monkeypatch):
+    monkeypatch.setenv("TOPOS_NO_UPDATE_NOTICES", "1")
+    assert should_skip_passive_notice(invoked_subcommand="evaluate", help_requested=False)
+
+
+def test_cache_is_fresh():
+    recent = {
+        "checked_at": datetime.now(UTC).isoformat(),
+        "latest": "0.3.6",
+    }
+    assert cache_is_fresh(recent)
+
+    stale = {
+        "checked_at": (datetime.now(UTC) - timedelta(hours=25)).isoformat(),
+        "latest": "0.3.6",
+    }
+    assert not cache_is_fresh(stale)
+
+
+@patch("topos.cli.update.is_outdated", return_value=True)
+@patch("topos.cli.update.save_update_check_cache")
+@patch("topos.cli.update.latest_version_for_channel", return_value="9.9.9")
+@patch("topos.cli.update.load_update_check_cache", return_value=None)
+@patch("topos.cli.update.detect_install_info")
+@patch("topos.cli.update.click.echo")
+@patch("topos.cli.update.sys.stderr.isatty", return_value=True)
+def test_maybe_show_update_notice_emits(
+    mock_isatty,
+    mock_echo,
+    mock_detect,
+    mock_load_cache,
+    mock_latest,
+    mock_save,
+    mock_outdated,
+):
+    from topos.cli.installation import InstallInfo
+
+    mock_detect.return_value = InstallInfo(method="binary-installer")
+
+    maybe_show_update_notice(invoked_subcommand="evaluate", help_requested=False)
+
+    mock_echo.assert_called_once()
+    assert "Update available" in mock_echo.call_args[0][0]
+    assert mock_echo.call_args[1]["err"] is True
+
+
+@patch("topos.cli.update.latest_version_for_channel")
+@patch("topos.cli.update.load_update_check_cache")
+@patch("topos.cli.update.detect_install_info")
+@patch("topos.cli.update.click.echo")
+@patch("topos.cli.update.sys.stderr.isatty", return_value=True)
+def test_maybe_show_update_notice_uses_fresh_cache(
+    mock_isatty,
+    mock_echo,
+    mock_detect,
+    mock_load_cache,
+    mock_latest,
+):
+    from topos.cli.installation import InstallInfo
+
+    mock_detect.return_value = InstallInfo(method="binary-installer")
+    mock_load_cache.return_value = {
+        "checked_at": datetime.now(UTC).isoformat(),
+        "latest": "9.9.9",
+    }
+
+    with patch("topos.cli.update.is_outdated", return_value=True):
+        maybe_show_update_notice(invoked_subcommand="evaluate", help_requested=False)
+
+    mock_latest.assert_not_called()
+    mock_echo.assert_called_once()
+
+
+def test_passive_notice_skipped_for_mcp():
+    with patch("topos.mcp.server.main"):
+        with patch("topos.cli.main.maybe_show_update_notice") as mock_notice:
+            runner = CliRunner()
+            result = runner.invoke(cli, ["mcp"])
+            assert result.exit_code == 0
+            mock_notice.assert_called_once()
+            assert mock_notice.call_args.kwargs["invoked_subcommand"] == "mcp"
+
+
+def test_passive_notice_skipped_for_update_command():
+    with patch("topos.cli.commands.system.run_update") as mock_run_update:
+        with patch("topos.cli.main.maybe_show_update_notice") as mock_notice:
+            runner = CliRunner()
+            with patch(
+                "topos.cli.update.latest_version_for_channel",
+                return_value="0.0.0",
+            ):
+                result = runner.invoke(cli, ["update", "--check"])
+            assert result.exit_code in (0, 1, 2)
+            mock_run_update.assert_called_once()
+            mock_notice.assert_called_once()
+            assert mock_notice.call_args.kwargs["invoked_subcommand"] == "update"

--- a/topos/cli/commands/system.py
+++ b/topos/cli/commands/system.py
@@ -12,6 +12,7 @@ from topos.cli.installation import (
     prune_path_hints,
     remove_provenance_record,
 )
+from topos.cli.update import run_update
 
 
 def _handle_binary_removal(path: Path, dry_run: bool, yes: bool) -> bool:
@@ -77,8 +78,8 @@ def uninstall(dry_run: bool, yes: bool, prune_path_hints_flag: bool) -> None:
             "Could not determine a managed installer provenance record.",
             err=True,
         )
-        click.echo("If installed via pip: pip uninstall topos", err=True)
-        click.echo("If installed via uv: uv pip uninstall topos", err=True)
+        click.echo("If installed via pip: pip uninstall topos-mcp", err=True)
+        click.echo("If installed via uv: uv pip uninstall topos-mcp", err=True)
         sys.exit(1)
 
     install_path = provenance.get("install_path", "").strip()
@@ -102,6 +103,23 @@ def uninstall(dry_run: bool, yes: bool, prune_path_hints_flag: bool) -> None:
                 "PATH hints were left unchanged. Re-run with --prune-path-hints "
                 "to remove installer-added PATH blocks."
             )
+
+
+@click.command()
+@click.option(
+    "--check",
+    is_flag=True,
+    help="Exit 0 if up to date, 1 if outdated (for scripts).",
+)
+@click.option(
+    "--version",
+    "pin_version",
+    default=None,
+    help="Pin release version for binary installs (e.g. v0.3.6).",
+)
+def update(check: bool, pin_version: str | None) -> None:
+    """Upgrade Topos using the detected install channel."""
+    run_update(check_only=check, pin_version=pin_version)
 
 
 @click.command()
@@ -153,6 +171,7 @@ def depgraph_generate(directory: str | None) -> None:
 
 def register_system_commands(cli_group: click.Group) -> None:
     """Attach system and integration commands to the root CLI group."""
+    cli_group.add_command(update)
     cli_group.add_command(uninstall)
     cli_group.add_command(mcp)
     cli_group.add_command(depgraph)

--- a/topos/cli/installation.py
+++ b/topos/cli/installation.py
@@ -1,10 +1,25 @@
 from __future__ import annotations
 
 import importlib.metadata
+import json
 import os
+from dataclasses import dataclass
 from pathlib import Path
 
 import click
+
+_PACKAGE_NAME = "topos-mcp"
+
+
+@dataclass(frozen=True)
+class InstallInfo:
+    """Detected install channel and related commands."""
+
+    method: str
+    provenance: dict[str, str] | None = None
+    uninstall_cmd: str | None = None
+    update_cmd: str | None = None
+    installer: str | None = None
 
 
 def provenance_file() -> Path:
@@ -34,15 +49,58 @@ def load_provenance() -> dict[str, str] | None:
     return data or None
 
 
-def detect_install_method() -> tuple[str, dict[str, str] | None, str | None]:
+def _is_editable_install(dist: importlib.metadata.Distribution) -> bool:
+    try:
+        direct_url_raw = dist.read_text("direct_url.json")
+    except (FileNotFoundError, OSError, UnicodeError):
+        return False
+    if not direct_url_raw:
+        return False
+    try:
+        direct_url = json.loads(direct_url_raw)
+    except json.JSONDecodeError:
+        return False
+    return bool(direct_url.get("dir")) and bool(direct_url.get("editable"))
+
+
+def _package_manager_info(installer: str) -> InstallInfo:
+    if installer == "uv":
+        return InstallInfo(
+            method="package-manager",
+            uninstall_cmd=f"uv pip uninstall {_PACKAGE_NAME}",
+            update_cmd=f"uv pip install -U {_PACKAGE_NAME}",
+            installer="uv",
+        )
+    if installer in {"pip", ""}:
+        return InstallInfo(
+            method="package-manager",
+            uninstall_cmd=f"pip uninstall {_PACKAGE_NAME}",
+            update_cmd=f"pip install -U {_PACKAGE_NAME}",
+            installer="pip",
+        )
+    return InstallInfo(
+        method="package-manager",
+        uninstall_cmd=f"{installer} uninstall {_PACKAGE_NAME}",
+        update_cmd=f"{installer} install -U {_PACKAGE_NAME}",
+        installer=installer,
+    )
+
+
+def detect_install_info() -> InstallInfo:
     provenance = load_provenance()
     if provenance and provenance.get("install_method") == "binary-installer":
-        return "binary-installer", provenance, None
+        return InstallInfo(method="binary-installer", provenance=provenance)
 
     try:
-        dist = importlib.metadata.distribution("topos")
+        dist = importlib.metadata.distribution(_PACKAGE_NAME)
     except importlib.metadata.PackageNotFoundError:
-        return "unknown", None, None
+        return InstallInfo(method="unknown")
+
+    if _is_editable_install(dist):
+        return InstallInfo(
+            method="source",
+            update_cmd="git pull && uv pip install -e .",
+        )
 
     try:
         installer_raw = dist.read_text("INSTALLER")
@@ -50,11 +108,12 @@ def detect_install_method() -> tuple[str, dict[str, str] | None, str | None]:
         installer_raw = "pip"
 
     installer = (installer_raw or "").strip().lower()
-    if installer == "uv":
-        return "package-manager", None, "uv pip uninstall topos"
-    if installer in {"pip", ""}:
-        return "package-manager", None, "pip uninstall topos"
-    return "package-manager", None, f"{installer} uninstall topos"
+    return _package_manager_info(installer)
+
+
+def detect_install_method() -> tuple[str, dict[str, str] | None, str | None]:
+    info = detect_install_info()
+    return info.method, info.provenance, info.uninstall_cmd
 
 
 def prune_path_hints(provenance: dict[str, str], dry_run: bool) -> None:

--- a/topos/cli/main.py
+++ b/topos/cli/main.py
@@ -4,25 +4,40 @@ CLI entry point — root Click group and command registration.
 
 from __future__ import annotations
 
+import sys
+
 import click
 
 from topos import __version__
 from topos.cli.commands.quality import register_quality_commands
 from topos.cli.commands.system import register_system_commands
+from topos.cli.update import maybe_show_update_notice
 
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
 @click.version_option(version=__version__, prog_name="topos")
-def cli() -> None:
+@click.pass_context
+def cli(ctx: click.Context) -> None:
     """
     Topos: Category-theoretic code quality evaluation.
 
     Treating programs as morphisms in a world of structured code.
     """
+    ctx.ensure_object(dict)
 
 
 register_quality_commands(cli)
 register_system_commands(cli)
+
+
+@cli.result_callback()
+@click.pass_context
+def _notify_updates(ctx: click.Context, result: object, **kwargs: object) -> None:
+    help_requested = any(arg in sys.argv for arg in ("-h", "--help"))
+    maybe_show_update_notice(
+        invoked_subcommand=ctx.invoked_subcommand,
+        help_requested=help_requested,
+    )
 
 
 def main() -> None:

--- a/topos/cli/update.py
+++ b/topos/cli/update.py
@@ -1,0 +1,272 @@
+"""Channel-aware update checks and upgrades for the Topos CLI."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+import click
+
+from topos import __version__
+from topos.cli.installation import InstallInfo, detect_install_info
+
+_INSTALL_SCRIPT_URL = "https://docs.krv.ai/topos/install.sh"
+_GITHUB_REPO = "Krv-Labs/topos"
+_PYPI_PACKAGE = "topos-mcp"
+_FETCH_TIMEOUT = 3
+_CACHE_TTL = timedelta(hours=24)
+_VERSION_RE = re.compile(
+    r"^v?(?P<major>\d+)(?:\.(?P<minor>\d+))?(?:\.(?P<patch>\d+))?"
+)
+
+
+def update_check_cache_file() -> Path:
+    override = os.environ.get("TOPOS_UPDATE_CHECK_FILE")
+    if override:
+        return Path(override).expanduser()
+    state_home = Path(os.environ.get("XDG_STATE_HOME", "~/.local/state")).expanduser()
+    return state_home / "topos" / "update-check.json"
+
+
+def normalize_version(tag: str) -> tuple[int, ...]:
+    match = _VERSION_RE.match(tag.strip())
+    if not match:
+        return (0,)
+    parts: list[int] = []
+    for key in ("major", "minor", "patch"):
+        value = match.group(key)
+        parts.append(int(value) if value is not None else 0)
+    return tuple(parts)
+
+
+def is_outdated(current: str, latest: str) -> bool:
+    return normalize_version(current) < normalize_version(latest)
+
+
+def fetch_latest_github_tag(repo: str = _GITHUB_REPO) -> str | None:
+    request = Request(
+        f"https://github.com/{repo}/releases/latest",
+        method="HEAD",
+        headers={"User-Agent": "topos-cli"},
+    )
+    try:
+        with urlopen(request, timeout=_FETCH_TIMEOUT) as response:
+            effective_url = response.geturl()
+    except (URLError, OSError, TimeoutError):
+        return None
+
+    if "/releases/tag/" not in effective_url:
+        return None
+    tag = effective_url.rsplit("/", 1)[-1].split("?")[0].split("#")[0]
+    if not tag or not _VERSION_RE.match(tag):
+        return None
+    return tag.lstrip("v") if tag.startswith("v") else tag
+
+
+def fetch_latest_pypi_version(package: str = _PYPI_PACKAGE) -> str | None:
+    request = Request(
+        f"https://pypi.org/pypi/{package}/json",
+        headers={"User-Agent": "topos-cli"},
+    )
+    try:
+        with urlopen(request, timeout=_FETCH_TIMEOUT) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except (URLError, OSError, TimeoutError, json.JSONDecodeError, KeyError):
+        return None
+    version = payload.get("info", {}).get("version")
+    return str(version) if version else None
+
+
+def latest_version_for_channel(method: str) -> str | None:
+    if method in {"package-manager", "source"}:
+        return fetch_latest_pypi_version()
+    return fetch_latest_github_tag()
+
+
+def load_update_check_cache() -> dict[str, str] | None:
+    path = update_check_cache_file()
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    return {str(k): str(v) for k, v in data.items()}
+
+
+def save_update_check_cache(latest: str, channel: str) -> None:
+    path = update_check_cache_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "checked_at": datetime.now(UTC).isoformat(),
+        "latest": latest,
+        "channel": channel,
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def cache_is_fresh(cache: dict[str, str] | None) -> bool:
+    if not cache or "checked_at" not in cache:
+        return False
+    try:
+        checked_at = datetime.fromisoformat(cache["checked_at"])
+    except ValueError:
+        return False
+    if checked_at.tzinfo is None:
+        checked_at = checked_at.replace(tzinfo=UTC)
+    return datetime.now(UTC) - checked_at < _CACHE_TTL
+
+
+def _run_binary_update(info: InstallInfo, pin_version: str | None) -> None:
+    provenance = info.provenance or {}
+    install_path = provenance.get("install_path", "").strip()
+    if not install_path:
+        click.echo("Installer provenance is missing install_path.", err=True)
+        sys.exit(1)
+
+    install_dir = str(Path(install_path).expanduser().parent)
+    env = os.environ.copy()
+    env["TOPOS_UPDATE"] = "1"
+    env["TOPOS_INSTALL"] = install_dir
+    env["TOPOS_NO_MODIFY_PATH"] = "1"
+    if pin_version:
+        env["TOPOS_VERSION"] = pin_version
+
+    click.echo("Updating Topos via install.sh...")
+    curl_proc = subprocess.Popen(
+        ["curl", "-fsSL", _INSTALL_SCRIPT_URL],
+        stdout=subprocess.PIPE,
+    )
+    try:
+        proc = subprocess.run(
+            ["sh", "-s"],
+            stdin=curl_proc.stdout,
+            env=env,
+            check=False,
+        )
+    finally:
+        if curl_proc.stdout is not None:
+            curl_proc.stdout.close()
+        curl_proc.wait()
+
+    if proc.returncode != 0:
+        sys.exit(proc.returncode)
+
+
+def _run_package_update(info: InstallInfo) -> None:
+    installer = info.installer or "pip"
+    if installer == "uv":
+        cmd = ["uv", "pip", "install", "-U", _PYPI_PACKAGE]
+    else:
+        cmd = ["pip", "install", "-U", _PYPI_PACKAGE]
+
+    click.echo(f"Running: {' '.join(cmd)}")
+    proc = subprocess.run(cmd, check=False)
+    if proc.returncode != 0:
+        sys.exit(proc.returncode)
+
+
+def _print_unknown_upgrade_paths() -> None:
+    click.echo("Could not determine install channel. Supported upgrade paths:")
+    click.echo("")
+    click.echo("  # Binary (recommended)")
+    click.echo("  curl -fsSL https://docs.krv.ai/topos/install.sh | sh")
+    click.echo("")
+    click.echo("  # PyPI")
+    click.echo("  uv pip install -U topos-mcp")
+    click.echo("")
+    click.echo("  # Source checkout")
+    click.echo("  git pull && uv pip install -e .")
+
+
+def run_update(*, check_only: bool, pin_version: str | None) -> None:
+    info = detect_install_info()
+    current = __version__
+    latest = latest_version_for_channel(info.method)
+
+    if check_only:
+        if latest is None:
+            click.echo(f"Could not determine latest version (channel: {info.method}).")
+            sys.exit(2)
+        if is_outdated(current, latest):
+            click.echo(f"Outdated: {current} → {latest}")
+            sys.exit(1)
+        click.echo(f"Up to date: {current}")
+        return
+
+    if pin_version and info.method != "binary-installer":
+        click.echo("--version is only supported for binary installs.", err=True)
+        sys.exit(1)
+
+    if info.method == "binary-installer":
+        _run_binary_update(info, pin_version)
+        return
+
+    if info.method == "package-manager":
+        _run_package_update(info)
+        return
+
+    if info.method == "source":
+        click.echo("Detected editable/source installation.")
+        click.echo(f"Run: {info.update_cmd or 'git pull && uv pip install -e .'}")
+        return
+
+    _print_unknown_upgrade_paths()
+
+
+def should_skip_passive_notice(
+    *,
+    invoked_subcommand: str | None,
+    help_requested: bool,
+) -> bool:
+    if os.environ.get("CI", "").lower() == "true":
+        return True
+    if os.environ.get("TOPOS_NO_UPDATE_NOTICES") == "1":
+        return True
+    if not sys.stderr.isatty():
+        return True
+    if help_requested:
+        return True
+    if invoked_subcommand in {"mcp", "update"}:
+        return True
+    return False
+
+
+def maybe_show_update_notice(
+    *,
+    invoked_subcommand: str | None,
+    help_requested: bool,
+) -> None:
+    if should_skip_passive_notice(
+        invoked_subcommand=invoked_subcommand,
+        help_requested=help_requested,
+    ):
+        return
+
+    info = detect_install_info()
+    cache = load_update_check_cache()
+    if cache_is_fresh(cache) and cache.get("latest"):
+        latest = cache["latest"]
+    else:
+        latest = latest_version_for_channel(info.method)
+        if latest is None:
+            return
+        save_update_check_cache(latest, info.method)
+
+    current = __version__
+    if not is_outdated(current, latest):
+        return
+
+    click.echo(
+        f"Update available: {current} → {latest}. Run: topos update",
+        err=True,
+    )

--- a/topos/cli/update.py
+++ b/topos/cli/update.py
@@ -22,9 +22,7 @@ _GITHUB_REPO = "Krv-Labs/topos"
 _PYPI_PACKAGE = "topos-mcp"
 _FETCH_TIMEOUT = 3
 _CACHE_TTL = timedelta(hours=24)
-_VERSION_RE = re.compile(
-    r"^v?(?P<major>\d+)(?:\.(?P<minor>\d+))?(?:\.(?P<patch>\d+))?"
-)
+_VERSION_RE = re.compile(r"^v?(?P<major>\d+)(?:\.(?P<minor>\d+))?(?:\.(?P<patch>\d+))?")
 
 
 def update_check_cache_file() -> Path:
@@ -236,9 +234,7 @@ def should_skip_passive_notice(
         return True
     if help_requested:
         return True
-    if invoked_subcommand in {"mcp", "update"}:
-        return True
-    return False
+    return invoked_subcommand in {"mcp", "update"}
 
 
 def maybe_show_update_notice(


### PR DESCRIPTION
## Blocked on #79

**Do not merge this PR until [#79](https://github.com/Krv-Labs/topos/pull/79) (`[cli] Add topos update command and passive update notices`) is merged to `main`.**

After #79 lands and we merge this, tag and release `v0.3.6`.

## Milestone: [Release v0.3.6](https://github.com/Krv-Labs/topos/milestone/1)

Close these issues before releasing (currently open on the milestone):

- [ ] Close [#67](https://github.com/Krv-Labs/topos/issues/67) — [mcp] Add metric locations for failing complexity gates
- [ ] Close [#68](https://github.com/Krv-Labs/topos/issues/68) — [mcp] Add changeset assessment for module splits
- [ ] Close [#70](https://github.com/Krv-Labs/topos/issues/70) — [mcp] Add depgraph status and approval-gated generation tools
- [ ] Close [#77](https://github.com/Krv-Labs/topos/issues/77) — Improve `__init__.py` handling
- [ ] Close [#78](https://github.com/Krv-Labs/topos/issues/78) — Add `topos update` command and optional update notifications
- [ ] Close [#82](https://github.com/Krv-Labs/topos/issues/82) — Install detection should prefer the active install source over stale binary provenance

## Summary

Version-only release PR for **v0.3.6**:

- Bump `Cargo.toml` and `extensions/vscode/package.json` to `0.3.6`
- Move `[Unreleased]` changelog entries to `[0.3.6] - 2026-06-27`
- Add release workflow instructions to `.agents/AGENTS.md`

## Test plan

- [ ] All milestone issues above are closed
- [ ] #79 is merged to `main`
- [ ] Version bumps and changelog are correct
- [ ] Release workflow docs in `.agents/AGENTS.md` are accurate