### PR TITLE
release: v0.3.9

### DIFF
--- a/.mcp/server.json
+++ b/.mcp/server.json
@@ -17,13 +17,13 @@
     "url": "https://github.com/Krv-Labs/topos",
     "source": "github"
   },
-  "version": "0.3.8",
+  "version": "0.3.9",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "topos-mcp",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "transport": {
         "type": "stdio"
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.9] - 2026-07-06
+
+### Changed
+
+- **CLI startup latency**: `--version` and root `--help` exit before Click and heavy imports load; subcommands register lazily and `import topos` exposes only `__version__` eagerly. Standalone binary warm `--version` drops from ~854ms to ~586ms on macOS arm64. ([#109](https://github.com/Krv-Labs/topos/pull/109), closes [#108](https://github.com/Krv-Labs/topos/issues/108))
+- **Single release binary**: retired the ECT semantic-coverage variant and slim-vs-ect packaging split; one `topos-{platform}` binary (~39 MB, down from ~72 MB). Semantic (ECT) coverage was removed from CLI, MCP, and policies. ([#109](https://github.com/Krv-Labs/topos/pull/109), [#116](https://github.com/Krv-Labs/topos/pull/116))
+- **Release CI dogfoods binaries**: packaging smoke tests run against the built PyInstaller artifact so a broken frozen binary fails CI instead of shipping. (closes [#110](https://github.com/Krv-Labs/topos/issues/110), via [#109](https://github.com/Krv-Labs/topos/pull/109))
+
+### Fixed
+
+- **MCP invalid `gitnexus_dir` routing**: centralized COMPOSABLE setup contract routing for invalid, missing, and stale GitNexus states; `invalid_gitnexus_dir` now propagates across evaluate, assess, worktree, and changeset tool contracts instead of suggesting `topos_generate_depgraph` for a bad override path. ([#112](https://github.com/Krv-Labs/topos/pull/112), closes [#98](https://github.com/Krv-Labs/topos/issues/98))
+
 ## [0.3.8] - 2026-07-04
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topos-functors"
-version = "0.3.8"
+version = "0.3.9"
 edition = "2021"
 
 [lib]

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "topos-vscode",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "topos-vscode",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@types/mocha": "^10.0.6",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "topos-vscode",
   "displayName": "Topos: Code Quality Targets for Agents",
   "description": "Structural code-quality targets your coding agents can optimize toward, delivered as MCP tools for agent mode.",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "publisher": "KrvLabs",
   "icon": "icon.png",
   "license": "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
Patch release shipping CLI startup optimizations (#109, closes #108), single-binary packaging without ECT semantic coverage (#116), release CI binary smoke tests (#110), and invalid `gitnexus_dir` MCP contract routing (#112, closes #98).

## Version bumps (0.3.8 → 0.3.9)

| File | What |
|---|---|
| `Cargo.toml` | Rust package + Python source of truth (`topos._version` reads this) |
| `extensions/vscode/package.json` | VS Code extension |
| `extensions/vscode/package-lock.json` | lockfile (both entries) |
| `.mcp/server.json` | MCP registry manifest + `topos-mcp` PyPI package version (both entries) |
| `CHANGELOG.md` | cut `[0.3.9] - 2026-07-06` section |

## Verification

```
scripts/check_versions.py → version check passed (0.3.9)
no stray 0.3.8 left in release-critical files
```

## Release steps after merge

1. Merge this PR.
2. Tag `v0.3.9` on `main` and push → `release.yml` rebuilds binaries.