### PR TITLE
build(glama): release scaffolding + MCP tool-description quality pass

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,29 @@
+# Rust build artifacts
+target/
+
+# Python caches and virtualenvs
+.venv/
+venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+.ruff_cache/
+*.egg-info/
+build/
+dist/
+wheels/
+
+# Tests, docs, and local tooling not needed for the runtime build
+tests/
+docs/
+extensions/
+.git/
+.github/
+.gitnexus/
+.cursor/
+.claude/
+.agents/
+
+# Editor / OS cruft
+.DS_Store
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,58 @@
+# syntax=docker/dockerfile:1
+#
+# Topos MCP server — containerized build for Glama releases.
+#
+# The package is a maturin hybrid: a Rust pyo3 extension (topos-functors) plus
+# a Python package. The builder stage carries the Rust toolchain + maturin and
+# produces a self-contained wheel; the runtime stage installs that wheel and
+# adds Node.js + GitNexus so the COMPOSABLE pillar works in-container.
+#
+# Transport is stdio. Launch the server with the `topos-mcp` entrypoint.
+
+# ---- Builder: compile the pyo3 extension into a wheel -----------------------
+FROM python:3.12-slim AS builder
+
+ENV PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    CARGO_HOME=/usr/local/cargo \
+    RUSTUP_HOME=/usr/local/rustup \
+    PATH=/usr/local/cargo/bin:$PATH
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+        | sh -s -- -y --profile minimal --default-toolchain stable \
+    && pip install "maturin>=1.5,<2.0"
+
+WORKDIR /src
+COPY . .
+
+# maturin reads the version from Cargo.toml; build a release wheel into /wheels.
+RUN maturin build --release --features pyo3/extension-module --out /wheels
+
+# ---- Runtime: install the wheel + Node/GitNexus -----------------------------
+FROM python:3.12-slim AS runtime
+
+ENV PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+# Node.js 20 (NodeSource) for the GitNexus CLI, which powers COMPOSABLE scoring.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates git \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && npm install -g gitnexus \
+    && apt-get purge -y --auto-remove \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /wheels /wheels
+RUN pip install /wheels/*.whl && rm -rf /wheels
+
+# Trusted file-access root. Mount the repository to evaluate at /workspace, or
+# override with TOPOS_MCP_FILE_ROOT. Topos refuses to read files outside it.
+ENV TOPOS_MCP_FILE_ROOT=/workspace
+WORKDIR /workspace
+
+# stdio MCP server.
+ENTRYPOINT ["topos-mcp"]

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["jeremy-wayland", "sgathrid", "eigensoup"]
+}

--- a/tests/fixtures/binarytrees/test_binarytrees.py
+++ b/tests/fixtures/binarytrees/test_binarytrees.py
@@ -1,0 +1,16 @@
+from binarytrees import make_tree, check_tree, make_check, get_argchunks
+
+def test_make_tree():
+    t = make_tree(2)
+    assert t is not None
+
+def test_check_tree():
+    t = make_tree(2)
+    assert check_tree(t) == 7
+
+def test_make_check():
+    assert make_check((1, 2)) == 7
+
+def test_get_argchunks():
+    chunks = list(get_argchunks(5, 2, chunksize=2))
+    assert len(chunks) == 3

--- a/tests/mcp/test_evaluate.py
+++ b/tests/mcp/test_evaluate.py
@@ -445,8 +445,36 @@ def test_evaluate_project_rolls_up_files() -> None:
     assert r.files, "expected at least one per-file entry"
     assert r.aggregate_explanation
     assert r.guidance
+    assert r.language_rollups
     assert r.agent_contract is not None
     assert r.agent_contract.verification_gates
+
+
+def test_evaluate_project_auto_detects_supported_languages(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from topos.mcp import security
+
+    monkeypatch.setenv("TOPOS_MCP_FILE_ROOT", str(tmp_path))
+    security.reset_file_root_cache()
+    (tmp_path / "alpha.py").write_text("def alpha():\n    return 1\n", encoding="utf-8")
+    (tmp_path / "beta.rs").write_text(
+        "fn beta() -> i32 {\n    1\n}\n", encoding="utf-8"
+    )
+
+    r = _project(
+        asyncio.run(
+            topos_evaluate_project(
+                EvaluateProjectInput(path=".", limit=10, preferences=_PREFS),
+                _StubCtx(),
+            )
+        )
+    )
+
+    assert r.file_count == 2
+    assert any(entry.filepath.endswith(".rs") for entry in r.files)
+    assert any(rollup.language == "python" for rollup in r.language_rollups)
+    assert any(rollup.language == "rust" for rollup in r.language_rollups)
 
 
 def test_evaluate_project_paginates() -> None:
@@ -519,5 +547,5 @@ def test_evaluate_project_rejects_outside_root(tmp_path: Path) -> None:
             )
         )
     )
-    # Either refused (path outside root) or empty (no .py files).
+    # Either refused (path outside root) or empty (no supported source files).
     assert r.error is not None or r.file_count == 0

--- a/topos/mcp/schemas.py
+++ b/topos/mcp/schemas.py
@@ -873,7 +873,7 @@ class InspectionResult(BaseModel):
 
 
 class TopologicalCoverageResult(BaseModel):
-    """ECT-based topological semantic coverage (optional extra)."""
+    """ECT-based topological semantic coverage (Experimental optional extra)."""
 
     unavailable: bool = False
     reason: str | None = None

--- a/topos/mcp/schemas.py
+++ b/topos/mcp/schemas.py
@@ -208,14 +208,17 @@ class CompareCodeInput(_StrictModel):
 
     source_code: str = Field(..., min_length=1, description="Baseline code.")
     target_code: str = Field(..., min_length=1, description="Proposed/target code.")
-    language: str = Field(default="python")
+    language: str = Field(
+        default="python",
+        description="python, rust, javascript, typescript, or cpp.",
+    )
 
 
 class CompareFilesInput(_StrictModel):
     """Arguments for ``topos_compare_files``."""
 
     source: str = Field(..., min_length=1, description="Baseline file path.")
-    target: str = Field(..., min_length=1, description="Proposed file path.")
+    target: str = Field(..., min_length=1, description="Comparison file path.")
 
 
 class AssessImprovementInput(_StrictModel):
@@ -424,18 +427,12 @@ class CalculateCoverageInput(_StrictModel):
 
 
 class PreferenceWalkInput(_StrictModel):
-    """Arguments for ``topos_preference_walk``.
-
-    Convert a strict total order on the three generators into a
-    concrete relaxation walk on Ω — the sequence of verdicts an agent
-    should aim for, in descending order of preference.
-    """
+    """Arguments for ``topos_preference_walk``."""
 
     ranking: list[Generator] = Field(
         ...,
         description=(
-            "Permutation of {simple, composable, secure}, most-preferred "
-            "first.  Required — supply an explicit permutation (no implicit default)."
+            "Permutation of {simple, composable, secure}, most-preferred first."
         ),
         min_length=3,
         max_length=3,
@@ -443,20 +440,13 @@ class PreferenceWalkInput(_StrictModel):
     current: LatticeElement | None = Field(
         default=None,
         description=(
-            "Optional current verdict (e.g. from a previous "
-            "``topos_evaluate_file`` call).  When provided, the walk is "
-            "truncated to entries strictly above ``current`` in the "
-            "preference order, and ``next_step`` is the smallest "
-            "improvement to aim for next.  Defaults to no truncation."
+            "Optional current verdict; truncates the walk to steps strictly "
+            "above it and sets ``next_step``. Defaults to the full walk."
         ),
     )
     target: LatticeElement | None = Field(
         default=None,
-        description=(
-            "Optional override of the aspirational target.  Defaults to "
-            "``IDEAL``; callers who know IDEAL is unreachable can pin "
-            "the target lower."
-        ),
+        description="Optional aspirational-target override; defaults to IDEAL.",
     )
 
 
@@ -499,10 +489,7 @@ class PreferenceWalkResult(BaseModel):
     )
     fallback_target: LatticeElement = Field(
         ...,
-        description=(
-            "Where to divert if the aspirational target plateaus — the "
-            "meet of the top-two ranked generators."
-        ),
+        description="Divert target when the aspirational target plateaus.",
     )
     current: LatticeElement | None = Field(
         default=None,
@@ -511,8 +498,7 @@ class PreferenceWalkResult(BaseModel):
     next_step: LatticeElement | None = Field(
         default=None,
         description=(
-            "Smallest improvement above ``current``.  ``None`` when "
-            "already at or beyond the aspirational target."
+            "Smallest improvement above ``current``; null when at/beyond target."
         ),
     )
     progress: float = Field(
@@ -523,19 +509,11 @@ class PreferenceWalkResult(BaseModel):
     )
     walk: list[WalkStep] = Field(
         default_factory=list,
-        description=(
-            "Descending preference-ordered walk from the aspirational "
-            "target down to (but not including) ``current``.  Empty "
-            "when ``current`` is at or beyond target."
-        ),
+        description="Steps from the target down to just above ``current``.",
     )
     induced_order: list[WalkStep] = Field(
         default_factory=list,
-        description=(
-            "All 8 Ω elements ranked by descending preference.  Useful "
-            "for clients that want to render the full lattice in "
-            "user-preferred order rather than just the walk."
-        ),
+        description="All 8 verdicts ranked by descending preference.",
     )
     warnings: list[str] = Field(default_factory=list)
     error: str | None = None

--- a/topos/mcp/schemas.py
+++ b/topos/mcp/schemas.py
@@ -747,6 +747,19 @@ class ProjectFileEntry(BaseModel):
     is_parseable: bool = True
 
 
+class ProjectLanguageRollup(BaseModel):
+    """Per-language project rollup for polyglot directory evaluation."""
+
+    language: str
+    file_count: int
+    parse_failures: int = 0
+    rolled_up_dimensions: dict[str, LatticeElement] = Field(default_factory=dict)
+    rolled_up_scores: dict[str, float] = Field(default_factory=dict)
+    aggregate_floor_verdict: LatticeElement = LatticeElement.SLOP
+    worst_file_path: str | None = None
+    worst_file_verdict: LatticeElement | None = None
+
+
 class ProjectEvaluationResult(BaseModel):
     """Result of a directory-wide evaluation."""
 
@@ -756,6 +769,7 @@ class ProjectEvaluationResult(BaseModel):
     rolled_up_dimensions: dict[str, LatticeElement]
     rolled_up_scores: dict[str, float]
     aggregate_floor_verdict: LatticeElement
+    language_rollups: list[ProjectLanguageRollup] = Field(default_factory=list)
     aggregate_explanation: str
     worst_file_verdict: LatticeElement | None = None
     worst_files: list[ProjectFileEntry] = Field(default_factory=list)

--- a/topos/mcp/tools/assess/core.py
+++ b/topos/mcp/tools/assess/core.py
@@ -188,12 +188,13 @@ def _calculate_deltas(
     annotations=_READ_ONLY_ANN,
 )
 def topos_assess_improvement(params: AssessImprovementInput) -> ToolResult:
-    """Compare a baseline to a side-by-side proposed variant.
+    """Compare a baseline to a side-by-side proposed variant (read-only).
 
     For normal edit-in-place loops, use ``topos_assess_worktree_change`` or
     snapshot first with ``topos_begin_refactor`` then ``topos_assess_snapshot``.
     This tool is for variants supplied as ``proposed_code`` or
-    ``proposed_filepath``.
+    ``proposed_filepath``. Read-only; returns an AssessmentResult with
+    ``status`` and score/metric deltas.
     """
     priority, priority_source = resolve_priority(params.preferences)
     try:

--- a/topos/mcp/tools/compare.py
+++ b/topos/mcp/tools/compare.py
@@ -47,11 +47,15 @@ def _failed_comparison(
     annotations=_READ_ONLY_ANN,
 )
 def topos_compare_code(params: CompareCodeInput) -> ToolResult:
-    """Compute AST edit distance between two source strings.
+    """Compute the AST (tree-edit) distance between two source-code strings.
 
-    Returns normalized distance in [0, 1] and a similarity score (1 - distance).
-    Useful for clone checks and independent refactor-impact inspection.
-    Assessment tools already include anti-gaming distance checks.
+    Read-only and idempotent; parses both snippets in memory, never writes or
+    scores. Use for clone detection or to measure refactor impact; the
+    ``topos_assess_*`` tools already fold this in as an anti-gaming check, so
+    call it directly only for the raw number. Returns a ComparisonResult:
+    ``normalized_distance`` in [0, 1], ``similarity`` (= 1 - it),
+    ``raw_distance``, an ``operations`` edit-count map, and
+    ``source_valid``/``target_valid`` (``error`` set if either fails to parse).
     """
     try:
         src = ProgramMorphism(source=params.source_code, language=params.language)
@@ -86,7 +90,15 @@ def topos_compare_code(params: CompareCodeInput) -> ToolResult:
     annotations=_READ_ONLY_ANN,
 )
 def topos_compare_files(params: CompareFilesInput) -> ToolResult:
-    """AST distance between two files on disk."""
+    """Compute the AST (tree-edit) distance between two source files on disk.
+
+    Read-only; parses both files, never writes or scores. Use for clone
+    detection or refactor impact; use ``topos_assess_*`` for a quality verdict.
+    Returns a ComparisonResult: ``normalized_distance`` in [0, 1],
+    ``similarity`` (= 1 - it), ``raw_distance``, an ``operations`` edit-count
+    map, and ``source_valid``/``target_valid`` (``error`` set on read/parse
+    failure).
+    """
     source_text, source_err = read_safe_utf8_file(params.source)
     if source_err:
         model = _failed_comparison(

--- a/topos/mcp/tools/coverage.py
+++ b/topos/mcp/tools/coverage.py
@@ -167,14 +167,13 @@ def _parse_roots(
     annotations=_READ_ONLY_ANN,
 )
 def topos_calculate_coverage(params: CalculateCoverageInput) -> ToolResult:
-    """Measure structural test coverage of program-under-test files against tests.
+    """Measure structural (UAST) and semantic (topological ECT) test coverage.
 
-    Read-only; a standalone signal OUTSIDE the quality lattice (never changes a
-    medal). Uses UAST kind histograms, statement/expression recall, and k-gram
-    path recall; with the ``ect-coverage`` extra it also returns topological ECT
-    coverage. Returns a CoverageResult: ``mean_declaration_coverage`` in [0, 1],
-    recall metrics, ``f2_score``, ``uncovered_declarations``, and optional
-    ``topological_coverage``.
+    Read-only standalone signal (outside the quality lattice). Calculates UAST
+    bipartite declaration matching and k-gram path recall.
+
+    ⚠️ AGENTS: Optional ECT semantic coverage is experimental and 100x-1000x slower
+    than structural coverage. Use selectively on small files to prevent timeouts.
     """
     warnings: list[str] = []
     put_roots, err_model = _parse_roots(
@@ -259,10 +258,17 @@ def _render_uncovered(r: CoverageResult) -> list[str]:
 
 
 def _render_topological_coverage(topo) -> list[str]:
-    lines = ["", "## Topological CPG Semantic Coverage (ECT)"]
+    lines = ["", "## 🧪 Topological CPG Semantic Coverage (ECT - Experimental)"]
     if topo.unavailable:
         lines.append(f"> Topological coverage unavailable: {topo.reason}")
     elif topo.coverage_score is not None:
+        lines.append(
+            "> ⚠️ **Experimental Warning:** ECT Semantic Coverage is an "
+            "experimental metric under method development. It uses deep learning "
+            "node embeddings and topological sweeps which can result in large "
+            "runtimes (100x to 1000x slower than structural coverage) on larger "
+            "files."
+        )
         lines.append(f"- **Coverage score:** {topo.coverage_score:.4f}")
         if topo.distance is not None:
             lines.append(f"- **ECT distance:** {topo.distance:.4f}")

--- a/topos/mcp/tools/coverage.py
+++ b/topos/mcp/tools/coverage.py
@@ -167,12 +167,14 @@ def _parse_roots(
     annotations=_READ_ONLY_ANN,
 )
 def topos_calculate_coverage(params: CalculateCoverageInput) -> ToolResult:
-    """Calculate structural test coverage (v2) for a set of PUT and test files.
+    """Measure structural test coverage of program-under-test files against tests.
 
-    Uses UAST kind histograms, statement/expression recall, and k-gram path
-    recall scoped to declarations. When the ``ect-coverage`` optional extra
-    is installed, also returns topological ECT semantic coverage from CPG
-    node embeddings.
+    Read-only; a standalone signal OUTSIDE the quality lattice (never changes a
+    medal). Uses UAST kind histograms, statement/expression recall, and k-gram
+    path recall; with the ``ect-coverage`` extra it also returns topological ECT
+    coverage. Returns a CoverageResult: ``mean_declaration_coverage`` in [0, 1],
+    recall metrics, ``f2_score``, ``uncovered_declarations``, and optional
+    ``topological_coverage``.
     """
     warnings: list[str] = []
     put_roots, err_model = _parse_roots(

--- a/topos/mcp/tools/evaluate/core.py
+++ b/topos/mcp/tools/evaluate/core.py
@@ -70,6 +70,9 @@ def topos_evaluate_code(params: EvaluateCodeInput) -> ToolResult:
         SIMPLE / COMPOSABLE / SECURE     One generator satisfied.
         SIMPLE_COMPOSABLE / SIMPLE_SECURE / COMPOSABLE_SECURE  Two satisfied.
         IDEAL (⊤)            All three generators satisfied.
+
+    Read-only. Use for a snippet not yet on disk; switch to
+    ``topos_evaluate_file`` for COMPOSABLE. Returns an EvaluationResult.
     """
     try:
         priority, priority_source = resolve_priority(params.preferences)
@@ -124,6 +127,9 @@ def topos_evaluate_file(params: EvaluateFileInput) -> ToolResult:
 
     Generate a ``.gitnexus/`` directory with ``topos depgraph generate`` first
     (requires ``npm install -g gitnexus``).
+
+    Read-only. ``coupling_available`` is false when no dependency graph was
+    found, making any COMPOSABLE verdict unreachable.
     """
     resolved, err = resolve_within_root(params.filepath)
     if err or resolved is None:

--- a/topos/mcp/tools/evaluate/project.py
+++ b/topos/mcp/tools/evaluate/project.py
@@ -185,11 +185,12 @@ async def _evaluate_project_files_loop(
 async def topos_evaluate_project(
     params: EvaluateProjectInput, ctx: Context
 ) -> ToolResult:
-    """Recursively evaluate every Python file in a directory.
+    """Recursively evaluate every Python file in a directory (read-only).
 
     Reports progress to the client via ``ctx.report_progress`` so the UI shows
     a live bar during long walks. Rolls up per-dimension scores using the
-    project-wide minimum (``CharacteristicMorphism.combine_dimensions``).
+    project-wide minimum (``CharacteristicMorphism.combine_dimensions``), so the
+    weakest file floors the verdict.
 
     Returns a paginated per-file table plus the overall rollup. Use ``limit``
     / ``offset`` to page through large codebases.

--- a/topos/mcp/tools/evaluate/project.py
+++ b/topos/mcp/tools/evaluate/project.py
@@ -4,6 +4,7 @@ Evaluation tool: whole project.
 
 from __future__ import annotations
 
+from collections import defaultdict
 from dataclasses import replace
 from pathlib import Path
 
@@ -16,11 +17,13 @@ from topos.evaluation.characteristic_morphism import (
     ClassificationResult,
 )
 from topos.evaluation.policies.base import Priority
+from topos.graphs.ast.dispatch import LANGUAGE_FILE_SUFFIXES
 from topos.utils.discovery import collect_source_files
 
 from ...diagnostics import overlay_for_file
 from ...evaluation import (
     classify_file,
+    detect_language,
     gitnexus_warnings,
     resolve_gitnexus_dir,
 )
@@ -36,6 +39,7 @@ from ...schemas import (
     PrioritySource,
     ProjectEvaluationResult,
     ProjectFileEntry,
+    ProjectLanguageRollup,
     resolve_priority,
 )
 from ...security import resolve_file_root, resolve_within_root
@@ -49,6 +53,16 @@ _READ_ONLY_ANN = {
     "idempotentHint": True,
     "openWorldHint": False,
 }
+
+_SUPPORTED_SOURCE_SUFFIXES = tuple(
+    sorted(
+        {
+            suffix
+            for suffixes in LANGUAGE_FILE_SUFFIXES.values()
+            for suffix in suffixes
+        }
+    )
+)
 
 
 def _adjusted_result(result: ClassificationResult, overlay):
@@ -127,33 +141,45 @@ def _validate_and_collect_project(
     if not resolved_root.is_dir():
         return None, None, f"Path is not a directory: {resolved_root}"
 
-    py_files = collect_source_files(
+    source_files = collect_source_files(
         (str(resolved_root),),
-        suffixes=(".py",),
+        suffixes=_SUPPORTED_SOURCE_SUFFIXES,
         recursive=True,
     )
-    if not py_files:
-        return None, None, "No .py files found."
+    if not source_files:
+        return None, None, "No supported source files found."
 
-    return resolved_root, py_files, None
+    return resolved_root, source_files, None
 
 
 async def _evaluate_project_files_loop(
-    py_files: list[Path],
+    source_files: list[Path],
     resolved_root: Path,
     priority: Priority,
     gitnexus_dir: Path | None,
     include_security_findings: bool,
     allows: list[str],
     ctx: Context,
-) -> tuple[list[ClassificationResult], list[ProjectFileEntry], int, bool]:
-    total_files = len(py_files)
+) -> tuple[
+    list[ClassificationResult],
+    list[ProjectFileEntry],
+    int,
+    bool,
+    dict[str, list[ClassificationResult]],
+    dict[str, list[ProjectFileEntry]],
+    dict[str, int],
+]:
+    total_files = len(source_files)
     per_file_results = []
     entries: list[ProjectFileEntry] = []
     parse_failures = 0
     any_dep_graph_loaded = False
+    per_language_results: dict[str, list[ClassificationResult]] = defaultdict(list)
+    per_language_entries: dict[str, list[ProjectFileEntry]] = defaultdict(list)
+    per_language_parse_failures: dict[str, int] = defaultdict(int)
 
-    for idx, path in enumerate(py_files, start=1):
+    for idx, path in enumerate(source_files, start=1):
+        language = detect_language(path)
         result, entry, failed, has_dep = _evaluate_single_file(
             path,
             resolved_root,
@@ -164,17 +190,29 @@ async def _evaluate_project_files_loop(
         )
         if failed:
             parse_failures += 1
+            per_language_parse_failures[language] += 1
         if result is None or entry is None:
             continue
         any_dep_graph_loaded = any_dep_graph_loaded or has_dep
         if not result.is_parseable:
             parse_failures += 1
+            per_language_parse_failures[language] += 1
         per_file_results.append(result)
         entries.append(entry)
+        per_language_results[language].append(result)
+        per_language_entries[language].append(entry)
         if idx % max(1, total_files // 20) == 0 or idx == total_files:
             await ctx.report_progress(progress=idx, total=total_files)
 
-    return per_file_results, entries, parse_failures, any_dep_graph_loaded
+    return (
+        per_file_results,
+        entries,
+        parse_failures,
+        any_dep_graph_loaded,
+        dict(per_language_results),
+        dict(per_language_entries),
+        dict(per_language_parse_failures),
+    )
 
 
 @mcp.tool(
@@ -185,7 +223,7 @@ async def _evaluate_project_files_loop(
 async def topos_evaluate_project(
     params: EvaluateProjectInput, ctx: Context
 ) -> ToolResult:
-    """Recursively evaluate every Python file in a directory (read-only).
+    """Recursively evaluate supported source files in a directory (read-only).
 
     Reports progress to the client via ``ctx.report_progress`` so the UI shows
     a live bar during long walks. Rolls up per-dimension scores using the
@@ -195,8 +233,8 @@ async def topos_evaluate_project(
     Returns a paginated per-file table plus the overall rollup. Use ``limit``
     / ``offset`` to page through large codebases.
     """
-    resolved_root, py_files, err_msg = _validate_and_collect_project(params)
-    if err_msg or resolved_root is None or py_files is None:
+    resolved_root, source_files, err_msg = _validate_and_collect_project(params)
+    if err_msg or resolved_root is None or source_files is None:
         model = _empty_project_result(params, error=err_msg)
         return to_tool_result(model, render_project_md(model))
 
@@ -210,8 +248,11 @@ async def topos_evaluate_project(
         entries,
         parse_failures,
         any_dep_graph_loaded,
+        per_language_results,
+        per_language_entries,
+        per_language_parse_failures,
     ) = await _evaluate_project_files_loop(
-        py_files,
+        source_files,
         resolved_root,
         priority,
         gitnexus_dir,
@@ -222,11 +263,14 @@ async def topos_evaluate_project(
 
     model = _build_project_result(
         resolved_root,
-        py_files,
+        source_files,
         parse_failures,
         per_file_results,
         entries,
         any_dep_graph_loaded,
+        per_language_results,
+        per_language_entries,
+        per_language_parse_failures,
         params,
         priority,
         priority_source,
@@ -239,11 +283,14 @@ async def topos_evaluate_project(
 
 def _build_project_result(
     resolved_root: Path,
-    py_files: list[Path],
+    source_files: list[Path],
     parse_failures: int,
     per_file_results: list[ClassificationResult],
     entries: list[ProjectFileEntry],
     any_dep_graph_loaded: bool,
+    per_language_results: dict[str, list[ClassificationResult]],
+    per_language_entries: dict[str, list[ProjectFileEntry]],
+    per_language_parse_failures: dict[str, int],
     params: EvaluateProjectInput,
     priority: Priority,
     priority_source: PrioritySource,
@@ -254,21 +301,15 @@ def _build_project_result(
     classifier = CharacteristicMorphism()
     rolled = classifier.combine_dimensions(per_file_results)
     rolled_scores = _minimum_scores_by_dim(per_file_results)
+    language_rollups = _build_language_rollups(
+        per_language_results,
+        per_language_entries,
+        per_language_parse_failures,
+    )
 
     # Combine the three rolled-up generator verdicts into a single ℋ
     # element via the free-algebra encoding.
-    from topos.core.omega import (
-        EvaluationValue,
-        verdict_from_generators,
-    )
-
-    simple_ok = rolled.get("simple") == EvaluationValue.SIMPLE
-    composable_ok = rolled.get("composable") == EvaluationValue.COMPOSABLE
-    secure_ok = rolled.get("secure") == EvaluationValue.SECURE
-    overall_value = verdict_from_generators(
-        simple=simple_ok, composable=composable_ok, secure=secure_ok
-    )
-    overall = lattice_to_str(overall_value)
+    overall = _aggregate_floor_verdict(rolled)
     aggregate_explanation = _aggregate_explanation(rolled, rolled_scores, entries)
 
     # Sort entries: lowest overall score first (worst files surfaced).
@@ -299,11 +340,12 @@ def _build_project_result(
 
     return ProjectEvaluationResult(
         root=str(resolved_root),
-        file_count=len(py_files),
+        file_count=len(source_files),
         parse_failures=parse_failures,
         rolled_up_dimensions={dim: lattice_to_str(val) for dim, val in rolled.items()},
         rolled_up_scores=rolled_scores,
         aggregate_floor_verdict=overall,
+        language_rollups=language_rollups,
         aggregate_explanation=aggregate_explanation,
         worst_file_verdict=worst_file_verdict,
         worst_files=worst_files,
@@ -336,6 +378,52 @@ def _minimum_scores_by_dim(results) -> dict[str, float]:
             if dim not in min_scores or s < min_scores[dim]:
                 min_scores[dim] = s
     return {dim: round(s * 100.0, 1) for dim, s in min_scores.items()}
+
+
+def _aggregate_floor_verdict(rolled: dict[str, object]) -> LatticeElement:
+    from topos.core.omega import verdict_from_generators
+
+    simple_ok = rolled.get("simple") == EvaluationValue.SIMPLE
+    composable_ok = rolled.get("composable") == EvaluationValue.COMPOSABLE
+    secure_ok = rolled.get("secure") == EvaluationValue.SECURE
+    return lattice_to_str(
+        verdict_from_generators(
+            simple=simple_ok, composable=composable_ok, secure=secure_ok
+        )
+    )
+
+
+def _build_language_rollups(
+    per_language_results: dict[str, list[ClassificationResult]],
+    per_language_entries: dict[str, list[ProjectFileEntry]],
+    per_language_parse_failures: dict[str, int],
+) -> list[ProjectLanguageRollup]:
+    classifier = CharacteristicMorphism()
+    rollups: list[ProjectLanguageRollup] = []
+    for language in sorted(per_language_results):
+        results = per_language_results[language]
+        rolled = classifier.combine_dimensions(results)
+        rolled_scores = _minimum_scores_by_dim(results)
+        entries = sorted(
+            per_language_entries.get(language, []),
+            key=lambda e: min(e.scores.values()) if e.scores else 0.0,
+        )
+        worst = entries[0] if entries else None
+        rollups.append(
+            ProjectLanguageRollup(
+                language=language,
+                file_count=len(entries),
+                parse_failures=per_language_parse_failures.get(language, 0),
+                rolled_up_dimensions={
+                    dim: lattice_to_str(val) for dim, val in rolled.items()
+                },
+                rolled_up_scores=rolled_scores,
+                aggregate_floor_verdict=_aggregate_floor_verdict(rolled),
+                worst_file_path=worst.filepath if worst else None,
+                worst_file_verdict=worst.lattice_element if worst else None,
+            )
+        )
+    return rollups
 
 
 def _empty_project_result(

--- a/topos/mcp/tools/evaluate/render.py
+++ b/topos/mcp/tools/evaluate/render.py
@@ -42,6 +42,20 @@ def render_project_md(r: ProjectEvaluationResult) -> str:
         lines.append(
             f"- **{dim}**: {val.value}" + (f" ({s:.1f}%)" if s is not None else "")
         )
+    if r.language_rollups:
+        lines.append("")
+        lines.append("## Per-language rollups")
+        for rollup in r.language_rollups:
+            lines.append(
+                f"- **{rollup.language}**: {rollup.aggregate_floor_verdict.value} "
+                f"(files={rollup.file_count}, parse_failures={rollup.parse_failures})"
+            )
+            if rollup.worst_file_path and rollup.worst_file_verdict:
+                lines.append(
+                    "  "
+                    f"- worst: `{rollup.worst_file_path}` "
+                    f"({rollup.worst_file_verdict.value})"
+                )
     lines.append("")
     lines.append(f"## Worst files (showing {r.count} of {r.total}, offset {r.offset})")
     for entry in r.files:

--- a/topos/mcp/tools/inspect.py
+++ b/topos/mcp/tools/inspect.py
@@ -44,12 +44,14 @@ _READ_ONLY_ANN = {
     annotations=_READ_ONLY_ANN,
 )
 def topos_inspect_code(params: InspectCodeInput) -> ToolResult:
-    """Full metric breakdown for a code string.
+    """Full metric breakdown for a single code unit (inline string or file).
 
-    Returns the lattice evaluation, a *top-N* function complexity table
-    (sorted descending; configurable via ``top_n_functions``), and entropy
-    details. The top-N cap prevents large files from dumping hundreds of
-    functions and blowing out agent context.
+    Read-only; provide exactly one of ``code`` or ``filepath``. Use when you
+    need the per-function detail behind a verdict; use ``topos_evaluate_*`` when
+    the medal alone is enough. Returns an InspectionResult: the lattice
+    ``evaluation``, a *top-N* function complexity table (``top_n_functions``,
+    default 10), ``total_functions``, and entropy details. The top-N cap keeps
+    large files from blowing out agent context.
     """
     source, source_error, file_path = _load_source(params)
     priority, priority_source = resolve_priority(params.preferences)

--- a/topos/mcp/tools/preferences.py
+++ b/topos/mcp/tools/preferences.py
@@ -64,9 +64,15 @@ def _to_step(prefs: UserPreferences, value: EvaluationValue) -> WalkStep:
     annotations=_READ_ONLY_ANN,
 )
 def topos_preference_walk(params: PreferenceWalkInput) -> ToolResult:
-    """Return the preference-ordered relaxation walk for a generator ranking.
+    """Turn a generator ranking into a preference-ordered relaxation walk.
 
-    Use after evaluation when an agent needs the next lattice target.
+    Pure and read-only (lattice math only; no files, no scoring). Call after an
+    evaluation to pick the next verdict to aim for, or to relax the goal
+    gracefully under a token/time budget; pair with ``topos_evaluate_*`` for
+    actual metrics. Returns a PreferenceWalkResult: ``walk`` (steps from target
+    down to just above ``current``), ``next_step``, ``progress`` in [0, 1],
+    ``aspirational_target``/``fallback_target``, and ``induced_order`` (all 8
+    verdicts ranked).
     """
     try:
         target_value = (


### PR DESCRIPTION
## Summary

Prepares Topos for a claimed, high-scoring Glama MCP release. Tracks #91.

- **Release scaffolding** (`25a189e`): `glama.json` with the maintainers array (required to claim an org-hosted repo), a multi-stage `Dockerfile` (Rust + maturin builder -> slim runtime with the wheel + Node/GitNexus for COMPOSABLE; stdio `topos-mcp` entrypoint; `TOPOS_MCP_FILE_ROOT` documented), and `.dockerignore`.
- **TDQS tool-description pass** (`23d1a49`): sharpened MCP tool docstrings/schemas for Glama's Tool Definition Quality score — purpose-first, explicit read-only/side-effect behavior, and output shape. Prioritized the weakest tools (`compare_files`, `compare_code`, `preference_walk`) since TDQS weights the minimum-scoring tool heavily. Left #90's new depgraph/changeset tools as-is (already strong).

## Notes

- Based on `feat/mcp-bolster`, so this PR shows only the two Glama commits.
- Kept the whole tool surface under the context-budget ceiling (`tests/mcp/test_context_budget.py`).
- The stray `tests/fixtures/binarytrees/test_binarytrees.py` coverage artifact is intentionally not committed.

## Test plan

- [x] `uv run pytest tests/mcp -o addopts=''` — 106 passed
- [x] `uv run ruff check topos/mcp` + `ruff format --check topos/mcp`
- [x] Glama build test (Deploy) + Make Release — human/Glama-UI steps tracked in #91
