### PR TITLE
fix(build): hard-fail on empty hidden-import list; scope CLI startup gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,10 @@ jobs:
         run: |
           chmod +x "$TOPOS_BINARY"
           uv run pytest tests/packaging/ -v --no-cov
-          uv run pytest tests/benchmarks/test_cli_startup.py -s --no-cov -k "warm"
+          # Gate only the documented trivial-command budgets (--version, --help).
+          # `evaluate --help` loads the full stack; its correctness is covered by
+          # tests/packaging/, and its latency is not a documented budget.
+          uv run pytest tests/benchmarks/test_cli_startup.py -s --no-cov -k "warm and not evaluate"
 
   extension:
     runs-on: ubuntu-latest

--- a/scripts/build-binary.sh
+++ b/scripts/build-binary.sh
@@ -33,9 +33,19 @@ PYINSTALLER_ARGS=(
   --add-data topos/mcp/resources/content:topos/mcp/resources/content
 )
 
+# Derive hidden imports from the lazy-export table. Capture into a variable
+# first: a command substitution failure aborts under `set -e`, and the
+# emptiness guard catches a helper that exits 0 but prints nothing (a renamed
+# `_LAZY_EXPORTS`, an import error). Process substitution would hide both,
+# silently shipping a binary with no hidden imports.
+hidden_imports="$(uv run python scripts/lazy_exports.py)"
+if [[ -z "${hidden_imports}" ]]; then
+  echo "error: scripts/lazy_exports.py produced no hidden imports" >&2
+  exit 1
+fi
 while IFS= read -r module; do
   PYINSTALLER_ARGS+=(--hidden-import "${module}")
-done < <(uv run python scripts/lazy_exports.py)
+done <<< "${hidden_imports}"
 
 if [[ "$(uname -s)" == "Darwin" && -n "${CODESIGN_IDENTITY:-}" ]]; then
   PYINSTALLER_ARGS+=(


### PR DESCRIPTION
> [!NOTE]
> @jeremy-wayland your PR (#109) is good to go after you review + merge this! Can run a release when the main PR goes through.
> _Also note: version not bumped here. Would reckon we go --> 0.3.9 on your PR + release this final version before we go 0.4.0 w/ additional MCP updates, methodology you're working on, etc_

Follow-up to the review of #109. Fixes two issues that #109's own changes introduced. Both are additive hardening — no behavior change to a correct build.

## 1. `build-binary.sh` could silently ship a binary with **zero** hidden imports

Hidden imports are derived from `topos._LAZY_EXPORTS` (the one module class PyInstaller cannot discover statically) via a subshell:

```bash
while IFS= read -r module; do ... done < <(uv run python scripts/lazy_exports.py)
```

`set -euo pipefail` does **not** propagate a failure from process substitution, and a helper that imports cleanly but prints nothing (e.g. `_LAZY_EXPORTS` renamed) yields zero loop iterations. In both cases the build **succeeds** with an empty `--hidden-import` list — the parity guarantee this refactor is built around is silently void, and no test catches it.

**Fix:** capture the helper output first — a command-substitution failure *does* abort under `set -e` — and hard-fail on empty output. Fail loud, not open.

## 2. `cli-startup` CI gate ran an undocumented, flakier budget

`-k "warm"` also matched `test_cli_startup_evaluate_help_warm`, which loads the full evaluation stack and re-extracts the onefile 5×, gated at 7s — a budget absent from the benchmarks doc (which lists only `--version` / `--help`) and the flakiest of the three on a shared runner. Its correctness is already covered by `tests/packaging/`.

**Fix:** `-k "warm and not evaluate"` — the gate now measures exactly the two documented trivial-command budgets.

## Verification

Dogfooded a real onefile binary built by the patched script:

- **`tests/packaging/` — 9/9 pass**: version-vs-Cargo, root/subcommand help, MCP `topos_get_doc` over stdio, and hidden-import parity.
- **Guard, all paths**: helper crash → build aborts; empty output → exits 1 with a message; normal run → 11 hidden imports bundled; `evaluate` / `coverage` / `mcp` all resolve in the binary.
- **CI selector**: now collects exactly `version_warm` + `help_warm` (was 3, including `evaluate`).

## Out of scope

Command registration still loads the eval stack (numpy) via `quality.py`'s top-level `Priority` import. This is **pre-existing** — it predates #109 and is unrelated to the tree-sitter deferral that review finding #2 asked for (which is correctly fixed). The `--version`/`--help` fast path already sidesteps it; deferring it for `topos update`/`uninstall` is a separate optimization, not a #109 regression.