### PR TITLE
feat: GitNexus process-flow representation scored into the three pillars

### DIFF
--- a/docs/process-flow-spike.md
+++ b/docs/process-flow-spike.md
@@ -1,0 +1,110 @@
+# GitNexus Process (dynamic behavior) extraction — spike
+
+Status: **IMPLEMENTED (v1)**. This document records what GitNexus
+"Processes" capture, how Topos lifts them into a `Representation`, and the
+per-pillar metrics they feed. Calibration is provisional and flagged below.
+
+## 1. What GitNexus captures
+
+`gitnexus analyze` writes a LadybugDB graph store to `.gitnexus/lbug`. Beyond
+the file/symbol/call structure consumed by the `ModuleDependencyGraph` (MDG),
+the store contains a **process layer**: statically-reconstructed *execution
+flows*. This is the closest signal the index has to dynamic behavior — the
+interprocedural call *sequence* a program runs, recovered without execution.
+
+Confirmed schema (read-only Cypher against this repo's `.gitnexus/lbug`):
+
+- **`Process` node** properties:
+  - `id` (e.g. `proc_0_curate_composable`)
+  - `label` / `heuristicLabel` (e.g. `Curate_composable -> _prepare`)
+  - `processType` (e.g. `cross_community`)
+  - `stepCount` (int)
+  - `communities` (list of community ids)
+  - `entryPointId` / `terminalId` (symbol ids of the flow's first / last step)
+- **`STEP_IN_PROCESS` edge**: direction `(Function|Class|Method) -> (Process)`,
+  with a `step` order index plus `confidence` / `reason` (`trace-detection`).
+
+Symbol ids embed the source path: `Function:<path>:<name>`
+(e.g. `Function:topos/mcp/evaluation.py:classify_file`). This repo's index
+holds **269 processes** over 3256 nodes / 213 communities.
+
+## 2. What Topos used before vs. now
+
+The MDG loader (`topos/graphs/mdg/object.py`) already pulls **every** node
+table and **every** `CodeRelation` edge into memory, so `Process` nodes and
+`STEP_IN_PROCESS` edges were already resident — just never read. `Process` /
+`STEP_IN_PROCESS` appeared only in the schema `Literal` enums and nowhere
+else. This spike surfaces them as a first-class `ProcessFlowGraph`
+representation.
+
+## 3. Extraction shape
+
+- `topos/graphs/process/object.py`
+  - `ProcessFlow` — one parsed flow (id, label, type, step count, communities,
+    entry/terminal ids, ordered step symbol ids).
+  - `ProcessFlowGraph` — implements the `Representation` protocol. Built from
+    an already-loaded `ModuleDependencyGraph` via
+    `ProcessFlowGraph.from_dep_graph(mdg, target_file, dimension=...)`, so the
+    LadybugDB read is paid **once** (shared with COMPOSABLE) and reuses the MCP
+    cache. It keeps only the flows that *touch* `target_file` (any of the
+    entry, terminal, or step symbols resolves to the file via the same
+    suffix-aware path match the MDG uses).
+  - One `Representation` feeds exactly one pillar (`dimension`), so the graph is
+    fanned out into three views via `for_dimension("simple"|"composable"|"secure")`,
+    sharing the parsed flow list.
+
+- `topos/functors/probes/process/flow.py` — pure measurements over a flow list:
+  flow length, participation, community span, cross-community count, and
+  dangerous-step (sink-on-flow) count using the existing danger registry.
+
+## 4. Per-pillar metrics (v1)
+
+| Pillar | Metric key | Meaning |
+| --- | --- | --- |
+| SIMPLE | `process.max_flow_length` | longest flow (steps) anchored at the file |
+| SIMPLE | `process.flow_participation` | number of flows the file participates in |
+| COMPOSABLE | `process.max_community_span` | most community boundaries any flow crosses |
+| COMPOSABLE | `process.cross_community_flows` | count of `cross_community` flows on the file |
+| SECURE | `process.dangerous_flows` | flows whose steps include a dangerous-API symbol |
+
+These complement (do not replace) the existing intra-procedural lenses:
+
+- **SIMPLE** today is per-function CFG cyclomatic + AST entropy — blind to
+  complexity that lives *between* functions. Process length/participation make
+  sprawling interprocedural flows visible.
+- **COMPOSABLE** today is static fan-in/out + Martin instability. Community
+  span / cross-community counts add *behavioral* (flow-level) coupling.
+- **SECURE** today is **intra-file** CPG taint (single UAST root) — it cannot
+  follow a sink across functions or files. `process.dangerous_flows` lifts
+  reachability to flow level: a dangerous sink that actually lies on an
+  execution flow from an entry point.
+
+## 5. Integration with the lattice
+
+Process metrics are scored by dedicated translators in
+`topos/evaluation/policies/process.py` (`score_process_simple`,
+`score_process_composable`, `score_process_secure`) and **merged** into each
+pillar's `ScoredDecision` inside the dispatchers
+(`topos/evaluation/characteristic_morphism.py`): `achieved` is AND-ed, `score`
+is min-ed, interpretations are unioned. Existing scorers
+(`simple.py` / `composable.py` / `secure.py`) are untouched. When no
+`.gitnexus` index is present, no process rep is attached and behavior is
+unchanged.
+
+## 6. Calibration — PROVISIONAL
+
+Gates/caps live in `ProcessPolicyThresholds` (`policies/calibration.py`) and
+are **not yet empirically calibrated** (unlike the PyPI-ECDF-calibrated
+SIMPLE/COMPOSABLE/SECURE singletons). SECURE uses zero-tolerance
+(`max_dangerous_flows = 0`) consistent with the existing SECURE philosophy;
+SIMPLE/COMPOSABLE gates are conservative starting points.
+
+## 7. Open items / future work
+
+- **Ordered taint.** The `step` index on `STEP_IN_PROCESS` enables true
+  `source -> ... -> sink` ordering within a flow; v1 only checks
+  membership of a dangerous step, not source-before-sink ordering.
+- **Calibration.** Run the PyPI corpus to derive ECDF-based gates/caps for the
+  three process axes, mirroring `CALIBRATION_REPORT.md`.
+- **Branching/depth.** `processType` and the step graph could yield true
+  branching factor and flow depth beyond raw step count.

--- a/tests/functors/probes/process/test_process_flow.py
+++ b/tests/functors/probes/process/test_process_flow.py
@@ -1,0 +1,146 @@
+"""Tests for the GitNexus process-flow representation and its probes."""
+
+from __future__ import annotations
+
+from topos.evaluation.characteristic_morphism import (
+    _score_secure_dim,
+    _score_simple_dim,
+)
+from topos.evaluation.policies.base import Priority
+from topos.graphs.mdg.object import GraphNode, GraphRelationship, ModuleDependencyGraph
+from topos.graphs.process.object import ProcessFlow, ProcessFlowGraph
+
+
+def _graph_with_process(
+    *,
+    process_type: str = "cross_community",
+    step_count: int = 4,
+    communities: list[str] | None = None,
+    step_symbol_ids: tuple[str, ...] = (
+        "Function:app.py:handler",
+        "Function:lib/util.py:helper",
+    ),
+) -> ModuleDependencyGraph:
+    """An MDG holding a single Process whose steps touch ``app.py``."""
+    g = ModuleDependencyGraph(target_file="app.py")
+    g.add_node(
+        GraphNode(
+            id="proc_0_handler",
+            label="Process",
+            properties={
+                "id": "proc_0_handler",
+                "label": "Handler -> helper",
+                "processType": process_type,
+                "stepCount": step_count,
+                "communities": communities
+                if communities is not None
+                else ["'comm_1'", "'comm_2'", "'comm_3'"],
+                "entryPointId": step_symbol_ids[0],
+                "terminalId": step_symbol_ids[-1],
+            },
+        )
+    )
+    for sid in step_symbol_ids:
+        g.add_relationship(
+            GraphRelationship(
+                id=f"{sid}->proc_0_handler",
+                source_id=sid,
+                target_id="proc_0_handler",
+                type="STEP_IN_PROCESS",
+            )
+        )
+    return g
+
+
+def test_from_dep_graph_keeps_flows_touching_file():
+    g = _graph_with_process()
+    pfg = ProcessFlowGraph.from_dep_graph(g, "app.py")
+    assert len(pfg.flows) == 1
+    flow = pfg.flows[0]
+    assert flow.id == "proc_0_handler"
+    assert flow.step_count == 4
+    assert flow.process_type == "cross_community"
+    # Community ids are stripped of GitNexus's stray quotes.
+    assert flow.communities == ("comm_1", "comm_2", "comm_3")
+
+
+def test_flows_not_touching_file_are_dropped():
+    g = _graph_with_process(
+        step_symbol_ids=("Function:other.py:a", "Function:other.py:b")
+    )
+    pfg = ProcessFlowGraph.from_dep_graph(g, "app.py")
+    assert pfg.flows == ()
+
+
+def test_metrics_by_dimension():
+    g = _graph_with_process(step_count=9)
+    pfg = ProcessFlowGraph.from_dep_graph(g, "app.py", dimension="simple")
+    assert pfg.metrics() == {
+        "process.max_flow_length": 9.0,
+        "process.flow_participation": 1.0,
+    }
+    composable = pfg.for_dimension("composable")
+    assert composable.metrics() == {
+        "process.max_community_span": 3.0,
+        "process.cross_community_flows": 1.0,
+    }
+    secure = pfg.for_dimension("secure")
+    assert secure.metrics() == {"process.dangerous_flows": 0.0}
+
+
+def test_secure_detects_dangerous_step_on_flow():
+    g = _graph_with_process(
+        step_symbol_ids=("Function:app.py:handler", "Function:lib/run.py:eval")
+    )
+    pfg = ProcessFlowGraph.from_dep_graph(g, "app.py", dimension="secure")
+    assert pfg.metrics() == {"process.dangerous_flows": 1.0}
+
+
+def test_step_names_include_entry_and_terminal():
+    flow = ProcessFlow(
+        id="p",
+        label="x",
+        process_type="cross_community",
+        step_count=2,
+        communities=(),
+        entry_point_id="Function:a.py:start",
+        terminal_id="Function:b.py:finish",
+        step_symbol_ids=("Function:a.py:start", "Function:b.py:finish"),
+    )
+    assert set(flow.step_names()) == {"start", "finish"}
+
+
+def test_dispatcher_merges_process_into_secure_gate():
+    # A dangerous flow must flip the SECURE generator off even when the
+    # intra-file CPG metrics are clean.
+    raw = {
+        "cpg.dangerous_calls": 0.0,
+        "cpg.taint_flows": 0.0,
+        "process.dangerous_flows": 1.0,
+    }
+    decision = _score_secure_dim(raw, Priority.SECURE)
+    assert decision is not None
+    assert decision.achieved is False
+
+
+def test_dispatcher_merges_process_into_simple_gate():
+    # Clean CFG/AST but an over-long interprocedural flow fails SIMPLE.
+    raw = {
+        "cfg.cyclomatic": 1.0,
+        "ast.entropy": 0.5,
+        "ast.max_function_complexity": 1.0,
+        "process.max_flow_length": 999.0,
+    }
+    decision = _score_simple_dim(raw, Priority.SECURE)
+    assert decision is not None
+    assert decision.achieved is False
+
+
+def test_dispatcher_unaffected_without_process_metrics():
+    raw = {
+        "cpg.dangerous_calls": 0.0,
+        "cpg.taint_flows": 0.0,
+    }
+    decision = _score_secure_dim(raw, Priority.SECURE)
+    assert decision is not None
+    assert decision.achieved is True

--- a/topos/evaluation/characteristic_morphism.py
+++ b/topos/evaluation/characteristic_morphism.py
@@ -54,6 +54,9 @@ from topos.evaluation.policies import (
     ScoredDecision,
     build_omega,
     score_coupling,
+    score_process_composable,
+    score_process_secure,
+    score_process_simple,
     score_secure,
     score_simple,
 )
@@ -70,54 +73,106 @@ if TYPE_CHECKING:
 # ScoredDecision via the matching policy translator Φᵢ.
 
 
+def _merge_decisions(
+    base: ScoredDecision | None, extra: ScoredDecision | None
+) -> ScoredDecision | None:
+    """Conjoin two contributions to one dimension (AND achieved, min score).
+
+    Used to fold an interprocedural process-flow contribution into the
+    intrinsic (CFG / MDG / CPG) decision for the same generator. Either side
+    may be ``None`` (metric family absent).
+    """
+    if base is None:
+        return extra
+    if extra is None:
+        return base
+    return ScoredDecision(
+        score=min(base.score, extra.score),
+        achieved=base.achieved and extra.achieved,
+        interpretation={**base.interpretation, **extra.interpretation},
+    )
+
+
+def _score_process_simple_dim(raw: dict[str, float]) -> ScoredDecision | None:
+    if "process.max_flow_length" not in raw and "process.flow_participation" not in raw:
+        return None
+    return score_process_simple(
+        max_flow_length=raw.get("process.max_flow_length"),
+        flow_participation=raw.get("process.flow_participation"),
+    )
+
+
+def _score_process_composable_dim(raw: dict[str, float]) -> ScoredDecision | None:
+    if (
+        "process.max_community_span" not in raw
+        and "process.cross_community_flows" not in raw
+    ):
+        return None
+    return score_process_composable(
+        max_community_span=raw.get("process.max_community_span"),
+        cross_community_flows=raw.get("process.cross_community_flows"),
+    )
+
+
+def _score_process_secure_dim(raw: dict[str, float]) -> ScoredDecision | None:
+    if "process.dangerous_flows" not in raw:
+        return None
+    return score_process_secure(dangerous_flows=raw.get("process.dangerous_flows"))
+
+
 def _score_simple_dim(
     raw: dict[str, float], priority: Priority
 ) -> ScoredDecision | None:
     # The SIMPLE dimension is fed by both CFG (cyclomatic) and AST (entropy, max_func).
     # We pass all available metrics to score_simple; it handles the independent
     # thresholds.
+    base: ScoredDecision | None = None
     if (
-        "cfg.cyclomatic" not in raw
-        and "ast.entropy" not in raw
-        and "ast.max_function_complexity" not in raw
+        "cfg.cyclomatic" in raw
+        or "ast.entropy" in raw
+        or "ast.max_function_complexity" in raw
     ):
-        return None
+        base = score_simple(
+            cyclomatic=raw.get("cfg.cyclomatic"),
+            entropy=raw.get("ast.entropy"),
+            max_function_complexity=raw.get("ast.max_function_complexity"),
+            priority=priority,
+        )
 
-    return score_simple(
-        cyclomatic=raw.get("cfg.cyclomatic"),
-        entropy=raw.get("ast.entropy"),
-        max_function_complexity=raw.get("ast.max_function_complexity"),
-        priority=priority,
-    )
+    return _merge_decisions(base, _score_process_simple_dim(raw))
 
 
 def _score_composable_dim(
     raw: dict[str, float], priority: Priority
 ) -> ScoredDecision | None:
+    base: ScoredDecision | None = None
     if (
-        "mdg.instability" not in raw
-        and "mdg.fan_in" not in raw
-        and "mdg.fan_out" not in raw
+        "mdg.instability" in raw
+        or "mdg.fan_in" in raw
+        or "mdg.fan_out" in raw
     ):
-        return None
-    return score_coupling(
-        instability=raw.get("mdg.instability"),
-        fan_in=raw.get("mdg.fan_in"),
-        fan_out=raw.get("mdg.fan_out"),
-        priority=priority,
-    )
+        base = score_coupling(
+            instability=raw.get("mdg.instability"),
+            fan_in=raw.get("mdg.fan_in"),
+            fan_out=raw.get("mdg.fan_out"),
+            priority=priority,
+        )
+
+    return _merge_decisions(base, _score_process_composable_dim(raw))
 
 
 def _score_secure_dim(
     raw: dict[str, float], priority: Priority
 ) -> ScoredDecision | None:
-    if "cpg.dangerous_calls" not in raw and "cpg.taint_flows" not in raw:
-        return None
-    return score_secure(
-        dangerous_calls=raw.get("cpg.dangerous_calls", 0.0),
-        taint_flows=raw.get("cpg.taint_flows", 0.0),
-        priority=priority,
-    )
+    base: ScoredDecision | None = None
+    if "cpg.dangerous_calls" in raw or "cpg.taint_flows" in raw:
+        base = score_secure(
+            dangerous_calls=raw.get("cpg.dangerous_calls", 0.0),
+            taint_flows=raw.get("cpg.taint_flows", 0.0),
+            priority=priority,
+        )
+
+    return _merge_decisions(base, _score_process_secure_dim(raw))
 
 
 _DIMENSION_SCORE_DISPATCHERS: dict[

--- a/topos/evaluation/policies/__init__.py
+++ b/topos/evaluation/policies/__init__.py
@@ -23,6 +23,7 @@ from topos.evaluation.policies.calibration import (
     CLONE,
     COMPOSABLE,
     COVERAGE,
+    PROCESS,
     SCORE_FLOORS,
     SECURE,
     SIMPLE,
@@ -32,6 +33,11 @@ from topos.evaluation.policies.composable import score_coupling
 from topos.evaluation.policies.coverage import (
     CoverageDecision,
     score_declaration_coverage,
+)
+from topos.evaluation.policies.process import (
+    score_process_composable,
+    score_process_secure,
+    score_process_simple,
 )
 from topos.evaluation.policies.secure import score_secure
 from topos.evaluation.policies.simple import (
@@ -51,11 +57,15 @@ __all__ = [
     "score_simple",
     "score_coupling",
     "score_secure",
+    "score_process_simple",
+    "score_process_composable",
+    "score_process_secure",
     "describe_entropy_ratio",
     "build_omega",
     "SIMPLE",
     "COMPOSABLE",
     "SECURE",
+    "PROCESS",
     "COVERAGE",
     "CLONE",
     "SCORE_FLOORS",

--- a/topos/evaluation/policies/calibration.py
+++ b/topos/evaluation/policies/calibration.py
@@ -75,6 +75,35 @@ class SecurePolicyThresholds:
 
 
 @dataclass(frozen=True)
+class ProcessPolicyThresholds:
+    """Process-flow gates and normalization (GitNexus execution flows).
+
+    PROVISIONAL — not yet ECDF-calibrated against the PyPI corpus (unlike the
+    SIMPLE/COMPOSABLE/SECURE singletons). SECURE is zero-tolerance, mirroring
+    :class:`SecurePolicyThresholds`; the SIMPLE/COMPOSABLE axes use conservative
+    starting gates. See ``docs/process-flow-spike.md``.
+    """
+
+    # SIMPLE axis — interprocedural flow complexity. Gates (achieved).
+    max_flow_length: float = 25.0
+    max_flow_participation: float = 20.0
+    # SIMPLE normalization (score only).
+    max_flow_length_cap: float = 80.0
+    max_flow_participation_cap: float = 60.0
+
+    # COMPOSABLE axis — flow-level coupling. Gates (achieved).
+    max_community_span: float = 5.0
+    max_cross_community_flows: float = 15.0
+    # COMPOSABLE normalization (score only).
+    max_community_span_cap: float = 12.0
+    max_cross_community_flows_cap: float = 50.0
+
+    # SECURE axis — interprocedural reachability. Gate (achieved) + decay scale.
+    max_dangerous_flows: float = 0.0
+    dangerous_flow_scale: float = 3.0
+
+
+@dataclass(frozen=True)
 class CoveragePolicyThresholds:
     """Structural test-coverage policy (outside Ω)."""
 
@@ -94,6 +123,7 @@ class ClonePolicyThresholds:
 SIMPLE = SimplePolicyThresholds()
 COMPOSABLE = ComposablePolicyThresholds()
 SECURE = SecurePolicyThresholds()
+PROCESS = ProcessPolicyThresholds()
 COVERAGE = CoveragePolicyThresholds()
 CLONE = ClonePolicyThresholds()
 

--- a/topos/evaluation/policies/process.py
+++ b/topos/evaluation/policies/process.py
@@ -1,0 +1,147 @@
+"""
+Φ_PROCESS — policy translators for GitNexus execution-flow metrics.
+------------------------------------------------------------------
+
+GitNexus execution flows give an *interprocedural* lens on each pillar. Rather
+than introduce a fourth generator, these translators emit per-pillar
+:class:`~topos.evaluation.policies.base.ScoredDecision` contributions that the
+characteristic morphism **merges** into the existing SIMPLE / COMPOSABLE /
+SECURE decisions (``achieved`` AND-ed, ``score`` min-ed):
+
+    score_process_simple      → SIMPLE      (flow length / participation)
+    score_process_composable  → COMPOSABLE  (community span / crossings)
+    score_process_secure      → SECURE      (dangerous-step reachability)
+
+Every metric is optional; a translator with no metrics returns a vacuous
+"achieved" decision, so behavior is unchanged when no ``.gitnexus`` index is
+present. Thresholds live in
+:class:`~topos.evaluation.policies.calibration.ProcessPolicyThresholds`
+(provisional — see ``docs/process-flow-spike.md``).
+"""
+
+from __future__ import annotations
+
+from math import exp
+
+from topos.evaluation.policies.base import ScoredDecision
+from topos.evaluation.policies.calibration import PROCESS
+
+
+def score_process_simple(
+    max_flow_length: float | None = None,
+    flow_participation: float | None = None,
+) -> ScoredDecision:
+    """Φ_PROCESS·SIMPLE — interprocedural flow complexity."""
+    achieved = True
+    interp: dict[str, str] = {}
+    qualities: list[float] = []
+
+    if max_flow_length is not None:
+        qualities.append(1.0 - min(max_flow_length / PROCESS.max_flow_length_cap, 1.0))
+        if max_flow_length > PROCESS.max_flow_length:
+            achieved = False
+        interp["process.max_flow_length"] = _gate_interpretation(
+            "longest execution flow",
+            max_flow_length,
+            PROCESS.max_flow_length,
+            unit="steps",
+        )
+
+    if flow_participation is not None:
+        qualities.append(
+            1.0 - min(flow_participation / PROCESS.max_flow_participation_cap, 1.0)
+        )
+        if flow_participation > PROCESS.max_flow_participation:
+            achieved = False
+        interp["process.flow_participation"] = _gate_interpretation(
+            "execution flows through this file",
+            flow_participation,
+            PROCESS.max_flow_participation,
+            unit="flows",
+        )
+
+    return _decision(qualities, achieved, interp)
+
+
+def score_process_composable(
+    max_community_span: float | None = None,
+    cross_community_flows: float | None = None,
+) -> ScoredDecision:
+    """Φ_PROCESS·COMPOSABLE — flow-level coupling across communities."""
+    achieved = True
+    interp: dict[str, str] = {}
+    qualities: list[float] = []
+
+    if max_community_span is not None:
+        qualities.append(
+            1.0 - min(max_community_span / PROCESS.max_community_span_cap, 1.0)
+        )
+        if max_community_span > PROCESS.max_community_span:
+            achieved = False
+        interp["process.max_community_span"] = _gate_interpretation(
+            "communities spanned by a single flow",
+            max_community_span,
+            PROCESS.max_community_span,
+            unit="communities",
+        )
+
+    if cross_community_flows is not None:
+        qualities.append(
+            1.0
+            - min(cross_community_flows / PROCESS.max_cross_community_flows_cap, 1.0)
+        )
+        if cross_community_flows > PROCESS.max_cross_community_flows:
+            achieved = False
+        interp["process.cross_community_flows"] = _gate_interpretation(
+            "cross-community flows through this file",
+            cross_community_flows,
+            PROCESS.max_cross_community_flows,
+            unit="flows",
+        )
+
+    return _decision(qualities, achieved, interp)
+
+
+def score_process_secure(dangerous_flows: float | None = None) -> ScoredDecision:
+    """Φ_PROCESS·SECURE — dangerous-API reachability on an execution flow."""
+    achieved = True
+    interp: dict[str, str] = {}
+    qualities: list[float] = []
+
+    if dangerous_flows is not None:
+        qualities.append(exp(-max(dangerous_flows, 0.0) / PROCESS.dangerous_flow_scale))
+        if dangerous_flows > PROCESS.max_dangerous_flows:
+            achieved = False
+        if dangerous_flows <= PROCESS.max_dangerous_flows:
+            interp["process.dangerous_flows"] = (
+                f"no dangerous-API steps on any execution flow "
+                f"({dangerous_flows:.0f} <= {PROCESS.max_dangerous_flows:.0f})"
+            )
+        else:
+            interp["process.dangerous_flows"] = (
+                f"{int(dangerous_flows)} execution flow(s) reach a dangerous-API "
+                f"step (> {PROCESS.max_dangerous_flows:.0f})"
+            )
+
+    return _decision(qualities, achieved, interp)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _decision(
+    qualities: list[float], achieved: bool, interp: dict[str, str]
+) -> ScoredDecision:
+    if not qualities:
+        return ScoredDecision(score=1.0, achieved=True, interpretation={})
+    return ScoredDecision(
+        score=min(qualities), achieved=achieved, interpretation=interp
+    )
+
+
+def _gate_interpretation(label: str, raw: float, gate: float, *, unit: str) -> str:
+    if raw <= gate:
+        return f"{label} ({raw:.0f} {unit}) within threshold (<= {gate:.0f})"
+    return f"{label} ({raw:.0f} {unit}) exceeds threshold (> {gate:.0f})"

--- a/topos/functors/probes/process/__init__.py
+++ b/topos/functors/probes/process/__init__.py
@@ -1,0 +1,25 @@
+"""
+Process-flow probes.
+
+Pure measurements over GitNexus execution flows (``ProcessFlow``):
+interprocedural flow length / participation (SIMPLE), community span and
+cross-community flow counts (COMPOSABLE), and dangerous-step reachability
+(SECURE). See :mod:`topos.graphs.process.object` for the representation that
+calls these.
+"""
+
+from topos.functors.probes.process.flow import (
+    cross_community_flow_count,
+    dangerous_flow_count,
+    flow_participation,
+    max_community_span,
+    max_flow_length,
+)
+
+__all__ = [
+    "max_flow_length",
+    "flow_participation",
+    "max_community_span",
+    "cross_community_flow_count",
+    "dangerous_flow_count",
+]

--- a/topos/functors/probes/process/flow.py
+++ b/topos/functors/probes/process/flow.py
@@ -1,0 +1,62 @@
+"""
+Process-flow probes (ProcessFlow list -> ℝ).
+
+These measure GitNexus execution flows that touch a target file. They are the
+interprocedural counterpart to the intra-procedural CFG/CPG probes: where the
+CFG sees one function and the CPG sees one file, a *process* is a reconstructed
+call sequence that can span many functions and files.
+
+    SIMPLE      max_flow_length, flow_participation
+    COMPOSABLE  max_community_span, cross_community_flow_count
+    SECURE      dangerous_flow_count   (sink-on-flow reachability)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from topos.functors.probes.cpg.danger import DANGEROUS_APIS, _matches_registry
+
+if TYPE_CHECKING:
+    from topos.graphs.process.object import ProcessFlow
+
+
+def max_flow_length(flows: list[ProcessFlow]) -> int:
+    """Longest flow (number of steps) among the given flows; 0 if none."""
+    return max((f.step_count for f in flows), default=0)
+
+
+def flow_participation(flows: list[ProcessFlow]) -> int:
+    """Number of distinct flows the file participates in."""
+    return len(flows)
+
+
+def max_community_span(flows: list[ProcessFlow]) -> int:
+    """Most community boundaries crossed by any single flow; 0 if none."""
+    return max((len(f.communities) for f in flows), default=0)
+
+
+def cross_community_flow_count(flows: list[ProcessFlow]) -> int:
+    """Count of flows GitNexus classified as crossing community boundaries."""
+    return sum(1 for f in flows if f.process_type == "cross_community")
+
+
+def dangerous_flow_count(flows: list[ProcessFlow], language: str) -> int:
+    """
+    Count flows that contain at least one dangerous-API step.
+
+    A *dangerous step* is a flow step whose symbol name matches the
+    per-language dangerous-API registry (shared with the intra-file CPG danger
+    probe). Unlike that probe, this counts reachability along a reconstructed
+    interprocedural execution flow, not call sites within a single file.
+    """
+    registry = DANGEROUS_APIS.get(language, set())
+    if not registry:
+        return 0
+    return sum(1 for f in flows if _flow_has_dangerous_step(f, registry))
+
+
+def _flow_has_dangerous_step(flow: ProcessFlow, registry: set[str]) -> bool:
+    return any(
+        name and _matches_registry(name, registry) for name in flow.step_names()
+    )

--- a/topos/graphs/process/__init__.py
+++ b/topos/graphs/process/__init__.py
@@ -1,0 +1,16 @@
+"""
+Process-flow representation.
+
+Lifts GitNexus execution flows (``Process`` nodes + ``STEP_IN_PROCESS`` edges)
+into a :class:`~topos.graphs.base.Representation`. This is the interprocedural
+complement to the intra-procedural CFG/CPG and the module-level
+:class:`~topos.graphs.mdg.object.ModuleDependencyGraph`: it measures the
+*sequences* a program executes rather than the structure of any single unit.
+"""
+
+from topos.graphs.process.object import ProcessFlow, ProcessFlowGraph
+
+__all__ = [
+    "ProcessFlow",
+    "ProcessFlowGraph",
+]

--- a/topos/graphs/process/object.py
+++ b/topos/graphs/process/object.py
@@ -1,0 +1,219 @@
+"""
+Process-flow representation (GitNexus dynamic behavior).
+
+GitNexus reconstructs *execution flows* — ordered call sequences ("Processes")
+— from the static call graph and stores them in ``.gitnexus/lbug`` as
+``Process`` nodes joined to their steps by ``STEP_IN_PROCESS`` edges. This is
+the closest signal the index has to dynamic behavior: the interprocedural
+sequence a program runs, recovered without execution.
+
+This module lifts those flows into a :class:`~topos.graphs.base.Representation`.
+It is the **interprocedural** complement to the intra-procedural CFG/CPG and
+the module-level :class:`~topos.graphs.mdg.object.ModuleDependencyGraph`:
+
+    SIMPLE      flow length / participation   (complexity *between* functions)
+    COMPOSABLE  community span / crossings    (flow-level coupling)
+    SECURE      dangerous-step reachability   (sinks on a real execution flow)
+
+The flows are parsed from an already-loaded ``ModuleDependencyGraph`` (whose
+LadybugDB loader already reads every node and edge), so no second DB read is
+paid. A single ``Representation`` feeds one pillar; use
+:meth:`ProcessFlowGraph.for_dimension` to fan one parsed flow list out across
+SIMPLE / COMPOSABLE / SECURE.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from topos.graphs.mdg.object import ModuleDependencyGraph
+
+
+@dataclass(frozen=True)
+class ProcessFlow:
+    """One reconstructed execution flow that touches the target file.
+
+    Attributes:
+        id:             GitNexus process id (e.g. ``proc_0_curate_composable``).
+        label:          Human-readable flow label (``entry -> terminal``).
+        process_type:   GitNexus classification (e.g. ``cross_community``).
+        step_count:     Number of steps in the flow.
+        communities:    Community ids the flow spans.
+        entry_point_id: Symbol id of the flow's first step.
+        terminal_id:    Symbol id of the flow's last step.
+        step_symbol_ids: Symbol ids of every step in the flow.
+    """
+
+    id: str
+    label: str
+    process_type: str
+    step_count: int
+    communities: tuple[str, ...]
+    entry_point_id: str
+    terminal_id: str
+    step_symbol_ids: tuple[str, ...]
+
+    def step_names(self) -> list[str]:
+        """Bare symbol names for every step (and the entry/terminal symbols)."""
+        ids = {self.entry_point_id, self.terminal_id, *self.step_symbol_ids}
+        return [_name_from_symbol_id(sid) for sid in ids if sid]
+
+
+@dataclass
+class ProcessFlowGraph:
+    """Execution flows touching ``target_file``, as a ``Representation``.
+
+    One instance feeds a single pillar (``dimension_axis``). Build once with
+    :meth:`from_dep_graph`, then :meth:`for_dimension` to share the parsed flow
+    list across the three pillars.
+    """
+
+    target_file: str
+    flows: tuple[ProcessFlow, ...] = field(default_factory=tuple)
+    language: str = "python"
+    dimension_axis: str = "simple"
+
+    @property
+    def name(self) -> str:
+        return "process"
+
+    @property
+    def dimension(self) -> str:
+        return self.dimension_axis
+
+    # ------------------------------------------------------------------
+    # Construction
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_dep_graph(
+        cls,
+        graph: ModuleDependencyGraph,
+        target_file: str,
+        *,
+        language: str = "python",
+        dimension: str = "simple",
+    ) -> ProcessFlowGraph:
+        """Parse the flows touching ``target_file`` from a loaded MDG."""
+        flows: list[ProcessFlow] = []
+        for node in graph.nodes_of_label("Process"):
+            props = node.properties
+            step_ids = tuple(
+                rel.source_id for rel in graph.incoming(node.id, "STEP_IN_PROCESS")
+            )
+            entry = str(props.get("entryPointId", ""))
+            terminal = str(props.get("terminalId", ""))
+            flow = ProcessFlow(
+                id=node.id,
+                label=str(props.get("label") or props.get("heuristicLabel") or node.id),
+                process_type=str(props.get("processType", "")),
+                step_count=_as_int(props.get("stepCount"), default=len(step_ids)),
+                communities=_clean_communities(props.get("communities")),
+                entry_point_id=entry,
+                terminal_id=terminal,
+                step_symbol_ids=step_ids,
+            )
+            if _flow_touches_file(flow, target_file):
+                flows.append(flow)
+
+        return cls(
+            target_file=target_file,
+            flows=tuple(flows),
+            language=language,
+            dimension_axis=dimension,
+        )
+
+    def for_dimension(self, dimension: str) -> ProcessFlowGraph:
+        """Return a view of these flows scored on a different pillar."""
+        return replace(self, dimension_axis=dimension)
+
+    # ------------------------------------------------------------------
+    # Metrics
+    # ------------------------------------------------------------------
+
+    def metrics(self) -> dict[str, float]:
+        from topos.functors.probes.process.flow import (
+            cross_community_flow_count,
+            dangerous_flow_count,
+            flow_participation,
+            max_community_span,
+            max_flow_length,
+        )
+
+        flows = list(self.flows)
+        if self.dimension_axis == "simple":
+            return {
+                "process.max_flow_length": float(max_flow_length(flows)),
+                "process.flow_participation": float(flow_participation(flows)),
+            }
+        if self.dimension_axis == "composable":
+            return {
+                "process.max_community_span": float(max_community_span(flows)),
+                "process.cross_community_flows": float(
+                    cross_community_flow_count(flows)
+                ),
+            }
+        if self.dimension_axis == "secure":
+            return {
+                "process.dangerous_flows": float(
+                    dangerous_flow_count(flows, self.language)
+                ),
+            }
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# Symbol-id helpers
+# ---------------------------------------------------------------------------
+# GitNexus symbol ids embed the source path: "<Label>:<path>:<name>".
+
+
+def _path_from_symbol_id(symbol_id: str) -> str:
+    parts = symbol_id.split(":")
+    if len(parts) >= 3:
+        return ":".join(parts[1:-1])
+    return ""
+
+
+def _name_from_symbol_id(symbol_id: str) -> str:
+    if not symbol_id:
+        return ""
+    return symbol_id.rsplit(":", 1)[-1]
+
+
+def _paths_match(symbol_path: str, target_file: str) -> bool:
+    """Suffix-aware path match, mirroring ``ModuleDependencyGraph.file_node_id``."""
+    if not symbol_path:
+        return False
+    return (
+        symbol_path == target_file
+        or symbol_path.endswith(f"/{target_file}")
+        or target_file.endswith(f"/{symbol_path}")
+    )
+
+
+def _flow_touches_file(flow: ProcessFlow, target_file: str) -> bool:
+    candidate_ids = (flow.entry_point_id, flow.terminal_id, *flow.step_symbol_ids)
+    return any(
+        _paths_match(_path_from_symbol_id(sid), target_file) for sid in candidate_ids
+    )
+
+
+def _as_int(value: object, *, default: int) -> int:
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+
+
+def _clean_communities(value: object) -> tuple[str, ...]:
+    """Normalize the ``communities`` property into a tuple of bare ids.
+
+    GitNexus stores these as a list whose elements may carry stray quotes
+    (e.g. ``"'comm_87'"``); strip them so ids compare cleanly.
+    """
+    if not isinstance(value, (list, tuple)):
+        return ()
+    return tuple(str(item).strip().strip("'\"") for item in value if item)

--- a/topos/mcp/evaluation.py
+++ b/topos/mcp/evaluation.py
@@ -229,15 +229,42 @@ def _intrinsic_representations(
     return reps
 
 
+def _process_representations(
+    dep_graph: ModuleDependencyGraph, language: str
+) -> list[Representation]:
+    """Fan GitNexus execution flows out across the three pillars.
+
+    The flows are parsed once from the already-loaded ``ModuleDependencyGraph``
+    (no second LadybugDB read) and viewed on each pillar so SIMPLE / COMPOSABLE
+    / SECURE all receive interprocedural signal.
+    """
+    from topos.graphs.process.object import ProcessFlowGraph
+
+    base = ProcessFlowGraph.from_dep_graph(
+        dep_graph, dep_graph.target_file, language=language, dimension="simple"
+    )
+    return [
+        base,
+        base.for_dimension("composable"),
+        base.for_dimension("secure"),
+    ]
+
+
 def classify_morphism(
     morphism: ProgramMorphism,
     priority: Priority,
     dep_graph: ModuleDependencyGraph | None = None,
 ) -> ClassificationResult:
-    """Run the classifier with CFG/PDG/CPG plus an optional ModuleDependencyGraph."""
+    """Run the classifier with CFG/PDG/CPG plus optional GitNexus graphs.
+
+    When a ``ModuleDependencyGraph`` is supplied, its execution-flow
+    (``Process``) layer is also lifted into per-pillar ``ProcessFlowGraph``
+    representations for interprocedural SIMPLE / COMPOSABLE / SECURE signal.
+    """
     reps: list[Representation] = _intrinsic_representations(morphism)
     if dep_graph is not None:
         reps.append(dep_graph)
+        reps.extend(_process_representations(dep_graph, morphism.language))
     classifier = CharacteristicMorphism()
     return classifier.classify_detailed(
         morphism,


### PR DESCRIPTION
## Draft — DO NOT MERGE until calibrated via the Topos leaderboard

The per-pillar process thresholds (`ProcessPolicyThresholds`) are **provisional and not ECDF-calibrated**, unlike the PyPI-corpus-calibrated SIMPLE/COMPOSABLE/SECURE singletons. Until those gates are derived from the leaderboard corpus, the flow signal is load-bearing on an uncalibrated guess. Hold merge until calibration lands.

> Stacked on `78-update-command` (its base, not `main`) so the diff is only the two process-flow commits. Rebase onto `main` once that branch merges.

## Summary

Lifts GitNexus statically-reconstructed **execution flows** (`Process` nodes + `STEP_IN_PROCESS` edges) into a first-class `Representation`, and folds the interprocedural signal into the existing three pillars **without adding a fourth generator** — Omega stays the 8-element 3-cube. Each pillar simply gains one more AND conjunct: it must hold under both the intra-file lens and the flow lens.

When no `.gitnexus` index is present, no process rep is attached and behavior is unchanged (the translators return a vacuous `achieved=True`).

## New methods / surface

### `topos/graphs/process/object.py`
- `ProcessFlow` (frozen dataclass) — one parsed flow: id, label, `process_type`, `step_count`, `communities`, entry/terminal ids, ordered step symbol ids.
  - `ProcessFlow.step_names()` -> bare symbol names for every step.
- `ProcessFlowGraph` — implements the `Representation` protocol; one instance feeds one pillar.
  - `from_dep_graph(graph, target_file, *, language, dimension)` — parse flows touching `target_file` from an already-loaded `ModuleDependencyGraph` (no second LadybugDB read).
  - `for_dimension(dimension)` — share one parsed flow list across SIMPLE/COMPOSABLE/SECURE.
  - `metrics()` — pillar-specific raw metric dict (`process.*`).
  - helpers: `_path_from_symbol_id`, `_name_from_symbol_id`, `_paths_match`, `_flow_touches_file`, `_as_int`, `_clean_communities`.

### `topos/functors/probes/process/flow.py` (pure flow-list -> R probes)
- `max_flow_length`, `flow_participation` (SIMPLE)
- `max_community_span`, `cross_community_flow_count` (COMPOSABLE)
- `dangerous_flow_count` — sink-on-flow reachability via the shared danger registry (SECURE)

### `topos/evaluation/policies/process.py` (Phi_PROCESS translators)
- `score_process_simple(max_flow_length, flow_participation)`
- `score_process_composable(max_community_span, cross_community_flows)`
- `score_process_secure(dangerous_flows)`
- helpers: `_decision`, `_gate_interpretation`

### `topos/evaluation/characteristic_morphism.py` (merge into pillars)
- `_merge_decisions(base, extra)` — conjoin two contributions to one dimension: `achieved` AND-ed, `score` min-ed, `interpretation` unioned.
- `_score_process_simple_dim` / `_score_process_composable_dim` / `_score_process_secure_dim` — gate process metrics into the existing `_score_*_dim` dispatchers.

### `topos/evaluation/policies/calibration.py`
- `ProcessPolicyThresholds` + `PROCESS` singleton — **provisional** gates/caps (SECURE zero-tolerance; SIMPLE/COMPOSABLE conservative).

### `topos/mcp/evaluation.py`
- Attach the three process views whenever a `.gitnexus` index is present; behavior unchanged when absent.

## Per-pillar metrics (v1)

| Pillar | Metric key | Meaning |
| --- | --- | --- |
| SIMPLE | `process.max_flow_length` | longest flow (steps) anchored at the file |
| SIMPLE | `process.flow_participation` | number of flows the file participates in |
| COMPOSABLE | `process.max_community_span` | most community boundaries any flow crosses |
| COMPOSABLE | `process.cross_community_flows` | count of `cross_community` flows on the file |
| SECURE | `process.dangerous_flows` | flows whose steps include a dangerous-API symbol |

## Design note (static vs flow)

We deliberately keep the flow contribution as **one more AND conjunct per pillar** rather than a separate static/dynamic bin or a fourth generator. The agent can still target flows vs structure because `raw_metrics` and `interpretation` are namespaced (`process.*` vs `cfg.*`/`ast.*`/`mdg.*`/`cpg.*`). Open question for review: should the **uncalibrated** flow gate be load-bearing now, or advisory (non-gating via not merging into `achieved`) until leaderboard calibration?

## Open items
- [ ] **Calibration via Topos leaderboard** (blocks merge) — derive ECDF gates/caps for the three process axes.
- [ ] Ordered taint: use the `step` index for true source -> ... -> sink ordering (v1 only checks membership).
- [ ] Branching/depth metrics beyond raw step count.

## Tests
- `tests/functors/probes/process/test_process_flow.py`

See `docs/process-flow-spike.md` for the full schema, extraction shape, and lattice integration.


---

**Release note:** This is **not** targeted for the **v0.3.6** release. It stays in draft (calibration-blocked) and should land in a later cycle.
