### PR TITLE
release: v0.3.8

### DIFF
--- a/.mcp/server.json
+++ b/.mcp/server.json
@@ -17,13 +17,13 @@
     "url": "https://github.com/Krv-Labs/topos",
     "source": "github"
   },
-  "version": "0.3.7",
+  "version": "0.3.8",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "topos-mcp",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "transport": {
         "type": "stdio"
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.8] - 2026-07-04
+
+### Fixed
+
+- **`cfg.longest_path` hung on functions with many sequential if/else branches**: `ControlFlowGraph::longest_acyclic_path` used backtracking-DFS path enumeration, which is O(2^k) for `k` sequential branches — real-world files (`typing_extensions`, `pycparser`'s `ply/yacc.py`) hung indefinitely. Replaced with a topological-sort + DP longest-path (O(V+E)). `CONTINUE` edges are now stripped alongside `LOOPBACK` before building the graph (a `continue`'s back-edge to its loop header also breaks the DAG invariant), and the implementation panics loudly if that invariant is ever violated instead of silently falling back to the algorithm that caused the hang. (closes [#113](https://github.com/Krv-Labs/topos/issues/113), [#114](https://github.com/Krv-Labs/topos/pull/114))
+
 ## [0.3.7] - 2026-07-02
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topos-functors"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 
 [lib]

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "topos-vscode",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "topos-vscode",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@types/mocha": "^10.0.6",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "topos-vscode",
   "displayName": "Topos: Code Quality Targets for Agents",
   "description": "Structural code-quality targets your coding agents can optimize toward, delivered as MCP tools for agent mode.",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "publisher": "KrvLabs",
   "icon": "icon.png",
   "license": "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
Patch release shipping the `longest_acyclic_path` exponential-blowup fix (#114, closes #113).

## Version bumps (0.3.7 → 0.3.8)

Mirrors the last release PR (#106):

| File | What |
|---|---|
| `Cargo.toml` | Rust package + Python source of truth (`topos._version` reads this) |
| `extensions/vscode/package.json` | VSCode extension |
| `extensions/vscode/package-lock.json` | lockfile (both entries) |
| `.mcp/server.json` | MCP registry manifest + `topos-mcp` pypi package version (both entries) |
| `CHANGELOG.md` | cut `[0.3.8] - 2026-07-04` section |

## Verification

```
scripts/check_versions.py → version check passed (0.3.8)
no stray 0.3.7 left in release-critical files
```

## Release steps after merge

1. Merge this PR.
2. Tag `v0.3.8` on `main` and push → `release.yml` rebuilds binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)