### PR TITLE
fix(cli): stop v0.3.6 frozen binary crashing on version lookup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,7 @@ jobs:
             --collect-all trailed
             --copy-metadata fastmcp
             --copy-metadata fastembed
+            --add-data Cargo.toml:.
           )
 
           # onefile embeds dylibs in the archive; they must be signed during

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Standalone binary crashed on every command** (`FileNotFoundError: .../\_MEIxxxx/Cargo.toml`). `topos-mcp` ships no importlib metadata, so `topos._version.get_version()` always fell through to `_cargo_version()`, which read `Cargo.toml` relative to `__file__`. Inside the PyInstaller `--onefile` bundle that path lives under the `_MEIxxxx` temp dir where `Cargo.toml` was never bundled, so version resolution raised on import and took down the whole CLI. `_version.py` now also searches `sys._MEIPASS` and never raises (falls back to `0.0.0+unknown`), and the release build bundles `Cargo.toml` (`--add-data Cargo.toml:.`). The defect was latent since the dynamic `_version.py` landed (before v0.3.5); it only surfaced now because v0.3.6 is the first standalone binary widely installed — the PyPI wheel carries dist metadata and never hits the broken path. ([#105](https://github.com/Krv-Labs/topos/pull/105))
+
 ## [0.3.6] - 2026-07-01
 
 ### Added

--- a/topos/_version.py
+++ b/topos/_version.py
@@ -1,30 +1,52 @@
 """Package version.
 
 Installed wheels/sdists get their version from maturin, which reads
-``[package].version`` in ``Cargo.toml``. Editable checkouts fall back to
-that same file so local dev matches the release source of truth.
+``[package].version`` in ``Cargo.toml``. Editable checkouts and the
+PyInstaller binary fall back to that same file so every distribution
+channel shares one source of truth.
 """
 
 from __future__ import annotations
 
+import sys
 import tomllib
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
 _PACKAGE = "topos-mcp"
-_CARGO_TOML = Path(__file__).resolve().parent.parent / "Cargo.toml"
+_FALLBACK_VERSION = "0.0.0+unknown"
 
 
-def _cargo_version() -> str:
-    with _CARGO_TOML.open("rb") as f:
-        return tomllib.load(f)["package"]["version"]
+def _cargo_toml_candidates() -> list[Path]:
+    """Locations to search for ``Cargo.toml``, most specific first.
+
+    In a normal checkout it sits one level above this file. In a frozen
+    PyInstaller bundle the source tree lives under ``sys._MEIPASS``, so we
+    look there too (see the ``--add-data Cargo.toml`` build step).
+    """
+    candidates = [Path(__file__).resolve().parent.parent / "Cargo.toml"]
+    bundle_dir = getattr(sys, "_MEIPASS", None)
+    if bundle_dir:
+        candidates.append(Path(bundle_dir) / "Cargo.toml")
+    return candidates
+
+
+def _cargo_version() -> str | None:
+    for cargo_toml in _cargo_toml_candidates():
+        try:
+            with cargo_toml.open("rb") as f:
+                return tomllib.load(f)["package"]["version"]
+        except (OSError, KeyError, tomllib.TOMLDecodeError):
+            continue
+    return None
 
 
 def get_version() -> str:
     try:
         return version(_PACKAGE)
     except PackageNotFoundError:
-        return _cargo_version()
+        pass
+    return _cargo_version() or _FALLBACK_VERSION
 
 
 __version__ = get_version()


### PR DESCRIPTION
## Problem

The v0.3.6 standalone binary crashes on **every** invocation before any command runs:

```
FileNotFoundError: [Errno 2] No such file or directory:
  '/private/var/folders/.../T/_MEIxxxx/Cargo.toml'
[PYI-xxxxx:ERROR] Failed to execute script 'main' due to unhandled exception!
```

## Root cause

`topos._version.get_version()` first tries `importlib.metadata.version("topos-mcp")`, then falls back to `_cargo_version()`, which reads `Cargo.toml` relative to `__file__`.

The `topos-mcp` distribution **ships no importlib metadata** (confirmed even in a normal install — `version("topos-mcp")` raises `PackageNotFoundError`, and the version is *only* ever resolved via the `Cargo.toml` fallback). In the PyInstaller `--onefile` bundle, `__file__` resolves under the `_MEIxxxx` temp dir, and `Cargo.toml` was never bundled → `FileNotFoundError` → the CLI dies on import.

## Fix

- **`topos/_version.py`** — also search `sys._MEIPASS` for `Cargo.toml` (where PyInstaller unpacks bundled data), and make version resolution non-fatal: any failure now falls back to `0.0.0+unknown` instead of crashing the whole CLI. A broken version string should never take down every command.
- **`.github/workflows/release.yml`** — bundle `Cargo.toml` into the binary via `--add-data Cargo.toml:.` so the frozen build resolves the real version (`0.3.6`).

## Verification

```
checkout version: 0.3.6
frozen(+bundle) version: 0.3.6          # _MEIPASS lookup
no-source version (must not crash): 0.0.0+unknown
check_versions _cargo_version(): 0.3.6  # scripts/check_versions.py still passes
```

Local `import topos` and `scripts/check_versions.py` both pass.

> Note: `topos.spec` in the repo is gitignored / not used by the release pipeline (which builds from the CLI args in `release.yml`), so the shipping fix lives in `release.yml`.


## When was this introduced?

**Not a v0.3.6 regression.** The version-resolution code and PyInstaller build args are byte-for-byte identical between v0.3.5 and v0.3.6 — the v0.3.5 binary was already broken the same way.

The defect was introduced in **#49 (`e1a8985`)**, which landed *between* the v0.3.4 and v0.3.5 tags. It replaced a hardcoded `__version__ = "0.3.4"` in `topos/__init__.py` with dynamic resolution (`from topos._version import __version__`) that assumes `Cargo.toml` sits next to the source at runtime.

| Tag / commit | version source | binary crashes? |
|---|---|---|
| v0.3.4 (`07c947e`) | hardcoded `"0.3.4"` literal | No |
| **#49 (`e1a8985`)** | dynamic `_version.py` reading `Cargo.toml` via `__file__` | **introduces bug** |
| v0.3.5 (`d8a1740`) | same dynamic `_version.py` | Yes (already broken) |
| v0.3.6 (`b8e576f`) | same dynamic `_version.py` | Yes (reported) |

That assumption holds for a dev checkout and a PyPI wheel (which carries dist metadata, so `version("topos-mcp")` succeeds and the fragile fallback never runs) but is false inside a PyInstaller `--onefile` bundle. It only surfaced at v0.3.6 because that's the first standalone binary widely installed; earlier usage went through the wheel or a checkout and never hit the broken path.

## Release note

Ship in **v0.3.7** (new patch tag) rather than re-releasing v0.3.6 — the fixed binary reports its version from `Cargo.toml`, so a bumped version is the only reliable signal that distinguishes a fixed build from the broken one.
