### PR TITLE
Update MCP registry manifest to 0.3.6

### DIFF
--- a/.mcp/server.json
+++ b/.mcp/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/Krv-Labs/topos",
     "source": "github"
   },
-  "version": "0.3.5",
+  "version": "0.3.6",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "topos-mcp",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Updates `.mcp/server.json` so the MCP Registry metadata points at the published `topos-mcp` 0.3.6 package.

Validation: 
```
mcp-publisher validate .mcp/server.json
```