### PR TITLE
release: v0.3.7

### DIFF
--- a/.mcp/server.json
+++ b/.mcp/server.json
@@ -17,13 +17,13 @@
     "url": "https://github.com/Krv-Labs/topos",
     "source": "github"
   },
-  "version": "0.3.6",
+  "version": "0.3.7",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "topos-mcp",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "transport": {
         "type": "stdio"
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Standalone binary crashed on every command** (`FileNotFoundError: .../\_MEIxxxx/Cargo.toml`). `topos-mcp` ships no importlib metadata, so `topos._version.get_version()` always fell through to `_cargo_version()`, which read `Cargo.toml` relative to `__file__`. Inside the PyInstaller `--onefile` bundle that path lives under the `_MEIxxxx` temp dir where `Cargo.toml` was never bundled, so version resolution raised on import and took down the whole CLI. `_version.py` now also searches `sys._MEIPASS` and never raises (falls back to `0.0.0+unknown`), and the release build bundles `Cargo.toml` (`--add-data Cargo.toml:.`). The defect was latent since the dynamic `_version.py` landed (before v0.3.5); it only surfaced now because v0.3.6 is the first standalone binary widely installed — the PyPI wheel carries dist metadata and never hits the broken path. ([#105](https://github.com/Krv-Labs/topos/pull/105))
+- **Standalone binary crashed on every command** with `FileNotFoundError: .../\_MEIxxxx/Cargo.toml`. Version lookup fell back to reading `Cargo.toml`, which isn't bundled in the PyInstaller binary. `_version.py` now also searches `sys._MEIPASS` and never raises (falls back to `0.0.0+unknown`), and the release build bundles `Cargo.toml`. ([#105](https://github.com/Krv-Labs/topos/pull/105))
+- **MCP `topos_depgraph_status`**: `risk_flags` now carries the state-specific code (`stale` / `load_error` / `schema_mismatch` / `invalid_dir`) alongside `composable_unavailable`, so clients branching on `risk_flags` alone can tell non-`PRESENT` states apart. ([#99](https://github.com/Krv-Labs/topos/pull/99))
 
 ## [0.3.6] - 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.7] - 2026-07-02
+
 ### Fixed
 
 - **Standalone binary crashed on every command** (`FileNotFoundError: .../\_MEIxxxx/Cargo.toml`). `topos-mcp` ships no importlib metadata, so `topos._version.get_version()` always fell through to `_cargo_version()`, which read `Cargo.toml` relative to `__file__`. Inside the PyInstaller `--onefile` bundle that path lives under the `_MEIxxxx` temp dir where `Cargo.toml` was never bundled, so version resolution raised on import and took down the whole CLI. `_version.py` now also searches `sys._MEIPASS` and never raises (falls back to `0.0.0+unknown`), and the release build bundles `Cargo.toml` (`--add-data Cargo.toml:.`). The defect was latent since the dynamic `_version.py` landed (before v0.3.5); it only surfaced now because v0.3.6 is the first standalone binary widely installed — the PyPI wheel carries dist metadata and never hits the broken path. ([#105](https://github.com/Krv-Labs/topos/pull/105))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topos-functors"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2021"
 
 [lib]

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "topos-vscode",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "topos-vscode",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@types/mocha": "^10.0.6",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "topos-vscode",
   "displayName": "Topos: Code Quality Targets for Agents",
   "description": "Structural code-quality targets your coding agents can optimize toward, delivered as MCP tools for agent mode.",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "publisher": "KrvLabs",
   "icon": "icon.png",
   "license": "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
Patch release shipping the frozen-binary version-lookup crash fix (#105, now merged to `main`).

✅ Rebased onto `main` after #105 merged — the diff is now **only** the version bumps below, and the branch merges cleanly.

## Why a new patch (not a re-release of v0.3.6)

The v0.3.6 standalone binary crashes on every command (#105). Re-tagging v0.3.6 would leave two different binaries under one version with no way to tell them apart — and after the fix the binary reports its own version from `Cargo.toml`, so a bumped version is the only reliable signal that a build is fixed. See #105 for full root-cause analysis.

## Version bumps (0.3.6 → 0.3.7)

Mirrors the last release PR (#95), plus the MCP registry manifest:

| File | What |
|---|---|
| `Cargo.toml` | Rust package + Python source of truth (`topos._version` reads this) |
| `extensions/vscode/package.json` | VSCode extension |
| `extensions/vscode/package-lock.json` | lockfile (both entries) |
| `.mcp/server.json` | MCP registry manifest + `topos-mcp` pypi package version (both entries) |
| `CHANGELOG.md` | cut `[0.3.7] - 2026-07-02` section |

## Verification

```
scripts/check_versions.py → version check passed (0.3.7)
import topos._version → topos-mcp 0.3.7
git merge-tree origin/main HEAD → clean (no conflicts)
no stray 0.3.6 left in release-critical files
```

## Release steps after merge

1. Merge this PR.
2. Tag `v0.3.7` on `main` and push → `release.yml` rebuilds binaries (now with `Cargo.toml` bundled + crash-proof `_version.py`).
3. Edit the v0.3.6 GitHub release notes to point users at v0.3.7 (note the CLI-crash bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)