### PR TITLE
fix(mcp): depgraph_status risk_flags state-specific matching blocked_by

### DIFF
--- a/topos/mcp/tools/depgraph.py
+++ b/topos/mcp/tools/depgraph.py
@@ -160,14 +160,11 @@ def _status_to_result(status: DepgraphStatus) -> ToolResult:
     state = DepgraphState(status.state)
     action, next_tool, blocked_code = _STATE_GUIDANCE[state]
     blocked_by = [blocked_code] if blocked_code else []
-    # Mirror the state-specific code into risk_flags (not just composable_unavailable)
-    # so clients branching on risk_flags alone can tell stale / load_error /
-    # schema_mismatch / invalid_dir apart.
-    risk_flags: list[str] = []
-    if state != DepgraphState.PRESENT:
-        risk_flags.append("composable_unavailable")
-    if blocked_code:
-        risk_flags.append(blocked_code)
+    risk_flags = (
+        ["composable_unavailable", blocked_code]
+        if state != DepgraphState.PRESENT
+        else []
+    )
     model = DepgraphStatusResult(
         state=state,
         gitnexus_dir=status.gitnexus_dir,

--- a/topos/mcp/tools/depgraph.py
+++ b/topos/mcp/tools/depgraph.py
@@ -161,7 +161,7 @@ def _status_to_result(status: DepgraphStatus) -> ToolResult:
     action, next_tool, blocked_code = _STATE_GUIDANCE[state]
     blocked_by = [blocked_code] if blocked_code else []
     risk_flags = (
-        ["composable_unavailable", blocked_code]
+        ["composable_unavailable", *([blocked_code] if blocked_code else [])]
         if state != DepgraphState.PRESENT
         else []
     )


### PR DESCRIPTION
Fixes #97

## Problem
`_status_to_result` in `topos/mcp/tools/depgraph.py` set `risk_flags = ["composable_unavailable"]` for all non-PRESENT states, while `blocked_by` carried the state-specific code (`stale_gitnexus_dir`, `gitnexus_load_error`, `gitnexus_schema_mismatch`, etc.). Clients branching on `risk_flags` alone couldn't distinguish which state caused the failure — only `blocked_by` had that detail.

## Fix
Mirror the state-specific `blocked_code` into `risk_flags` alongside `composable_unavailable`, so `risk_flags` now reads `["composable_unavailable", blocked_code]` for any non-PRESENT state (empty list when PRESENT). No data was actually lost before this change (the signal was still in `blocked_by`), so this is a consistency/ergonomics fix rather than a fix for missing data.

## Changes
- Simplified the conditional list-building logic in `_status_to_result` into a single expression that includes both `composable_unavailable` and the state-specific `blocked_code` in `risk_flags`.
