### PR TITLE
Add cross-language entrypoint-module handling via evaluation.file_roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Cross-language **entrypoint-module** handling: import/export-only modules (`__init__.py`, `mod.rs`/`lib.rs`, `index.ts`/`index.tsx`, `index.js`/`index.mjs`/`index.cjs`, C++ headers) are recognized via the new `topos/evaluation/file_roles.py` and receive relaxed SIMPLE (low-entropy) and COMPOSABLE (high-instability with zero fan-in) gates, so trivial re-export hubs are not penalized. `file_roles` is a general home for file-role predicates (generated/vendored/test files can follow). ([#87](https://github.com/Krv-Labs/topos/pull/87), closes [#77](https://github.com/Krv-Labs/topos/issues/77))
 - **`topos update`** system command: channel-aware upgrades for binary installs (re-runs `install.sh` with checksum verification), PyPI installs (`uv pip` / `pip install -U topos-mcp`), and source checkouts (prints `git pull && uv pip install -e .`). Supports `--check` (exit 0 if current, 1 if outdated) and `--version` to pin a binary release. (closes [#78](https://github.com/Krv-Labs/topos/issues/78))
 - Passive update notices on interactive CLI use (at most once per 24h; skipped for `topos mcp`, CI, non-TTY, and when `TOPOS_NO_UPDATE_NOTICES=1` is set).
 - MCP edit-in-place assessment workflow for agents: snapshot and worktree-based assessment without pasting full source into tool calls. ([#76](https://github.com/Krv-Labs/topos/pull/76))

--- a/docs/source/api/evaluation.rst
+++ b/docs/source/api/evaluation.rst
@@ -3,12 +3,14 @@ Evaluation
 
 Evaluation modules turn structural measurements into Topos verdicts. Start here
 to understand quality policies, preference ordering, calibration, suppression,
-and the suggestions returned after a file or project is assessed.
+file-role detection, and the suggestions returned after a file or project is
+assessed.
 
 .. autosummary::
    :toctree: generated/evaluation
 
    topos.evaluation.characteristic_morphism
+   topos.evaluation.file_roles
    topos.evaluation.preferences
    topos.evaluation.suggestions
    topos.evaluation.suppression

--- a/tests/evaluation/test_calibration.py
+++ b/tests/evaluation/test_calibration.py
@@ -90,6 +90,17 @@ def test_simple_achieved_boundary_uses_calibration():
     )
 
 
+def test_simple_entrypoint_tolerates_low_entropy():
+    decision = score_simple(
+        cyclomatic=SIMPLE.max_cyclomatic - 5,
+        entropy=SIMPLE.min_entropy - 0.05,
+        max_function_complexity=SIMPLE.max_function_complexity - 5,
+        is_entrypoint_module=True,
+    )
+    assert decision.achieved is True
+    assert "entrypoint modules" in decision.interpretation["ast.entropy"]
+
+
 def test_secure_achieved_boundary_uses_calibration():
     assert score_secure(dangerous_calls=0, taint_flows=0).achieved is True
     assert (
@@ -141,3 +152,23 @@ def test_composable_achieved_boundary_uses_calibration():
         ).achieved
         is False
     )
+
+
+def test_composable_entrypoint_tolerates_high_instability_when_fan_in_zero():
+    decision = score_coupling(
+        instability=1.0,
+        fan_in=0.0,
+        fan_out=2.0,
+        is_entrypoint_module=True,
+    )
+    assert decision.achieved is True
+    assert "entrypoint modules" in decision.interpretation["mdg.instability"]
+
+
+def test_composable_high_instability_still_fails_without_entrypoint_flag():
+    decision = score_coupling(
+        instability=1.0,
+        fan_in=0.0,
+        fan_out=2.0,
+    )
+    assert decision.achieved is False

--- a/tests/graphs/test_graphs.py
+++ b/tests/graphs/test_graphs.py
@@ -317,7 +317,7 @@ def test_score_simple_dim_returns_none_on_missing_keys():
 
 
 def test_entrypoint_filename_hints_cover_supported_languages():
-    from topos.evaluation.characteristic_morphism import _entrypoint_filename_hint
+    from topos.evaluation.file_roles import _entrypoint_filename_hint
 
     assert _entrypoint_filename_hint(Path("__init__.py"), "python") is True
     assert _entrypoint_filename_hint(Path("mod.rs"), "rust") is True
@@ -328,7 +328,7 @@ def test_entrypoint_filename_hints_cover_supported_languages():
 
 
 def test_entrypoint_source_only_rejects_logic_for_entrypoint_files():
-    from topos.evaluation.characteristic_morphism import _is_entrypoint_source_only
+    from topos.evaluation.file_roles import _is_entrypoint_source_only
 
     assert _is_entrypoint_source_only("from .core import run\n", "python") is True
     assert (
@@ -336,6 +336,17 @@ def test_entrypoint_source_only_rejects_logic_for_entrypoint_files():
     )
     assert _is_entrypoint_source_only("export * from './a'\n", "typescript") is True
     assert _is_entrypoint_source_only("export const x = 1\n", "typescript") is False
+    assert (
+        _is_entrypoint_source_only("// re-export\nexport * from './a'\n", "typescript")
+        is True
+    )
+    assert (
+        _is_entrypoint_source_only("#pragma once\n#include <vector>\n", "cpp") is True
+    )
+    assert _is_entrypoint_source_only("#include <vector>\nint x;\n", "cpp") is False
+    assert (
+        _is_entrypoint_source_only("/// module\npub use crate::a;\n", "rust") is True
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/graphs/test_graphs.py
+++ b/tests/graphs/test_graphs.py
@@ -1,5 +1,7 @@
 """Tests for the graphs package."""
 
+from pathlib import Path
+
 from topos.core.object import ProgramObject
 from topos.graphs.ast.object import ASTRepresentation
 from topos.graphs.base import Representation
@@ -312,6 +314,26 @@ def test_score_simple_dim_returns_none_on_missing_keys():
 
     assert _score_simple_dim({}, Priority.SECURE) is None
     assert _score_simple_dim({"mdg.coupling": 3.0}, Priority.SECURE) is None
+
+
+def test_entrypoint_filename_hints_cover_supported_languages():
+    from topos.evaluation.characteristic_morphism import _entrypoint_filename_hint
+
+    assert _entrypoint_filename_hint(Path("__init__.py"), "python") is True
+    assert _entrypoint_filename_hint(Path("mod.rs"), "rust") is True
+    assert _entrypoint_filename_hint(Path("lib.rs"), "rust") is True
+    assert _entrypoint_filename_hint(Path("index.ts"), "typescript") is True
+    assert _entrypoint_filename_hint(Path("index.js"), "javascript") is True
+    assert _entrypoint_filename_hint(Path("something.cpp"), "cpp") is False
+
+
+def test_entrypoint_source_only_rejects_logic_for_entrypoint_files():
+    from topos.evaluation.characteristic_morphism import _is_entrypoint_source_only
+
+    assert _is_entrypoint_source_only("from .core import run\n", "python") is True
+    assert _is_entrypoint_source_only("from .core import run\nx = 1\n", "python") is False
+    assert _is_entrypoint_source_only("export * from './a'\n", "typescript") is True
+    assert _is_entrypoint_source_only("export const x = 1\n", "typescript") is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/graphs/test_graphs.py
+++ b/tests/graphs/test_graphs.py
@@ -331,7 +331,9 @@ def test_entrypoint_source_only_rejects_logic_for_entrypoint_files():
     from topos.evaluation.characteristic_morphism import _is_entrypoint_source_only
 
     assert _is_entrypoint_source_only("from .core import run\n", "python") is True
-    assert _is_entrypoint_source_only("from .core import run\nx = 1\n", "python") is False
+    assert (
+        _is_entrypoint_source_only("from .core import run\nx = 1\n", "python") is False
+    )
     assert _is_entrypoint_source_only("export * from './a'\n", "typescript") is True
     assert _is_entrypoint_source_only("export const x = 1\n", "typescript") is False
 

--- a/tests/graphs/test_graphs.py
+++ b/tests/graphs/test_graphs.py
@@ -344,9 +344,7 @@ def test_entrypoint_source_only_rejects_logic_for_entrypoint_files():
         _is_entrypoint_source_only("#pragma once\n#include <vector>\n", "cpp") is True
     )
     assert _is_entrypoint_source_only("#include <vector>\nint x;\n", "cpp") is False
-    assert (
-        _is_entrypoint_source_only("/// module\npub use crate::a;\n", "rust") is True
-    )
+    assert _is_entrypoint_source_only("/// module\npub use crate::a;\n", "rust") is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/graphs/test_graphs.py
+++ b/tests/graphs/test_graphs.py
@@ -334,6 +334,16 @@ def test_entrypoint_source_only_rejects_logic_for_entrypoint_files():
     assert (
         _is_entrypoint_source_only("from .core import run\nx = 1\n", "python") is False
     )
+    assert (
+        _is_entrypoint_source_only(
+            "from . import (\n    assess,\n    evaluate,\n)\n", "python"
+        )
+        is True
+    )
+    assert (
+        _is_entrypoint_source_only("from . import (\n    assess,\n)\nx = 1\n", "python")
+        is False
+    )
     assert _is_entrypoint_source_only("export * from './a'\n", "typescript") is True
     assert _is_entrypoint_source_only("export const x = 1\n", "typescript") is False
     assert (

--- a/topos/evaluation/characteristic_morphism.py
+++ b/topos/evaluation/characteristic_morphism.py
@@ -213,6 +213,7 @@ def _is_import_export_entrypoint(morphism: ProgramMorphism) -> bool:
         return False
     return _is_entrypoint_source_only(morphism.source, morphism.language)
 
+
 # Map each *dimension* name to the singleton generator value it produces
 # when satisfied.  These three generators are pairwise incomparable in ℋ.
 _DIMENSION_GENERATOR: dict[str, EvaluationValue] = {

--- a/topos/evaluation/characteristic_morphism.py
+++ b/topos/evaluation/characteristic_morphism.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from topos.core.omega import (
@@ -71,7 +72,9 @@ if TYPE_CHECKING:
 
 
 def _score_simple_dim(
-    raw: dict[str, float], priority: Priority
+    raw: dict[str, float],
+    priority: Priority,
+    is_entrypoint_module: bool = False,
 ) -> ScoredDecision | None:
     # The SIMPLE dimension is fed by both CFG (cyclomatic) and AST (entropy, max_func).
     # We pass all available metrics to score_simple; it handles the independent
@@ -87,12 +90,15 @@ def _score_simple_dim(
         cyclomatic=raw.get("cfg.cyclomatic"),
         entropy=raw.get("ast.entropy"),
         max_function_complexity=raw.get("ast.max_function_complexity"),
+        is_entrypoint_module=is_entrypoint_module,
         priority=priority,
     )
 
 
 def _score_composable_dim(
-    raw: dict[str, float], priority: Priority
+    raw: dict[str, float],
+    priority: Priority,
+    is_entrypoint_module: bool = False,
 ) -> ScoredDecision | None:
     if (
         "mdg.instability" not in raw
@@ -104,12 +110,15 @@ def _score_composable_dim(
         instability=raw.get("mdg.instability"),
         fan_in=raw.get("mdg.fan_in"),
         fan_out=raw.get("mdg.fan_out"),
+        is_entrypoint_module=is_entrypoint_module,
         priority=priority,
     )
 
 
 def _score_secure_dim(
-    raw: dict[str, float], priority: Priority
+    raw: dict[str, float],
+    priority: Priority,
+    is_entrypoint_module: bool = False,
 ) -> ScoredDecision | None:
     if "cpg.dangerous_calls" not in raw and "cpg.taint_flows" not in raw:
         return None
@@ -122,12 +131,87 @@ def _score_secure_dim(
 
 _DIMENSION_SCORE_DISPATCHERS: dict[
     str,
-    Callable[[dict[str, float], Priority], ScoredDecision | None],
+    Callable[[dict[str, float], Priority, bool], ScoredDecision | None],
 ] = {
     "simple": _score_simple_dim,
     "composable": _score_composable_dim,
     "secure": _score_secure_dim,
 }
+
+
+def _entrypoint_filename_hint(path: Path, language: str) -> bool:
+    filename = path.name
+    lower_name = filename.lower()
+    if language == "python":
+        return filename == "__init__.py"
+    if language == "rust":
+        return filename in {"mod.rs", "lib.rs"}
+    if language == "typescript":
+        return lower_name in {"index.ts", "index.tsx"}
+    if language == "javascript":
+        return lower_name in {"index.js", "index.mjs", "index.cjs"}
+    if language == "cpp":
+        return path.suffix.lower() in {".hpp", ".hh", ".hxx"}
+    return False
+
+
+def _is_entrypoint_source_only(source: str, language: str) -> bool:
+    lines = [line.strip() for line in source.splitlines()]
+    lines = [line for line in lines if line and not line.startswith("#")]
+    if not lines:
+        return False
+
+    if language == "python":
+        return all(
+            line.startswith("import ")
+            or line.startswith("from ")
+            or line.startswith("__all__")
+            or line in {"[", "]", "(", ")"}
+            or line.startswith(("'", '"'))
+            for line in lines
+        )
+    if language in {"typescript", "javascript"}:
+        return all(
+            line.startswith("import ")
+            or line.startswith("export *")
+            or line.startswith("export {")
+            or line.startswith("export type ")
+            or line.startswith("export interface ")
+            or line.startswith("/*")
+            or line.startswith("*")
+            or line.endswith("*/")
+            for line in lines
+        )
+    if language == "rust":
+        return all(
+            line.startswith("use ")
+            or line.startswith("pub use ")
+            or line.startswith("pub mod ")
+            or line.startswith("mod ")
+            or line.startswith("extern crate ")
+            or line.startswith("#!")
+            or line.startswith("#[")
+            for line in lines
+        )
+    if language == "cpp":
+        return all(
+            line.startswith("#include")
+            or line.startswith("#pragma once")
+            or line.startswith("//")
+            or line.startswith("/*")
+            or line.startswith("*")
+            or line.endswith("*/")
+            for line in lines
+        )
+    return False
+
+
+def _is_import_export_entrypoint(morphism: ProgramMorphism) -> bool:
+    if morphism.filepath is None:
+        return False
+    if not _entrypoint_filename_hint(morphism.filepath, morphism.language):
+        return False
+    return _is_entrypoint_source_only(morphism.source, morphism.language)
 
 # Map each *dimension* name to the singleton generator value it produces
 # when satisfied.  These three generators are pairwise incomparable in ℋ.
@@ -250,6 +334,7 @@ class CharacteristicMorphism:
         by_dimension: dict[str, list[Representation]] = defaultdict(list)
         for rep in all_reps:
             by_dimension[rep.dimension].append(rep)
+        is_entrypoint_module = _is_import_export_entrypoint(morphism)
 
         raw_metrics: dict[str, float] = {}
         interpretation: dict[str, str] = {}
@@ -266,7 +351,7 @@ class CharacteristicMorphism:
             if not scorer:
                 continue
 
-            decision = scorer(dim_raw, priority)
+            decision = scorer(dim_raw, priority, is_entrypoint_module)
             if decision is None:
                 continue
 

--- a/topos/evaluation/characteristic_morphism.py
+++ b/topos/evaluation/characteristic_morphism.py
@@ -42,7 +42,6 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from topos.core.omega import (
@@ -50,6 +49,7 @@ from topos.core.omega import (
     Omega,
     verdict_from_generators,
 )
+from topos.evaluation.file_roles import is_entrypoint_module
 from topos.evaluation.policies import (
     Priority,
     ScoredDecision,
@@ -137,81 +137,6 @@ _DIMENSION_SCORE_DISPATCHERS: dict[
     "composable": _score_composable_dim,
     "secure": _score_secure_dim,
 }
-
-
-def _entrypoint_filename_hint(path: Path, language: str) -> bool:
-    filename = path.name
-    lower_name = filename.lower()
-    if language == "python":
-        return filename == "__init__.py"
-    if language == "rust":
-        return filename in {"mod.rs", "lib.rs"}
-    if language == "typescript":
-        return lower_name in {"index.ts", "index.tsx"}
-    if language == "javascript":
-        return lower_name in {"index.js", "index.mjs", "index.cjs"}
-    if language == "cpp":
-        return path.suffix.lower() in {".hpp", ".hh", ".hxx"}
-    return False
-
-
-def _is_entrypoint_source_only(source: str, language: str) -> bool:
-    lines = [line.strip() for line in source.splitlines()]
-    lines = [line for line in lines if line and not line.startswith("#")]
-    if not lines:
-        return False
-
-    if language == "python":
-        return all(
-            line.startswith("import ")
-            or line.startswith("from ")
-            or line.startswith("__all__")
-            or line in {"[", "]", "(", ")"}
-            or line.startswith(("'", '"'))
-            for line in lines
-        )
-    if language in {"typescript", "javascript"}:
-        return all(
-            line.startswith("import ")
-            or line.startswith("export *")
-            or line.startswith("export {")
-            or line.startswith("export type ")
-            or line.startswith("export interface ")
-            or line.startswith("/*")
-            or line.startswith("*")
-            or line.endswith("*/")
-            for line in lines
-        )
-    if language == "rust":
-        return all(
-            line.startswith("use ")
-            or line.startswith("pub use ")
-            or line.startswith("pub mod ")
-            or line.startswith("mod ")
-            or line.startswith("extern crate ")
-            or line.startswith("#!")
-            or line.startswith("#[")
-            for line in lines
-        )
-    if language == "cpp":
-        return all(
-            line.startswith("#include")
-            or line.startswith("#pragma once")
-            or line.startswith("//")
-            or line.startswith("/*")
-            or line.startswith("*")
-            or line.endswith("*/")
-            for line in lines
-        )
-    return False
-
-
-def _is_import_export_entrypoint(morphism: ProgramMorphism) -> bool:
-    if morphism.filepath is None:
-        return False
-    if not _entrypoint_filename_hint(morphism.filepath, morphism.language):
-        return False
-    return _is_entrypoint_source_only(morphism.source, morphism.language)
 
 
 # Map each *dimension* name to the singleton generator value it produces
@@ -335,7 +260,7 @@ class CharacteristicMorphism:
         by_dimension: dict[str, list[Representation]] = defaultdict(list)
         for rep in all_reps:
             by_dimension[rep.dimension].append(rep)
-        is_entrypoint_module = _is_import_export_entrypoint(morphism)
+        is_entrypoint = is_entrypoint_module(morphism)
 
         raw_metrics: dict[str, float] = {}
         interpretation: dict[str, str] = {}
@@ -352,7 +277,7 @@ class CharacteristicMorphism:
             if not scorer:
                 continue
 
-            decision = scorer(dim_raw, priority, is_entrypoint_module)
+            decision = scorer(dim_raw, priority, is_entrypoint)
             if decision is None:
                 continue
 

--- a/topos/evaluation/file_roles.py
+++ b/topos/evaluation/file_roles.py
@@ -1,0 +1,106 @@
+"""
+File roles
+==========
+
+Predicates that classify what *role* a source file plays, so the
+characteristic morphism can relax or skip specific quality gates when a
+file is structurally special rather than ordinary logic.
+
+The first role is the **import/export-only entrypoint module** —
+``__init__.py``, ``mod.rs``/``lib.rs``, ``index.ts``, and friends — which
+are trivial re-export hubs and should not be penalized for low entropy or
+high instability.  Additional roles (generated code, vendored code, test
+files, …) can be added here as further predicates over the same
+:class:`~topos.core.morphism.ProgramMorphism`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from topos.core.morphism import ProgramMorphism
+
+
+def is_entrypoint_module(morphism: ProgramMorphism) -> bool:
+    """True iff *morphism* is an import/export-only entrypoint module."""
+    if morphism.filepath is None:
+        return False
+    if not _entrypoint_filename_hint(morphism.filepath, morphism.language):
+        return False
+    return _is_entrypoint_source_only(morphism.source, morphism.language)
+
+
+def _entrypoint_filename_hint(path: Path, language: str) -> bool:
+    filename = path.name
+    lower_name = filename.lower()
+    if language == "python":
+        return filename == "__init__.py"
+    if language == "rust":
+        return filename in {"mod.rs", "lib.rs"}
+    if language == "typescript":
+        return lower_name in {"index.ts", "index.tsx"}
+    if language == "javascript":
+        return lower_name in {"index.js", "index.mjs", "index.cjs"}
+    if language == "cpp":
+        return path.suffix.lower() in {".hpp", ".hh", ".hxx"}
+    return False
+
+
+def _is_entrypoint_source_only(source: str, language: str) -> bool:
+    lines = [line.strip() for line in source.splitlines()]
+    lines = [line for line in lines if line]
+    if not lines:
+        return False
+
+    if language == "python":
+        return all(
+            line.startswith("#")
+            or line.startswith("import ")
+            or line.startswith("from ")
+            or line.startswith("__all__")
+            or line in {"[", "]", "(", ")"}
+            or line.startswith(("'", '"'))
+            for line in lines
+        )
+    if language in {"typescript", "javascript"}:
+        return all(
+            line.startswith("import ")
+            or line.startswith("export *")
+            or line.startswith("export {")
+            or line.startswith("export type ")
+            or line.startswith("export interface ")
+            or line.startswith("//")
+            or line.startswith("#!")
+            or line.startswith("/*")
+            or line.startswith("*")
+            or line.endswith("*/")
+            for line in lines
+        )
+    if language == "rust":
+        return all(
+            line.startswith("use ")
+            or line.startswith("pub use ")
+            or line.startswith("pub mod ")
+            or line.startswith("mod ")
+            or line.startswith("extern crate ")
+            or line.startswith("#!")
+            or line.startswith("#[")
+            or line.startswith("//")
+            or line.startswith("/*")
+            or line.startswith("*")
+            or line.endswith("*/")
+            for line in lines
+        )
+    if language == "cpp":
+        return all(
+            line.startswith("#include")
+            or line.startswith("#pragma once")
+            or line.startswith("//")
+            or line.startswith("/*")
+            or line.startswith("*")
+            or line.endswith("*/")
+            for line in lines
+        )
+    return False

--- a/topos/evaluation/file_roles.py
+++ b/topos/evaluation/file_roles.py
@@ -55,15 +55,7 @@ def _is_entrypoint_source_only(source: str, language: str) -> bool:
         return False
 
     if language == "python":
-        return all(
-            line.startswith("#")
-            or line.startswith("import ")
-            or line.startswith("from ")
-            or line.startswith("__all__")
-            or line in {"[", "]", "(", ")"}
-            or line.startswith(("'", '"'))
-            for line in lines
-        )
+        return _python_entrypoint_only(lines)
     if language in {"typescript", "javascript"}:
         return all(
             line.startswith("import ")
@@ -104,3 +96,31 @@ def _is_entrypoint_source_only(source: str, language: str) -> bool:
             for line in lines
         )
     return False
+
+
+def _python_entrypoint_only(lines: list[str]) -> bool:
+    # Track open brackets so multiline ``from x import (...)`` and
+    # ``__all__ = [...]`` continuation lines (e.g. ``assess,``) are accepted.
+    depth = 0
+    for line in lines:
+        if depth > 0:
+            depth += _bracket_delta(line)
+            continue
+        if not (
+            line.startswith("#")
+            or line.startswith("import ")
+            or line.startswith("from ")
+            or line.startswith("__all__")
+            or line in {"[", "]", "(", ")"}
+            or line.startswith(("'", '"'))
+        ):
+            return False
+        if line.startswith(("import ", "from ", "__all__")):
+            depth += _bracket_delta(line)
+    return True
+
+
+def _bracket_delta(line: str) -> int:
+    opens = line.count("(") + line.count("[")
+    closes = line.count(")") + line.count("]")
+    return opens - closes

--- a/topos/evaluation/policies/composable.py
+++ b/topos/evaluation/policies/composable.py
@@ -34,6 +34,7 @@ def score_coupling(
     instability: float | None = None,
     fan_in: float | None = None,
     fan_out: float | None = None,
+    is_entrypoint_module: bool = False,
     priority: Priority = Priority.SECURE,
     threshold: float | None = None,
 ) -> ScoredDecision:
@@ -60,9 +61,17 @@ def score_coupling(
         quality = _instability_tent(instability)
         qualities.append(quality)
         low, high = COMPOSABLE.instability_low, COMPOSABLE.instability_high
-        if not (low <= instability <= high):
+        allow_entrypoint_instability = (
+            is_entrypoint_module and instability >= 0.95 and fan_in == 0.0
+        )
+        if not (low <= instability <= high) and not allow_entrypoint_instability:
             achieved = False
-        interp["mdg.instability"] = _instability_interpretation(instability, quality)
+        interp["mdg.instability"] = _instability_interpretation(
+            instability,
+            quality,
+            is_entrypoint_module=is_entrypoint_module,
+            allow_entrypoint_instability=allow_entrypoint_instability,
+        )
 
     # 2. Fan-In
     if fan_in is not None:
@@ -115,13 +124,24 @@ def _instability_tent(instability: float) -> float:
     return max(0.0, (1.0 - instability) / (1.0 - high))
 
 
-def _instability_interpretation(instability: float, quality: float) -> str:
+def _instability_interpretation(
+    instability: float,
+    quality: float,
+    *,
+    is_entrypoint_module: bool = False,
+    allow_entrypoint_instability: bool = False,
+) -> str:
     low = COMPOSABLE.instability_low
     high = COMPOSABLE.instability_high
     if low <= instability <= high:
         return f"instability ({instability:.2f}) within balanced range [{low}, {high}]"
     if instability < low:
         return f"instability ({instability:.2f}) is too low (module is too stable)"
+    if is_entrypoint_module and allow_entrypoint_instability:
+        return (
+            f"instability ({instability:.2f}) is high, but tolerated for "
+            "import/export-only entrypoint modules"
+        )
     return (
         f"instability ({instability:.2f}) is too high "
         "(module depends on too many things)"

--- a/topos/evaluation/policies/composable.py
+++ b/topos/evaluation/policies/composable.py
@@ -34,9 +34,10 @@ def score_coupling(
     instability: float | None = None,
     fan_in: float | None = None,
     fan_out: float | None = None,
-    is_entrypoint_module: bool = False,
     priority: Priority = Priority.SECURE,
     threshold: float | None = None,
+    *,
+    is_entrypoint_module: bool = False,
 ) -> ScoredDecision:
     """
     Φ_COMPOSABLE — score the COMPOSABLE generator using independent raw thresholds.
@@ -47,6 +48,8 @@ def score_coupling(
         fan_out:     Number of unique modules this module depends on.
         priority:    Retained for API compatibility; not read by this Φᵢ.
         threshold:   Retained for API compatibility; not read by this Φᵢ.
+        is_entrypoint_module: When True, tolerate high instability for
+            import/export-only entrypoint modules with zero fan-in.
 
     Returns:
         A ScoredDecision; ``achieved`` is the truth value of the COMPOSABLE

--- a/topos/evaluation/policies/simple.py
+++ b/topos/evaluation/policies/simple.py
@@ -28,9 +28,10 @@ def score_simple(
     cyclomatic: float | None = None,
     entropy: float | None = None,
     max_function_complexity: float | None = None,
-    is_entrypoint_module: bool = False,
     priority: Priority = Priority.SECURE,
     threshold: float | None = None,
+    *,
+    is_entrypoint_module: bool = False,
 ) -> ScoredDecision:
     """
     Φ_SIMPLE — score the SIMPLE generator using independent raw thresholds.
@@ -41,6 +42,8 @@ def score_simple(
         max_function_complexity: Maximum McCabe complexity of any single function.
         priority:   Retained for API compatibility; not read by this Φᵢ.
         threshold:  Retained for API compatibility; not read by this Φᵢ.
+        is_entrypoint_module: When True, tolerate low entropy for
+            import/export-only entrypoint modules.
 
     Returns:
         A ScoredDecision; ``achieved`` is the truth value of the SIMPLE

--- a/topos/evaluation/policies/simple.py
+++ b/topos/evaluation/policies/simple.py
@@ -28,6 +28,7 @@ def score_simple(
     cyclomatic: float | None = None,
     entropy: float | None = None,
     max_function_complexity: float | None = None,
+    is_entrypoint_module: bool = False,
     priority: Priority = Priority.SECURE,
     threshold: float | None = None,
 ) -> ScoredDecision:
@@ -61,9 +62,13 @@ def score_simple(
     if entropy is not None:
         quality = max(0.0, 1.0 - 2.0 * abs(entropy - SIMPLE.entropy_ideal))
         qualities.append(quality)
-        if not (SIMPLE.min_entropy <= entropy <= SIMPLE.max_entropy):
+        if not (SIMPLE.min_entropy <= entropy <= SIMPLE.max_entropy) and not (
+            is_entrypoint_module and entropy < SIMPLE.min_entropy
+        ):
             achieved = False
-        interp["ast.entropy"] = _entropy_interpretation(entropy, quality)
+        interp["ast.entropy"] = _entropy_interpretation(
+            entropy, quality, is_entrypoint_module=is_entrypoint_module
+        )
 
     # 3. AST Max Function Complexity
     if max_function_complexity is not None:
@@ -131,12 +136,19 @@ def _max_func_interpretation(raw: float, quality: float) -> str:
     )
 
 
-def _entropy_interpretation(entropy: float, quality: float) -> str:
+def _entropy_interpretation(
+    entropy: float, quality: float, *, is_entrypoint_module: bool = False
+) -> str:
     if SIMPLE.min_entropy <= entropy <= SIMPLE.max_entropy:
         return (
             f"entropy ({entropy:.2f}) within structured range "
             f"[{SIMPLE.min_entropy}, {SIMPLE.max_entropy}]"
         )
     if entropy < SIMPLE.min_entropy:
+        if is_entrypoint_module:
+            return (
+                f"entropy ({entropy:.2f}) is low, but tolerated for "
+                "import/export-only entrypoint modules"
+            )
         return f"entropy ({entropy:.2f}) is too low; code may be repetitive or trivial"
     return f"entropy ({entropy:.2f}) is too high; code may be unstructured"


### PR DESCRIPTION
## Summary
- Add cross-language **entrypoint module** detection (`__init__.py`, `mod.rs`/`lib.rs`, `index.ts`/`index.tsx`, `index.js`/`index.mjs`/`index.cjs`, C++ headers) behind a structural import/export-only source gate, so trivial re-export hubs are not penalized for low entropy / high instability.
- Thread an `is_entrypoint_module` context flag into SIMPLE and COMPOSABLE scoring so only the relevant entropy/instability edge cases are relaxed.
- Extract this logic into a new, general **`topos/evaluation/file_roles.py`** module — a home for predicates that classify what *role* a source file plays so the characteristic morphism can relax or skip specific quality gates. Entrypoint detection is the first role; generated / vendored / test-file detection can be added here as further predicates over the same `ProgramMorphism`. Public API: `is_entrypoint_module(morphism)`.

## Design note: `file_roles`
`characteristic_morphism.py` stays focused on the map `χ_S : P → Ω`. File-category heuristics now live in `file_roles.py`, keeping the classifier clean and giving future "special-case this kind of file" rules an obvious, single place to grow. This is distinct from `suppression.py`, which handles the SECURE allowlist / anti-gaming axis.

## Review fixes (addresses Copilot review)
- **Language-aware comments in `_is_entrypoint_source_only`**: removed the global `#`-line strip that dropped C++ `#include` / `#pragma once` and Rust `#!` / `#[` before the per-language check ran. Now Python allows `#`, TS/JS allow `//` and `#!` (shebang), and Rust allows `//` (`//`, `///`, `//!`) comments — so commented entrypoints are correctly recognized.
- **Keyword-only scoring flag**: `is_entrypoint_module` moved to a keyword-only parameter after `threshold` in `score_simple` and `score_coupling`, fixing a latent bug where a positional `priority` argument (e.g. in `tests/evaluation/test_logic.py`) was silently bound to the flag. Docstrings updated.
- **Regression tests**: added coverage for `//` comments in TS/JS entrypoints, `#include` / `#pragma once`-only C++ headers, and `///` doc comments in Rust entrypoints, plus a negative guard for C++ logic files.

## Test plan
- [x] `python -m pytest -o addopts='' -q tests/evaluation/test_calibration.py tests/evaluation/test_logic.py tests/graphs/test_graphs.py tests/functors/probes/mdg/test_pdg_metrics.py`
- [x] `python -c "import topos.evaluation.characteristic_morphism"` (clean import, no circular/unused-import issues)
- [x] `python -m pytest -o addopts='' tests/mcp/test_evaluate.py` (need fastmcp version bump in #90 if this fails locally)

Resolves #77.
