### PR TITLE
Fix invalid gitnexus_dir contract routing

### DIFF
--- a/tests/mcp/test_assess.py
+++ b/tests/mcp/test_assess.py
@@ -61,6 +61,33 @@ def test_assess_accepts_proposed_filepath(
     assert r.structural_distance is not None
 
 
+def test_assess_flags_invalid_gitnexus_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from topos.mcp import security
+
+    monkeypatch.setenv("TOPOS_MCP_FILE_ROOT", str(tmp_path))
+    security.reset_file_root_cache()
+    current = tmp_path / "current.py"
+    current.write_text("def f():\n    return 1\n", encoding="utf-8")
+
+    r = _assess(
+        topos_assess_improvement(
+            AssessImprovementInput(
+                filepath="current.py",
+                proposed_code="def f():\n    return 2\n",
+                gitnexus_dir=str(tmp_path / "missing"),
+                preferences=_PREFS,
+            )
+        )
+    )
+
+    assert r.agent_contract is not None
+    assert "invalid_gitnexus_dir" in r.agent_contract.blocked_by
+    assert "missing_gitnexus_dir" not in r.agent_contract.blocked_by
+    assert r.agent_contract.next_tool != "topos_generate_depgraph"
+
+
 def test_assess_reports_security_findings() -> None:
     current = "def f(expr):\n    return eval(expr)\n"
     tr = topos_assess_improvement(

--- a/tests/mcp/test_changeset.py
+++ b/tests/mcp/test_changeset.py
@@ -99,6 +99,30 @@ def test_changeset_detects_project_regression(tmp_path, monkeypatch) -> None:
     assert r.agent_contract.next_tool == "topos_inspect_code"
 
 
+def test_changeset_flags_invalid_gitnexus_dir(tmp_path, monkeypatch) -> None:
+    _init_repo(tmp_path)
+    a = tmp_path / "a.py"
+    a.write_text(_CLEAN, encoding="utf-8")
+    _git(tmp_path, "add", "a.py")
+    _git(tmp_path, "commit", "-m", "init")
+    _use_root(tmp_path, monkeypatch)
+    a.write_text(_CLEAN + "\ndef extra():\n    return 2\n", encoding="utf-8")
+
+    r = _changeset(
+        topos_assess_changeset(
+            AssessChangesetInput(
+                files=["a.py"],
+                gitnexus_dir=str(tmp_path / "missing"),
+            )
+        )
+    )
+
+    assert r.agent_contract is not None
+    assert "invalid_gitnexus_dir" in r.agent_contract.blocked_by
+    assert "missing_gitnexus_dir" not in r.agent_contract.blocked_by
+    assert r.agent_contract.next_tool != "topos_generate_depgraph"
+
+
 def test_changeset_rejects_invalid_baseline_ref(tmp_path, monkeypatch) -> None:
     # A mistyped ref must fail structurally, not masquerade as "every file is
     # new" (git can't tell an absent-at-ref path from an invalid ref).

--- a/tests/mcp/test_evaluate.py
+++ b/tests/mcp/test_evaluate.py
@@ -480,6 +480,34 @@ def test_evaluate_project_auto_detects_supported_languages(
     assert "using language" in r.agent_contract.next_actions[0]
 
 
+def test_evaluate_project_flags_invalid_gitnexus_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from topos.mcp import security
+
+    monkeypatch.setenv("TOPOS_MCP_FILE_ROOT", str(tmp_path))
+    security.reset_file_root_cache()
+    (tmp_path / "module.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+
+    r = _project(
+        asyncio.run(
+            topos_evaluate_project(
+                EvaluateProjectInput(
+                    path=".",
+                    gitnexus_dir=str(tmp_path / "missing"),
+                    preferences=_PREFS,
+                ),
+                _StubCtx(),
+            )
+        )
+    )
+
+    assert r.agent_contract is not None
+    assert "invalid_gitnexus_dir" in r.agent_contract.blocked_by
+    assert "missing_gitnexus_dir" not in r.agent_contract.blocked_by
+    assert r.agent_contract.next_tool != "topos_generate_depgraph"
+
+
 def test_evaluate_project_paginates() -> None:
     full = _project(
         asyncio.run(

--- a/tests/mcp/test_evaluate.py
+++ b/tests/mcp/test_evaluate.py
@@ -508,6 +508,43 @@ def test_evaluate_project_flags_invalid_gitnexus_dir(
     assert r.agent_contract.next_tool != "topos_generate_depgraph"
 
 
+def test_evaluate_project_flags_invalid_gitnexus_dir_when_all_files_fail(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Invalid gitnexus_dir routing must win even when no file yields a
+    usable entry (``worst_files`` empty) — matches the other three
+    agent-contract surfaces (file, changeset, worktree-change)."""
+    from topos.mcp import security
+
+    monkeypatch.setenv("TOPOS_MCP_FILE_ROOT", str(tmp_path))
+    security.reset_file_root_cache()
+    (tmp_path / "module.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+
+    with patch(
+        "topos.mcp.tools.evaluate.project.classify_file",
+        side_effect=RuntimeError("boom"),
+    ):
+        r = _project(
+            asyncio.run(
+                topos_evaluate_project(
+                    EvaluateProjectInput(
+                        path=".",
+                        gitnexus_dir=str(tmp_path / "missing"),
+                        preferences=_PREFS,
+                    ),
+                    _StubCtx(),
+                )
+            )
+        )
+
+    assert r.worst_files == []
+    assert r.agent_contract is not None
+    assert "invalid_gitnexus_dir" in r.agent_contract.blocked_by
+    assert r.agent_contract.next_actions == [
+        "fix gitnexus_dir — it must be an existing directory inside the file root"
+    ]
+
+
 def test_evaluate_project_paginates() -> None:
     full = _project(
         asyncio.run(

--- a/tests/mcp/test_snapshot.py
+++ b/tests/mcp/test_snapshot.py
@@ -270,6 +270,33 @@ def test_worktree_change_vs_head(
 
 
 @pytestmark_git
+def test_worktree_change_flags_invalid_gitnexus_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _root(tmp_path, monkeypatch)
+    _git(tmp_path, "init")
+    target = tmp_path / "m.py"
+    target.write_text(_BASE, encoding="utf-8")
+    _git(tmp_path, "add", "m.py")
+    _git(tmp_path, "commit", "-m", "base")
+    target.write_text(_EDIT, encoding="utf-8")
+
+    r = _assessment(
+        topos_assess_worktree_change(
+            AssessWorktreeChangeInput(
+                filepath="m.py",
+                gitnexus_dir=str(tmp_path / "missing"),
+            )
+        )
+    )
+
+    assert r.agent_contract is not None
+    assert "invalid_gitnexus_dir" in r.agent_contract.blocked_by
+    assert "missing_gitnexus_dir" not in r.agent_contract.blocked_by
+    assert r.agent_contract.next_tool != "topos_generate_depgraph"
+
+
+@pytestmark_git
 def test_worktree_bad_ref(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     _root(tmp_path, monkeypatch)
     _git(tmp_path, "init")

--- a/topos/mcp/formatting.py
+++ b/topos/mcp/formatting.py
@@ -7,7 +7,7 @@ return models defined in ``schemas.py``.
 
 from __future__ import annotations
 
-from dataclasses import replace
+from dataclasses import dataclass, replace
 
 from fastmcp.tools.base import ToolResult
 from pydantic import BaseModel
@@ -49,12 +49,70 @@ _STR_TO_LATTICE: dict[LatticeElement, EvaluationValue] = {
 }
 
 
+@dataclass(frozen=True)
+class ComposableContractSignals:
+    """Agent-contract fields implied by COMPOSABLE setup state."""
+
+    blocked_by: list[str]
+    risk_flags: list[str]
+    next_tool: str | None = None
+    next_action: str | None = None
+
+
 def lattice_to_str(value: EvaluationValue) -> LatticeElement:
     return _LATTICE_TO_STR[value]
 
 
 def str_to_lattice(value: LatticeElement) -> EvaluationValue:
     return _STR_TO_LATTICE[value]
+
+
+def composable_contract_signals(
+    *,
+    coupling_available: bool,
+    warnings: list[str] | None = None,
+    include_missing: bool = True,
+) -> ComposableContractSignals:
+    """Classify COMPOSABLE setup blockers from the shared warning markers."""
+    blocked_by: list[str] = []
+    risk_flags: list[str] = []
+    messages = warnings or []
+
+    invalid_override = any(
+        marker in w for w in messages for marker in INVALID_GITNEXUS_MARKERS
+    )
+    stale_graph = any(STALE_GITNEXUS_MARKER in w for w in messages)
+
+    if not coupling_available:
+        if invalid_override:
+            blocked_by.append("invalid_gitnexus_dir")
+            risk_flags.append("invalid_gitnexus_dir")
+        elif include_missing:
+            blocked_by.append("missing_gitnexus_dir")
+        if invalid_override or include_missing:
+            risk_flags.append("composable_unavailable")
+
+    if stale_graph:
+        blocked_by.append("stale_gitnexus_dir")
+        risk_flags.append("stale_gitnexus_dir")
+
+    if "invalid_gitnexus_dir" in blocked_by:
+        return ComposableContractSignals(
+            blocked_by=blocked_by,
+            risk_flags=risk_flags,
+            next_action=(
+                "fix gitnexus_dir — it must be an existing directory inside "
+                "the file root"
+            ),
+        )
+    if "stale_gitnexus_dir" in blocked_by:
+        return ComposableContractSignals(
+            blocked_by=blocked_by,
+            risk_flags=risk_flags,
+            next_tool="topos_generate_depgraph",
+            next_action="run topos_generate_depgraph to refresh COMPOSABLE",
+        )
+    return ComposableContractSignals(blocked_by=blocked_by, risk_flags=risk_flags)
 
 
 def build_preference_walk(
@@ -137,27 +195,12 @@ def build_agent_contract(
         risk_flags.append("parse_failure")
         return None, [], blocked_by, ["restore parseable source"], risk_flags
 
-    # An invalid/denied gitnexus_dir override is distinct from a plain missing
-    # graph: regenerating in the project root won't fix a bad path, so the agent
-    # must fix the path instead. Detected via the shared markers so the contract
-    # can't drift from the warning prose.
-    invalid_override = any(
-        marker in w for w in (warnings or []) for marker in INVALID_GITNEXUS_MARKERS
+    composable = composable_contract_signals(
+        coupling_available=coupling_available,
+        warnings=warnings,
     )
-    if not coupling_available:
-        if invalid_override:
-            blocked_by.append("invalid_gitnexus_dir")
-            risk_flags.append("invalid_gitnexus_dir")
-        else:
-            blocked_by.append("missing_gitnexus_dir")
-        risk_flags.append("composable_unavailable")
-    # A loaded-but-stale graph is a distinct precondition: COMPOSABLE *is*
-    # scored, but the agent should refresh the index before trusting it. Match
-    # on the shared marker (not a bare "stale" substring) so the contract can't
-    # silently drift from the warning prose.
-    if warnings and any(STALE_GITNEXUS_MARKER in w for w in warnings):
-        blocked_by.append("stale_gitnexus_dir")
-        risk_flags.append("stale_gitnexus_dir")
+    blocked_by.extend(composable.blocked_by)
+    risk_flags.extend(composable.risk_flags)
     if security_findings:
         risk_flags.append("active_security_findings")
     if acknowledged_risks:
@@ -170,14 +213,9 @@ def build_agent_contract(
     summary = result.summary()
     simple_ok = result.dimensions.get("simple") == EvaluationValue.SIMPLE
 
-    if "invalid_gitnexus_dir" in blocked_by:
-        next_tool = None
-        next_actions.append(
-            "fix gitnexus_dir — it must be an existing directory inside the file root"
-        )
-    elif "stale_gitnexus_dir" in blocked_by:
-        next_tool = "topos_generate_depgraph"
-        next_actions.append("run topos_generate_depgraph to refresh COMPOSABLE")
+    if composable.next_action:
+        next_tool = composable.next_tool
+        next_actions.append(composable.next_action)
     elif summary == EvaluationValue.IDEAL:
         next_tool = "topos_evaluate_project"
         next_actions.append(

--- a/topos/mcp/tools/assess/changeset.py
+++ b/topos/mcp/tools/assess/changeset.py
@@ -22,7 +22,7 @@ from ...evaluation import (
     load_dep_graph,
     resolve_gitnexus_dir,
 )
-from ...formatting import lattice_to_str, to_tool_result
+from ...formatting import composable_contract_signals, lattice_to_str, to_tool_result
 from ...schemas import (
     AgentContract,
     AssessChangesetInput,
@@ -116,6 +116,12 @@ def topos_assess_changeset(params: AssessChangesetInput) -> ToolResult:
         before_evals=before_evals,
         after_evals=after_evals,
         coupling_available=any_coupling,
+        warnings=gitnexus_warnings(
+            params.gitnexus_dir,
+            project_root,
+            gitnexus_dir,
+            dep_graph_loaded=any_coupling,
+        ),
     )
 
 
@@ -293,6 +299,7 @@ def _build_changeset_result(
     before_evals: list[EvaluationResult],
     after_evals: list[EvaluationResult],
     coupling_available: bool,
+    warnings: list[str],
 ) -> ToolResult:
     before_dims, before_scores, before_ok = _rollup(before_evals)
     after_dims, after_scores, after_ok = _rollup(after_evals)
@@ -319,7 +326,7 @@ def _build_changeset_result(
         priority=priority,
         priority_source=priority_source,
         agent_contract=_changeset_contract(
-            project_regression, relocated_files, coupling_available
+            project_regression, relocated_files, coupling_available, warnings
         ),
     )
     return to_tool_result(model, _render_changeset_md(model))
@@ -329,20 +336,29 @@ def _changeset_contract(
     project_regression: bool,
     relocated_files: list[str],
     coupling_available: bool,
+    warnings: list[str],
 ) -> AgentContract:
     blocked_by: list[str] = []
     risk_flags: list[str] = []
     next_actions: list[str] = []
 
-    if not coupling_available:
-        blocked_by.append("missing_gitnexus_dir")
-        risk_flags.append("composable_unavailable")
+    composable = composable_contract_signals(
+        coupling_available=coupling_available,
+        warnings=warnings,
+    )
+    blocked_by.extend(composable.blocked_by)
+    risk_flags.extend(composable.risk_flags)
+    if warnings:
+        risk_flags.append("warnings")
     if relocated_files:
         risk_flags.append("complexity_relocated_within_file")
         next_actions.append(
             "move extracted logic across a module boundary instead of within one file"
         )
-    if project_regression:
+    if composable.next_action:
+        next_tool = composable.next_tool
+        next_actions.append(composable.next_action)
+    elif project_regression:
         blocked_by.append("project_regression")
         risk_flags.append("project_regression")
         next_tool = "topos_inspect_code"

--- a/topos/mcp/tools/assess/core.py
+++ b/topos/mcp/tools/assess/core.py
@@ -31,7 +31,11 @@ from ...evaluation import (
     load_dep_graph,
     resolve_gitnexus_dir,
 )
-from ...formatting import to_evaluation_result, to_tool_result
+from ...formatting import (
+    composable_contract_signals,
+    to_evaluation_result,
+    to_tool_result,
+)
 from ...schemas import (
     AgentContract,
     AssessImprovementInput,
@@ -446,6 +450,13 @@ def _assessment_contract(
     blocked_by: list[str] = []
     next_actions: list[str] = []
 
+    composable = composable_contract_signals(
+        coupling_available=proposed_eval.coupling_available,
+        warnings=warnings,
+        include_missing=False,
+    )
+    blocked_by.extend(composable.blocked_by)
+    risk_flags.extend(composable.risk_flags)
     if warnings:
         risk_flags.append("warnings")
     if proposed_eval.grade_capped:
@@ -453,7 +464,10 @@ def _assessment_contract(
     if proposed_eval.security_findings:
         risk_flags.append("active_security_findings")
 
-    if status == AssessmentStatus.SUSPICIOUS_NO_STRUCTURAL_CHANGE:
+    if composable.next_action:
+        next_tool = composable.next_tool
+        next_actions.append(composable.next_action)
+    elif status == AssessmentStatus.SUSPICIOUS_NO_STRUCTURAL_CHANGE:
         blocked_by.append("suspicious_no_structural_change")
         risk_flags.append("metric_gaming_risk")
         next_tool = "topos_inspect_code"

--- a/topos/mcp/tools/evaluate/project.py
+++ b/topos/mcp/tools/evaluate/project.py
@@ -532,8 +532,6 @@ def _project_contract(
         "project rollup does not regress after non-trivial changes",
         "behavior tests or type/lint checks pass when available",
     ]
-    if not worst_files:
-        return None, [], blocked_by, [], risk_flags
     if composable.next_action:
         return (
             composable.next_tool,
@@ -542,6 +540,8 @@ def _project_contract(
             verification_gates,
             risk_flags,
         )
+    if not worst_files:
+        return None, [], blocked_by, [], risk_flags
     if overall == LatticeElement.IDEAL:
         next_tool = None
         next_actions.append("preserve behavior checks before accepting")

--- a/topos/mcp/tools/evaluate/project.py
+++ b/topos/mcp/tools/evaluate/project.py
@@ -29,6 +29,7 @@ from ...evaluation import (
 )
 from ...formatting import (
     build_pillars,
+    composable_contract_signals,
     lattice_to_str,
     to_tool_result,
 )
@@ -510,9 +511,12 @@ def _project_contract(
     risk_flags: list[str] = []
     next_actions: list[str] = []
 
-    if not coupling_available:
-        blocked_by.append("missing_gitnexus_dir")
-        risk_flags.append("composable_unavailable")
+    composable = composable_contract_signals(
+        coupling_available=coupling_available,
+        warnings=warnings,
+    )
+    blocked_by.extend(composable.blocked_by)
+    risk_flags.extend(composable.risk_flags)
     if parse_failures:
         blocked_by.append("parse_failures")
         risk_flags.append("parse_failures")
@@ -523,8 +527,21 @@ def _project_contract(
     if any(f.security_findings for f in worst_files):
         risk_flags.append("active_security_findings")
 
+    verification_gates = [
+        "topos_assess_worktree_change validates each accepted in-place refactor",
+        "project rollup does not regress after non-trivial changes",
+        "behavior tests or type/lint checks pass when available",
+    ]
     if not worst_files:
         return None, [], blocked_by, [], risk_flags
+    if composable.next_action:
+        return (
+            composable.next_tool,
+            [composable.next_action],
+            blocked_by,
+            verification_gates,
+            risk_flags,
+        )
     if overall == LatticeElement.IDEAL:
         next_tool = None
         next_actions.append("preserve behavior checks before accepting")
@@ -535,9 +552,4 @@ def _project_contract(
             f"start with worst file {worst.filepath} using language {worst.language}"
         )
 
-    verification_gates = [
-        "topos_assess_worktree_change validates each accepted in-place refactor",
-        "project rollup does not regress after non-trivial changes",
-        "behavior tests or type/lint checks pass when available",
-    ]
     return next_tool, next_actions, blocked_by, verification_gates, risk_flags


### PR DESCRIPTION
## Summary
- centralize COMPOSABLE setup contract routing for invalid, missing, and stale GitNexus states
- propagate `invalid_gitnexus_dir` across project, assessment, worktree, and changeset MCP contracts
- add regressions for invalid override handling on all affected tool surfaces

Closes #98.

## Verification
- `uv run ruff check topos/mcp/formatting.py topos/mcp/tools/evaluate/project.py topos/mcp/tools/assess/core.py topos/mcp/tools/assess/changeset.py tests/mcp/test_evaluate.py tests/mcp/test_assess.py tests/mcp/test_changeset.py tests/mcp/test_snapshot.py`
- `uv run pytest tests/mcp/test_depgraph.py tests/mcp/test_evaluate.py tests/mcp/test_assess.py tests/mcp/test_changeset.py tests/mcp/test_snapshot.py`
- FastMCP dogfood: invalid override returns `invalid_gitnexus_dir` and no `topos_generate_depgraph` route across depgraph status, evaluate file/project, assess improvement/worktree, and changeset
