### PR TITLE
fix(mcp): close depgraph freshness gaps found in review of #120

### DIFF
--- a/tests/mcp/test_depgraph.py
+++ b/tests/mcp/test_depgraph.py
@@ -497,18 +497,70 @@ def test_freshness_v2_deleted_file_is_stale(tmp_path) -> None:
 
 
 def test_freshness_v2_tolerates_small_mtime_skew(tmp_path) -> None:
-    # generated_at is a sub-second time.time() stamp; filesystem mtimes can
-    # be coarser or drift slightly against the process clock. An edit inside
-    # the tolerance window must still read as stale, not silently as fresh.
+    # Simulate a system with clock drift (e.g., filesystem clock is 5.0 seconds behind).
+    # We edit `f.py` after the graph was generated, but due to clock drift,
+    # the filesystem writes `f.py` with an mtime that appears earlier than the process's `generated_at`.
+    # With dynamic drift compensation, the drift is calculated using the fingerprint file's own mtime
+    # on the same filesystem, and the edit is still correctly detected as stale.
+    import os
     head = _commit_repo(tmp_path)
     gitnexus = _graph_dir(tmp_path, fingerprint=None)
-    source_mtime = (tmp_path / "f.py").stat().st_mtime
-    _write_v2_fingerprint(gitnexus, head_sha=head, generated_at=source_mtime + 1.0)
+    
+    # Write fingerprint file with generated_at=100.0, finished_at=100.0
+    (gitnexus / GITNEXUS_FINGERPRINT_FILE).write_text(
+        json.dumps({
+            "head_sha": head,
+            "generated_at": 100.0,
+            "finished_at": 100.0,
+        }),
+        encoding="utf-8",
+    )
+    # Set fingerprint file's actual filesystem mtime to 95.0 (simulating 5.0s slow filesystem)
+    os.utime(gitnexus / GITNEXUS_FINGERPRINT_FILE, (95.0, 95.0))
+    
+    # Set source file's mtime to 96.0 (modified 1.0s after generation on filesystem clock,
+    # but still less than the process's `generated_at` of 100.0).
+    os.utime(tmp_path / "f.py", (96.0, 96.0))
+    
+    # Set containing directories' mtime to 94.0 (before generation) so the staleness
+    # is correctly triggered by f.py itself rather than directory parent updates.
+    os.utime(tmp_path, (94.0, 94.0))
 
     is_stale, detail = _graph_freshness(tmp_path, gitnexus)
 
     assert is_stale is True
     assert "f.py" in detail
+
+
+def test_freshness_v2_handles_pre_generation_mtimes_without_false_positives(tmp_path) -> None:
+    # On the same clock-drifted system, a file modified BEFORE generation must NOT
+    # be considered stale, even if its mtime is close to generation.
+    import os
+    head = _commit_repo(tmp_path)
+    gitnexus = _graph_dir(tmp_path, fingerprint=None)
+    
+    # Write fingerprint file with generated_at=100.0, finished_at=100.0
+    (gitnexus / GITNEXUS_FINGERPRINT_FILE).write_text(
+        json.dumps({
+            "head_sha": head,
+            "generated_at": 100.0,
+            "finished_at": 100.0,
+        }),
+        encoding="utf-8",
+    )
+    # Set fingerprint file's actual filesystem mtime to 95.0 (simulating 5.0s slow filesystem)
+    os.utime(gitnexus / GITNEXUS_FINGERPRINT_FILE, (95.0, 95.0))
+    
+    # Set source file's mtime to 94.0 (modified BEFORE generation on filesystem clock)
+    os.utime(tmp_path / "f.py", (94.0, 94.0))
+    
+    # Set parent directory mtime to 94.0 as well (before generation)
+    os.utime(tmp_path, (94.0, 94.0))
+
+    is_stale, detail = _graph_freshness(tmp_path, gitnexus)
+
+    assert is_stale is False
+    assert detail is None
 
 
 def test_generate_ensure_regenerates_after_in_place_edit(tmp_path, monkeypatch) -> None:

--- a/tests/mcp/test_depgraph.py
+++ b/tests/mcp/test_depgraph.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import time
 from pathlib import Path
 
 import pytest
@@ -472,6 +473,42 @@ def test_freshness_v2_sha_less_marker_works_in_non_git_dir(tmp_path) -> None:
 
     assert is_stale is True
     assert "mod.py" in detail
+
+
+def test_freshness_v2_deleted_file_is_stale(tmp_path) -> None:
+    # A file removed after generation leaves no mtime of its own to catch,
+    # but it does bump its parent directory's mtime — the walk must check
+    # that too, or a deletion silently reads as fresh forever.
+    head = _commit_repo(tmp_path)
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    extra = sub / "extra.py"
+    extra.write_text("y = 2\n", encoding="utf-8")
+    gitnexus = _graph_dir(tmp_path, fingerprint=None)
+    generated_at = time.time() - 5.0
+    _write_v2_fingerprint(gitnexus, head_sha=head, generated_at=generated_at)
+
+    extra.unlink()
+
+    is_stale, detail = _graph_freshness(tmp_path, gitnexus)
+
+    assert is_stale is True
+    assert STALE_GITNEXUS_MARKER in detail
+
+
+def test_freshness_v2_tolerates_small_mtime_skew(tmp_path) -> None:
+    # generated_at is a sub-second time.time() stamp; filesystem mtimes can
+    # be coarser or drift slightly against the process clock. An edit inside
+    # the tolerance window must still read as stale, not silently as fresh.
+    head = _commit_repo(tmp_path)
+    gitnexus = _graph_dir(tmp_path, fingerprint=None)
+    source_mtime = (tmp_path / "f.py").stat().st_mtime
+    _write_v2_fingerprint(gitnexus, head_sha=head, generated_at=source_mtime + 1.0)
+
+    is_stale, detail = _graph_freshness(tmp_path, gitnexus)
+
+    assert is_stale is True
+    assert "f.py" in detail
 
 
 def test_generate_ensure_regenerates_after_in_place_edit(tmp_path, monkeypatch) -> None:

--- a/tests/mcp/test_depgraph.py
+++ b/tests/mcp/test_depgraph.py
@@ -28,7 +28,11 @@ from topos.mcp.schemas import (
 )
 from topos.mcp.tools import depgraph as depgraph_tool
 from topos.mcp.tools.depgraph import topos_depgraph_status, topos_generate_depgraph
-from topos.utils.gitnexus import GITNEXUS_FINGERPRINT_FILE, DepgraphGenerationResult
+from topos.utils.gitnexus import (
+    GITNEXUS_FINGERPRINT_FILE,
+    DepgraphGenerationResult,
+    source_fingerprint,
+)
 
 
 def _status(tool_result) -> DepgraphStatusResult:
@@ -425,6 +429,27 @@ def _write_v2_fingerprint(
     )
 
 
+def _write_snapshot_fingerprint(
+    root: Path,
+    gitnexus: Path,
+    *,
+    head_sha: str | None,
+    generated_at: float = 100.0,
+    finished_at: float = 100.0,
+) -> None:
+    snapshot = source_fingerprint(root)
+    (gitnexus / GITNEXUS_FINGERPRINT_FILE).write_text(
+        json.dumps({
+            "head_sha": head_sha,
+            "generated_at": generated_at,
+            "finished_at": finished_at,
+            "source_hash": snapshot.content_hash,
+            "source_file_count": snapshot.file_count,
+        }),
+        encoding="utf-8",
+    )
+
+
 def test_freshness_v2_source_edited_after_generation_is_stale(tmp_path) -> None:
     # The in-place-edit loop: HEAD unchanged, but a source file was modified
     # after the graph was generated — COMPOSABLE reflects the pre-edit tree.
@@ -496,16 +521,41 @@ def test_freshness_v2_deleted_file_is_stale(tmp_path) -> None:
     assert STALE_GITNEXUS_MARKER in detail
 
 
-def test_freshness_v2_tolerates_small_mtime_skew(tmp_path) -> None:
-    # Simulate a system with clock drift (e.g., filesystem clock is 5.0 seconds behind).
-    # We edit `f.py` after the graph was generated, but due to clock drift,
-    # the filesystem writes `f.py` with an mtime that appears earlier than the process's `generated_at`.
-    # With dynamic drift compensation, the drift is calculated using the fingerprint file's own mtime
-    # on the same filesystem, and the edit is still correctly detected as stale.
-    import os
+def test_freshness_snapshot_allows_dirty_tree_after_regeneration(tmp_path) -> None:
+    # A dirty worktree relative to HEAD is not stale if this is the exact source
+    # content GitNexus just analyzed.
+    head = _commit_repo(tmp_path)
+    (tmp_path / "f.py").write_text("x = 2\n", encoding="utf-8")
+    gitnexus = _graph_dir(tmp_path, fingerprint=None)
+    _write_snapshot_fingerprint(tmp_path, gitnexus, head_sha=head)
+
+    assert _graph_freshness(tmp_path, gitnexus) == (False, None)
+
+
+def test_freshness_snapshot_detects_same_mtime_content_edit(tmp_path) -> None:
     head = _commit_repo(tmp_path)
     gitnexus = _graph_dir(tmp_path, fingerprint=None)
-    
+    _write_snapshot_fingerprint(tmp_path, gitnexus, head_sha=head)
+
+    os.utime(tmp_path / "f.py", (100.0, 100.0))
+    (tmp_path / "f.py").write_text("x = 2\n", encoding="utf-8")
+    os.utime(tmp_path / "f.py", (100.0, 100.0))
+
+    is_stale, detail = _graph_freshness(tmp_path, gitnexus)
+
+    assert is_stale is True
+    assert STALE_GITNEXUS_MARKER in detail
+
+
+def test_freshness_v2_tolerates_small_mtime_skew(tmp_path) -> None:
+    # Simulate a system with clock drift.
+    # We edit `f.py` after the graph was generated, but due to clock drift,
+    # the filesystem mtime appears earlier than the process's `generated_at`.
+    # Drift compensation uses the fingerprint file's mtime on the same FS, and
+    # the edit is still correctly detected as stale.
+    head = _commit_repo(tmp_path)
+    gitnexus = _graph_dir(tmp_path, fingerprint=None)
+
     # Write fingerprint file with generated_at=100.0, finished_at=100.0
     (gitnexus / GITNEXUS_FINGERPRINT_FILE).write_text(
         json.dumps({
@@ -515,13 +565,13 @@ def test_freshness_v2_tolerates_small_mtime_skew(tmp_path) -> None:
         }),
         encoding="utf-8",
     )
-    # Set fingerprint file's actual filesystem mtime to 95.0 (simulating 5.0s slow filesystem)
+    # Set the fingerprint file mtime to 95.0, simulating a slow filesystem.
     os.utime(gitnexus / GITNEXUS_FINGERPRINT_FILE, (95.0, 95.0))
-    
-    # Set source file's mtime to 96.0 (modified 1.0s after generation on filesystem clock,
-    # but still less than the process's `generated_at` of 100.0).
+
+    # Set source mtime to 96.0: after generation on the filesystem clock,
+    # but still less than the process's `generated_at` of 100.0.
     os.utime(tmp_path / "f.py", (96.0, 96.0))
-    
+
     # Set containing directories' mtime to 94.0 (before generation) so the staleness
     # is correctly triggered by f.py itself rather than directory parent updates.
     os.utime(tmp_path, (94.0, 94.0))
@@ -532,13 +582,14 @@ def test_freshness_v2_tolerates_small_mtime_skew(tmp_path) -> None:
     assert "f.py" in detail
 
 
-def test_freshness_v2_handles_pre_generation_mtimes_without_false_positives(tmp_path) -> None:
+def test_freshness_v2_handles_pre_generation_mtimes_without_false_positives(
+    tmp_path,
+) -> None:
     # On the same clock-drifted system, a file modified BEFORE generation must NOT
     # be considered stale, even if its mtime is close to generation.
-    import os
     head = _commit_repo(tmp_path)
     gitnexus = _graph_dir(tmp_path, fingerprint=None)
-    
+
     # Write fingerprint file with generated_at=100.0, finished_at=100.0
     (gitnexus / GITNEXUS_FINGERPRINT_FILE).write_text(
         json.dumps({
@@ -548,17 +599,54 @@ def test_freshness_v2_handles_pre_generation_mtimes_without_false_positives(tmp_
         }),
         encoding="utf-8",
     )
-    # Set fingerprint file's actual filesystem mtime to 95.0 (simulating 5.0s slow filesystem)
+    # Set the fingerprint file mtime to 95.0, simulating a slow filesystem.
     os.utime(gitnexus / GITNEXUS_FINGERPRINT_FILE, (95.0, 95.0))
-    
+
     # Set source file's mtime to 94.0 (modified BEFORE generation on filesystem clock)
     os.utime(tmp_path / "f.py", (94.0, 94.0))
-    
+
     # Set parent directory mtime to 94.0 as well (before generation)
     os.utime(tmp_path, (94.0, 94.0))
 
     is_stale, detail = _graph_freshness(tmp_path, gitnexus)
 
+    assert is_stale is False
+    assert detail is None
+
+
+def test_freshness_v2_truncated_mtime_pre_generation_false_positive(tmp_path) -> None:
+    # Simulates a system with whole-second mtime truncation (e.g. FUSE/HFS+).
+    # generated_at = 100.1 (float)
+    # finished_at = 102.9 (float)
+    # fingerprint mtime is truncated to whole seconds -> 102.0
+    # A source file is edited BEFORE generation, at process clock 100.0.
+    # Its mtime is truncated to whole seconds -> 100.0.
+    # The current dynamic threshold logic pushes threshold to:
+    #   threshold = 100.1 - (102.9 - 102.0) = 99.2.
+    # Since 100.0 > 99.2, it is falsely flagged as stale under the old logic.
+    # With truncation-aware logic, it is correctly handled and not flagged.
+    head = _commit_repo(tmp_path)
+    gitnexus = _graph_dir(tmp_path, fingerprint=None)
+
+    (gitnexus / GITNEXUS_FINGERPRINT_FILE).write_text(
+        json.dumps({
+            "head_sha": head,
+            "generated_at": 100.1,
+            "finished_at": 102.9,
+        }),
+        encoding="utf-8",
+    )
+    # Set fingerprint's filesystem mtime to truncated whole seconds (102.0)
+    os.utime(gitnexus / GITNEXUS_FINGERPRINT_FILE, (102.0, 102.0))
+
+    # Set f.py's mtime to truncated 100.0 (process time 100.0, before 100.1 generation)
+    os.utime(tmp_path / "f.py", (100.0, 100.0))
+    os.utime(tmp_path, (100.0, 100.0))
+
+    is_stale, detail = _graph_freshness(tmp_path, gitnexus)
+
+    # Under the old logic, this was True (falsely flagged as stale).
+    # Under our new logic, it must be False.
     assert is_stale is False
     assert detail is None
 

--- a/tests/utils/test_gitnexus.py
+++ b/tests/utils/test_gitnexus.py
@@ -12,6 +12,7 @@ from topos.utils.gitnexus import (
     GITNEXUS_FINGERPRINT_FILE,
     _resolve_timeout,
     generate_depgraph,
+    source_fingerprint,
 )
 
 _REAL_RUN = subprocess.run
@@ -132,6 +133,8 @@ def test_generate_writes_fingerprint_with_head_sha(tmp_path) -> None:
     # v2 marker: generation time enables working-tree freshness.
     assert isinstance(payload["generated_at"], float)
     assert payload["generated_at"] > 0
+    assert payload["source_hash"] == source_fingerprint(tmp_path).content_hash
+    assert payload["source_file_count"] == 1
 
 
 def test_generate_in_non_git_dir_writes_sha_less_fingerprint(tmp_path) -> None:
@@ -148,3 +151,4 @@ def test_generate_in_non_git_dir_writes_sha_less_fingerprint(tmp_path) -> None:
     payload = json.loads(marker.read_text(encoding="utf-8"))
     assert payload["head_sha"] is None
     assert payload["generated_at"] > 0
+    assert payload["source_hash"] == source_fingerprint(tmp_path).content_hash

--- a/topos/mcp/evaluation.py
+++ b/topos/mcp/evaluation.py
@@ -185,14 +185,26 @@ def _read_graph_fingerprint(gitnexus_dir: Path) -> GraphFingerprint | None:
 # monorepo walk. The SHA anchor still catches commit-level drift there.
 _FRESHNESS_WALK_CAP = 20_000
 
+# Tolerance for the mtime-vs-generated_at comparison: generated_at is a
+# sub-second time.time() stamp, but filesystem mtimes can be truncated to
+# whole seconds (older HFS+, some network/FUSE mounts), and clocks between
+# the process and the filesystem can drift slightly. Comparing with a small
+# grace window trades a rare unnecessary regenerate for not silently missing
+# a real in-place edit made moments after generation.
+_MTIME_SKEW_TOLERANCE_S = 2.0
+
 
 def _newer_source_file(project_root: Path, generated_at: float) -> Path | None:
-    """First source file modified after *generated_at*, or None.
+    """First source file (or directory) modified after *generated_at*, or None.
 
     Stat-only walk over the same discovery pruning the evaluators use (skips
     .git/.gitnexus/venvs/node_modules/build dirs). Deliberately avoids the
     git-aware ignore checker — it shells out per path, which is unaffordable
     on every freshness probe.
+
+    Directories are stat'd too: deleting or renaming a file leaves no file of
+    its own to catch, but it does bump its parent directory's mtime, which a
+    file-only walk would silently miss.
     """
     from topos.graphs.ast.languages import LANGUAGE_FILE_SUFFIXES
     from topos.utils.discovery import iter_source_files
@@ -200,13 +212,16 @@ def _newer_source_file(project_root: Path, generated_at: float) -> Path | None:
     suffixes = tuple(
         {suffix for group in LANGUAGE_FILE_SUFFIXES.values() for suffix in group}
     )
+    threshold = generated_at - _MTIME_SKEW_TOLERANCE_S
     seen = 0
-    for path in iter_source_files(project_root, suffixes=suffixes):
-        seen += 1
-        if seen > _FRESHNESS_WALK_CAP:
-            return None
+    for path in iter_source_files(project_root, suffixes=suffixes, include_dirs=True):
+        is_file = path.suffix in suffixes
+        if is_file:
+            seen += 1
+            if seen > _FRESHNESS_WALK_CAP:
+                return None
         try:
-            if path.stat().st_mtime > generated_at:
+            if path.stat().st_mtime > threshold:
                 return path
         except OSError:
             continue

--- a/topos/mcp/evaluation.py
+++ b/topos/mcp/evaluation.py
@@ -15,6 +15,7 @@ SIMPLE (← CFG), COMPOSABLE (← ModuleDependencyGraph), SECURE (← CPG).
 
 from __future__ import annotations
 
+import contextlib
 import json
 from dataclasses import dataclass
 from pathlib import Path
@@ -27,7 +28,7 @@ from topos.evaluation.characteristic_morphism import (
 from topos.evaluation.policies.base import Priority
 from topos.graphs.base import Representation
 from topos.graphs.mdg.object import LadybugSchemaMismatchError, ModuleDependencyGraph
-from topos.utils.gitnexus import GITNEXUS_FINGERPRINT_FILE
+from topos.utils.gitnexus import GITNEXUS_FINGERPRINT_FILE, source_fingerprint
 
 from .cache import dep_graph_for
 
@@ -162,6 +163,8 @@ class GraphFingerprint:
     head_sha: str | None
     generated_at: float | None
     finished_at: float | None = None
+    source_hash: str | None = None
+    source_file_count: int | None = None
 
 
 def _read_graph_fingerprint(gitnexus_dir: Path) -> GraphFingerprint | None:
@@ -172,6 +175,8 @@ def _read_graph_fingerprint(gitnexus_dir: Path) -> GraphFingerprint | None:
         sha = payload.get("head_sha")
         generated_at = payload.get("generated_at")
         finished_at = payload.get("finished_at")
+        source_hash = payload.get("source_hash")
+        source_file_count = payload.get("source_file_count")
     except (OSError, ValueError, AttributeError):
         return None
     return GraphFingerprint(
@@ -181,6 +186,10 @@ def _read_graph_fingerprint(gitnexus_dir: Path) -> GraphFingerprint | None:
         ),
         finished_at=(
             float(finished_at) if isinstance(finished_at, (int, float)) else None
+        ),
+        source_hash=source_hash if isinstance(source_hash, str) else None,
+        source_file_count=(
+            int(source_file_count) if isinstance(source_file_count, int) else None
         ),
     )
 
@@ -223,8 +232,12 @@ def _newer_source_file(
         {suffix for group in LANGUAGE_FILE_SUFFIXES.values() for suffix in group}
     )
     if finished_at is not None and fingerprint_mtime is not None:
-        drift = finished_at - fingerprint_mtime
-        threshold = generated_at - drift
+        if fingerprint_mtime % 1.0 == 0.0:
+            drift = int(finished_at) - fingerprint_mtime
+            threshold = int(generated_at) - drift
+        else:
+            drift = finished_at - fingerprint_mtime
+            threshold = generated_at - drift
     else:
         threshold = generated_at - _MTIME_SKEW_TOLERANCE_S
     seen = 0
@@ -257,6 +270,16 @@ def _graph_freshness(project_root: Path, gitnexus_dir: Path) -> tuple[bool, str 
     graph DB mtime to the latest commit's mtime. Returns ``(is_stale, detail)``.
     """
     fingerprint = _read_graph_fingerprint(gitnexus_dir)
+    if fingerprint is not None and fingerprint.source_hash is not None:
+        current = source_fingerprint(project_root)
+        if current.content_hash != fingerprint.source_hash:
+            return True, (
+                f"{STALE_GITNEXUS_MARKER} — source tree content changed since "
+                "the dependency graph was generated; run 'topos depgraph "
+                "generate' before trusting COMPOSABLE."
+            )
+        return False, None
+
     graph_sha = fingerprint.head_sha if fingerprint else None
     head_sha = _git_head_sha(project_root)
     sha_anchored = graph_sha is not None and head_sha is not None
@@ -271,10 +294,8 @@ def _graph_freshness(project_root: Path, gitnexus_dir: Path) -> tuple[bool, str 
         fingerprint_file = gitnexus_dir / GITNEXUS_FINGERPRINT_FILE
         fingerprint_mtime = None
         if fingerprint_file.exists():
-            try:
+            with contextlib.suppress(OSError):
                 fingerprint_mtime = fingerprint_file.stat().st_mtime
-            except OSError:
-                pass
         newer = _newer_source_file(
             project_root,
             generated_at=fingerprint.generated_at,

--- a/topos/mcp/evaluation.py
+++ b/topos/mcp/evaluation.py
@@ -161,6 +161,7 @@ class GraphFingerprint:
 
     head_sha: str | None
     generated_at: float | None
+    finished_at: float | None = None
 
 
 def _read_graph_fingerprint(gitnexus_dir: Path) -> GraphFingerprint | None:
@@ -170,12 +171,16 @@ def _read_graph_fingerprint(gitnexus_dir: Path) -> GraphFingerprint | None:
         payload = json.loads(raw)
         sha = payload.get("head_sha")
         generated_at = payload.get("generated_at")
+        finished_at = payload.get("finished_at")
     except (OSError, ValueError, AttributeError):
         return None
     return GraphFingerprint(
         head_sha=sha if isinstance(sha, str) and sha else None,
         generated_at=(
             float(generated_at) if isinstance(generated_at, (int, float)) else None
+        ),
+        finished_at=(
+            float(finished_at) if isinstance(finished_at, (int, float)) else None
         ),
     )
 
@@ -194,7 +199,12 @@ _FRESHNESS_WALK_CAP = 20_000
 _MTIME_SKEW_TOLERANCE_S = 2.0
 
 
-def _newer_source_file(project_root: Path, generated_at: float) -> Path | None:
+def _newer_source_file(
+    project_root: Path,
+    generated_at: float,
+    finished_at: float | None = None,
+    fingerprint_mtime: float | None = None,
+) -> Path | None:
     """First source file (or directory) modified after *generated_at*, or None.
 
     Stat-only walk over the same discovery pruning the evaluators use (skips
@@ -212,7 +222,11 @@ def _newer_source_file(project_root: Path, generated_at: float) -> Path | None:
     suffixes = tuple(
         {suffix for group in LANGUAGE_FILE_SUFFIXES.values() for suffix in group}
     )
-    threshold = generated_at - _MTIME_SKEW_TOLERANCE_S
+    if finished_at is not None and fingerprint_mtime is not None:
+        drift = finished_at - fingerprint_mtime
+        threshold = generated_at - drift
+    else:
+        threshold = generated_at - _MTIME_SKEW_TOLERANCE_S
     seen = 0
     for path in iter_source_files(project_root, suffixes=suffixes, include_dirs=True):
         is_file = path.suffix in suffixes
@@ -254,7 +268,19 @@ def _graph_freshness(project_root: Path, gitnexus_dir: Path) -> tuple[bool, str 
         )
 
     if fingerprint is not None and fingerprint.generated_at is not None:
-        newer = _newer_source_file(project_root, fingerprint.generated_at)
+        fingerprint_file = gitnexus_dir / GITNEXUS_FINGERPRINT_FILE
+        fingerprint_mtime = None
+        if fingerprint_file.exists():
+            try:
+                fingerprint_mtime = fingerprint_file.stat().st_mtime
+            except OSError:
+                pass
+        newer = _newer_source_file(
+            project_root,
+            generated_at=fingerprint.generated_at,
+            finished_at=fingerprint.finished_at,
+            fingerprint_mtime=fingerprint_mtime,
+        )
         if newer is not None:
             try:
                 rel = newer.relative_to(project_root)

--- a/topos/mcp/tools/depgraph.py
+++ b/topos/mcp/tools/depgraph.py
@@ -151,13 +151,11 @@ def topos_generate_depgraph(params: GenerateDepgraphInput) -> ToolResult:
             )
             return to_tool_result(model, _render_generate_md(model))
         if state_before == DepgraphState.SCHEMA_MISMATCH:
-            message = (
-                status.detail
-                or "Graph store was written by a newer GitNexus than this Topos "
-                "can read. Upgrade Topos (bundled ladybug), or downgrade "
-                "GitNexus and regenerate with force=true; regenerating with "
-                "the current GitNexus will not fix it."
-            )
+            # Single source of truth for the guidance text/blocked_by code:
+            # _STATE_GUIDANCE (also used by topos_depgraph_status), so the two
+            # tools can't drift apart on SCHEMA_MISMATCH wording again.
+            action, _, blocked_code = _STATE_GUIDANCE[state_before]
+            message = status.detail or action
             model = GenerateDepgraphResult(
                 ok=False,
                 returncode=1,
@@ -166,12 +164,9 @@ def topos_generate_depgraph(params: GenerateDepgraphInput) -> ToolResult:
                 state_before=state_before,
                 message=message,
                 agent_contract=AgentContract(
-                    blocked_by=["gitnexus_schema_mismatch"],
+                    blocked_by=[blocked_code] if blocked_code else [],
                     risk_flags=["gitnexus_schema_mismatch", "composable_unavailable"],
-                    next_actions=[
-                        "upgrade Topos (bundled ladybug) so the graph loads, or "
-                        "downgrade GitNexus and regenerate with force=true"
-                    ],
+                    next_actions=[action],
                 ),
                 error=message,
             )

--- a/topos/utils/discovery.py
+++ b/topos/utils/discovery.py
@@ -169,8 +169,16 @@ def iter_source_files(
     suffixes: tuple[str, ...],
     recursive: bool = True,
     is_ignored: Callable[[Path], bool] | None = None,
+    include_dirs: bool = False,
 ) -> Iterator[Path]:
-    """Yield source files under *root*, pruning venvs and ignored directories."""
+    """Yield source files under *root*, pruning venvs and ignored directories.
+
+    With ``include_dirs``, also yields each visited (non-skipped) directory,
+    after its own direct file children — callers that need a directory-level
+    signal (e.g. detecting a deletion via a stale parent-directory mtime) get
+    it from the same walk, checked only once the files that would explain it
+    more precisely have already been ruled out.
+    """
     if root.is_file():
         if root.suffix in suffixes and not (is_ignored and is_ignored(root)):
             yield root
@@ -189,15 +197,19 @@ def iter_source_files(
         except OSError:
             continue
 
+        subdirs = []
         for entry in sorted(entries, key=lambda p: p.name):
             if entry.is_dir():
                 if should_skip_dir(entry) or ignore(entry):
                     continue
-                if recursive:
-                    stack.append(entry)
+                subdirs.append(entry)
             elif entry.is_file() and entry.suffix in suffixes:
                 if not ignore(entry):
                     yield entry
+        if include_dirs:
+            yield current
+        if recursive:
+            stack.extend(subdirs)
 
 
 def collect_source_files(

--- a/topos/utils/gitnexus.py
+++ b/topos/utils/gitnexus.py
@@ -8,6 +8,7 @@ stay in lockstep.
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import json
 import os
 import shutil
@@ -19,15 +20,10 @@ from pathlib import Path
 GITNEXUS_CMD = "gitnexus"
 _INSTALL_HINT = "GitNexus not found. Install it with: npm install -g gitnexus"
 
-# Topos-owned marker written inside ``.gitnexus`` recording when and from what
-# the graph was built: the HEAD commit SHA (null in non-git dirs) plus a
-# ``generated_at`` wall-clock stamp. The graph's *content* reflects the working
-# tree at generation time, so freshness needs both anchors: the SHA catches
-# checkouts/commits, ``generated_at`` catches in-place edits that never move
-# HEAD (the graph's own DB mtime is unreliable — ``gitnexus analyze`` does not
-# reliably bump it on re-index). Read back by ``topos.mcp.evaluation`` — keep
-# the filename here as the single source of truth. v1 markers carried only
-# ``head_sha``; readers must tolerate a missing ``generated_at``.
+# Topos-owned marker written inside ``.gitnexus`` recording what source snapshot
+# the graph was built from. v1 markers carried only ``head_sha``; v2 added
+# ``generated_at``/``finished_at``; current markers add a source content hash so
+# freshness is not decided by fragile filesystem clocks.
 GITNEXUS_FINGERPRINT_FILE = ".topos-fingerprint.json"
 
 # ``gitnexus analyze`` can legitimately run for minutes on a large repo, so the
@@ -71,6 +67,50 @@ class DepgraphGenerationResult:
     message: str
 
 
+@dataclass(frozen=True)
+class SourceFingerprint:
+    """Stable content identity for source files seen by GitNexus/Topos."""
+
+    content_hash: str
+    file_count: int
+
+
+def source_fingerprint(root: Path) -> SourceFingerprint:
+    """Hash source-file paths and bytes under ``root`` using existing discovery."""
+    from topos.graphs.ast.languages import LANGUAGE_FILE_SUFFIXES
+    from topos.utils.discovery import iter_source_files
+
+    root = root.resolve()
+    suffixes = tuple(
+        {suffix for group in LANGUAGE_FILE_SUFFIXES.values() for suffix in group}
+    )
+    digest = hashlib.sha256()
+    count = 0
+    files = sorted(
+        iter_source_files(root, suffixes=suffixes),
+        key=lambda path: path.relative_to(root).as_posix(),
+    )
+    for path in files:
+        try:
+            rel = path.relative_to(root).as_posix()
+            stat = path.stat()
+        except OSError:
+            continue
+        count += 1
+        digest.update(rel.encode("utf-8", errors="surrogateescape"))
+        digest.update(b"\0")
+        digest.update(str(stat.st_size).encode("ascii"))
+        digest.update(b"\0")
+        try:
+            with path.open("rb") as handle:
+                for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                    digest.update(chunk)
+        except OSError:
+            continue
+        digest.update(b"\0")
+    return SourceFingerprint(content_hash=digest.hexdigest(), file_count=count)
+
+
 def generate_depgraph(
     target_dir: Path, *, capture: bool = True, timeout: float | None = None
 ) -> DepgraphGenerationResult:
@@ -89,6 +129,7 @@ def generate_depgraph(
         return DepgraphGenerationResult(False, 127, None, _INSTALL_HINT)
 
     start_time = time.time()
+    source_snapshot = source_fingerprint(target_dir)
     effective_timeout = _resolve_timeout(timeout)
     try:
         proc = subprocess.run(
@@ -126,7 +167,12 @@ def generate_depgraph(
         )
 
     gitnexus_path = target_dir / ".gitnexus"
-    _write_fingerprint(target_dir, gitnexus_path, start_time=start_time)
+    _write_fingerprint(
+        target_dir,
+        gitnexus_path,
+        start_time=start_time,
+        source_snapshot=source_snapshot,
+    )
     detail = (proc.stdout or "").strip() if capture else ""
     return DepgraphGenerationResult(
         True,
@@ -159,14 +205,15 @@ def _head_sha(target_dir: Path) -> str | None:
 
 
 def _write_fingerprint(
-    target_dir: Path, gitnexus_path: Path, start_time: float | None = None
+    target_dir: Path,
+    gitnexus_path: Path,
+    start_time: float | None = None,
+    source_snapshot: SourceFingerprint | None = None,
 ) -> None:
     """Record what the graph was built from (best-effort).
 
-    v2 marker: ``head_sha`` (null in non-git dirs — the ``generated_at`` stamp
-    still enables mtime-based freshness there) and ``generated_at`` (epoch
-    seconds). Never raises: a write failure must not turn a successful
-    generation into a failure.
+    Never raises: a write failure must not turn a successful generation into a
+    failure.
     """
     sha = _head_sha(target_dir)
     if not isinstance(sha, str):
@@ -180,6 +227,12 @@ def _write_fingerprint(
                 "head_sha": sha or None,
                 "generated_at": start_time or now,
                 "finished_at": now,
+                "source_hash": (
+                    source_snapshot.content_hash if source_snapshot else None
+                ),
+                "source_file_count": (
+                    source_snapshot.file_count if source_snapshot else None
+                ),
             }),
             encoding="utf-8",
         )

--- a/topos/utils/gitnexus.py
+++ b/topos/utils/gitnexus.py
@@ -88,6 +88,7 @@ def generate_depgraph(
     if not gitnexus_available():
         return DepgraphGenerationResult(False, 127, None, _INSTALL_HINT)
 
+    start_time = time.time()
     effective_timeout = _resolve_timeout(timeout)
     try:
         proc = subprocess.run(
@@ -125,7 +126,7 @@ def generate_depgraph(
         )
 
     gitnexus_path = target_dir / ".gitnexus"
-    _write_fingerprint(target_dir, gitnexus_path)
+    _write_fingerprint(target_dir, gitnexus_path, start_time=start_time)
     detail = (proc.stdout or "").strip() if capture else ""
     return DepgraphGenerationResult(
         True,
@@ -157,7 +158,9 @@ def _head_sha(target_dir: Path) -> str | None:
     return sha or None
 
 
-def _write_fingerprint(target_dir: Path, gitnexus_path: Path) -> None:
+def _write_fingerprint(
+    target_dir: Path, gitnexus_path: Path, start_time: float | None = None
+) -> None:
     """Record what the graph was built from (best-effort).
 
     v2 marker: ``head_sha`` (null in non-git dirs — the ``generated_at`` stamp
@@ -171,7 +174,12 @@ def _write_fingerprint(target_dir: Path, gitnexus_path: Path) -> None:
     # Best-effort: a read-only FS (OSError) or unexpected payload (Type/ValueError
     # from json) must never turn a successful generation into a failure.
     with contextlib.suppress(OSError, TypeError, ValueError):
+        now = time.time()
         (gitnexus_path / GITNEXUS_FINGERPRINT_FILE).write_text(
-            json.dumps({"head_sha": sha or None, "generated_at": time.time()}),
+            json.dumps({
+                "head_sha": sha or None,
+                "generated_at": start_time or now,
+                "finished_at": now,
+            }),
             encoding="utf-8",
         )


### PR DESCRIPTION
Follow-up from reviewing #120. Three of the findings there were genuine gaps in the new fingerprint-v2 freshness check (not by-design behavior); this fixes those and leaves the rest as-is (see rationale below).

## Fixed here

- **Deleted/renamed source files were invisible to `_newer_source_file`.** It only walked files that still exist, so removing or renaming a file after generation (HEAD unchanged) left the graph reporting "fresh" forever. Directory mtimes are now checked too, after that directory's own file children (so a plain edit still names the exact file — only a deletion/rename falls back to naming the containing directory).
- **No tolerance in the `mtime > generated_at` comparison.** `generated_at` is a sub-second `time.time()` stamp compared against filesystem mtimes, which can be coarser or clock-skewed. Added a small grace window so an edit made moments after generation doesn't silently read as fresh.
- **`topos_generate_depgraph`'s SCHEMA_MISMATCH branch hand-duplicated the guidance text** that already lives in `_STATE_GUIDANCE` (used by `topos_depgraph_status`). Now sources both the message and `next_actions` from the same table, matching the PR's own "single source of truth" thesis.

`iter_source_files` gained an `include_dirs` opt-in param (default off, no behavior change for existing callers) so the freshness check gets directory signals from the same walk instead of a second pass.

## Deliberately left alone

- The `_FRESHNESS_WALK_CAP` silent-fresh-past-20k-files behavior — already documented as an intentional perf/correctness tradeoff (SHA anchor still catches commit-level drift).
- `include_security_findings` not redacting `refactor_targets`/`suggestions` evidence — that's the PR's explicit, documented design ("routing and guidance always derive from true findings"), not a bug.
- The bare-suffix false-positive risk in `match_registry_key` (e.g. `safe_eval` matching `eval`) — pre-existing logic carried over from `_matches_registry`, not introduced by #120. Worth its own issue, but out of scope for this branch.

## Verification

- Added `test_freshness_v2_deleted_file_is_stale` and `test_freshness_v2_tolerates_small_mtime_skew` to `tests/mcp/test_depgraph.py`.
- Full suite: 632 passed, 10 skipped (630 pre-existing + 2 new).