### PR TITLE
Add Go language support (SIMPLE, SECURE, COMPOSABLE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Go language support**: Added parsing, mapping, and evaluation support for Go across all three quality dimensions (SIMPLE, SECURE, COMPOSABLE). Introduces `tree-sitter-go` parsing, `GoParser`, a dedicated Go UAST mapper (`mapper_go.py`), and central provider registry dispatching. Registers Go entries in the CPG dangerous-API (`exec.Command`, `syscall.Exec`, etc.) and taint-source (`os.Getenv`, `os.Args`, etc.) registries, and integrates cross-package boundary `IMPORTS` and `CALLS` edge mapping via GitNexus. ([#123](https://github.com/Krv-Labs/topos/pull/123), closes [#72](https://github.com/Krv-Labs/topos/issues/72), [#73](https://github.com/Krv-Labs/topos/issues/73), [#74](https://github.com/Krv-Labs/topos/issues/74))
+
+### Fixed
+
+- **CFG parser `if` branch locating**: Fixed a bug where `_if_branches` used a fixed position to locate the `then` block, causing it to break on Go's `if x := f(); cond {}` init-clause statement, and independently, on any Python, C++, or Rust `if` condition containing a same-line trailing comment. The `then` block is now correctly located by node kind. ([#123](https://github.com/Krv-Labs/topos/pull/123))
+- **CFG parser loop body locating**: Fixed a bug where `_loop_body` unconditionally sliced off the first child as a loop condition/iterator, which silently dropped the entire body of Go's condition-less `for {}` loop. The loop body is now correctly located by node kind. ([#123](https://github.com/Krv-Labs/topos/pull/123))
+- **CLI language detection for non-Python files**: Fixed a bug where `topos inspect` and `topos evaluate` CPG building and entropy calculations defaulted non-Python files to Python parsing due to a default parameter in `ProgramMorphism.from_file`. Correctly threads `detect_language(path)` through the affected CLI paths. ([#123](https://github.com/Krv-Labs/topos/pull/123))
+
 ## [0.3.9] - 2026-07-06
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "tree-sitter-javascript>=0.23",
     "tree-sitter-cpp>=0.23",
     "tree-sitter-typescript>=0.23",
+    "tree-sitter-go>=0.23",
     "click>=8.1",
     "fastmcp>=3.4.2",
     "numpy>=1.24",

--- a/tests/cli/test_quality.py
+++ b/tests/cli/test_quality.py
@@ -270,6 +270,25 @@ def test_inspect_shows_security_findings_and_suggestions(tmp_path: Path):
     assert "Suggestions" in out
 
 
+def test_inspect_go_file_uses_go_cpg_for_security_findings(tmp_path: Path):
+    """`_build_cpg` must detect the file's language from its suffix, not
+    default to Python — otherwise a non-Python CPG build silently finds
+    nothing and every dangerous call goes unreported."""
+    f = tmp_path / "danger.go"
+    f.write_text(
+        'package main\n\nimport "os/exec"\n\n'
+        "func run(cmd string) {\n\texec.Command(cmd).Run()\n}\n",
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["inspect", str(f)])
+    assert result.exit_code == 0
+    out = _strip_ansi(result.output)
+    assert "Security Findings" in out
+    assert "exec.Command" in out
+
+
 def test_inspect_allowlist_flips_verdict_and_caps_grade(tmp_path: Path):
     f = tmp_path / "conf.py"
     f.write_text("import yaml\ndef g(p):\n    return yaml.load(p)\n", encoding="utf-8")

--- a/tests/fixtures/binarytrees/binarytrees.go
+++ b/tests/fixtures/binarytrees/binarytrees.go
@@ -1,0 +1,68 @@
+// The Computer Language Benchmarks Game
+// https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
+//
+// Go transliteration for topos multilang AST fixtures.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+type Tree struct {
+	left  *Tree
+	right *Tree
+}
+
+func bottomUpTree(depth int) *Tree {
+	if depth <= 0 {
+		return &Tree{}
+	}
+	return &Tree{
+		left:  bottomUpTree(depth - 1),
+		right: bottomUpTree(depth - 1),
+	}
+}
+
+func itemCheck(tree *Tree) int {
+	if tree.left == nil {
+		return 1
+	}
+	return 1 + itemCheck(tree.left) + itemCheck(tree.right)
+}
+
+func main() {
+	n := 10
+	if len(os.Args) > 1 {
+		parsed, err := strconv.Atoi(os.Args[1])
+		if err == nil {
+			n = parsed
+		}
+	}
+
+	minDepth := 4
+	maxDepth := n
+	if minDepth+2 > maxDepth {
+		maxDepth = minDepth + 2
+	}
+	stretchDepth := maxDepth + 1
+
+	stretchTree := bottomUpTree(stretchDepth)
+	fmt.Printf("stretch tree of depth %d\t check: %d\n", stretchDepth, itemCheck(stretchTree))
+
+	longLivedTree := bottomUpTree(maxDepth)
+
+	for depth := minDepth; depth <= maxDepth; depth += 2 {
+		iterations := 1 << uint(maxDepth-depth+minDepth)
+		check := 0
+		for i := 0; i < iterations; i++ {
+			tree := bottomUpTree(depth)
+			check += itemCheck(tree)
+		}
+		fmt.Printf("%d\t trees of depth %d\t check: %d\n", iterations, depth, check)
+	}
+
+	fmt.Printf("long lived tree of depth %d\t check: %d\n", maxDepth, itemCheck(longLivedTree))
+}

--- a/tests/graphs/ast/test_multilang_ast.py
+++ b/tests/graphs/ast/test_multilang_ast.py
@@ -29,6 +29,16 @@ def test_parse_source_rust_hybrid_falls_back_to_tree_sitter():
     assert result.provenance.parser == "tree-sitter-rust"
 
 
+def test_parse_source_go_hybrid_falls_back_to_tree_sitter():
+    result = parse_source(
+        'package main\n\nfunc main() {\n\tif 1 > 0 {\n\t\tprintln("ok")\n\t}\n}\n',
+        language="go",
+    )
+    assert result.native_ast is None
+    assert result.uast_root is not None
+    assert result.provenance.parser == "tree-sitter-go"
+
+
 def test_parse_source_typescript_hybrid():
     result = parse_source("const x: number = 1;\n", language="typescript")
     assert result.native_ast is None
@@ -58,15 +68,21 @@ def test_program_morphism_supports_multiple_languages():
         source="interface A { x: number }\n",
         language="typescript",
     )
+    go_morphism = ProgramMorphism(
+        source="package main\n\nfunc main() {}\n",
+        language="go",
+    )
 
     assert rust_morphism.ast is not None
     assert js_morphism.ast is not None
     assert cpp_morphism.ast is not None
     assert ts_morphism.ast is not None
+    assert go_morphism.ast is not None
     assert rust_morphism.ast.language == "rust"
     assert js_morphism.ast.language == "javascript"
     assert cpp_morphism.ast.language == "cpp"
     assert ts_morphism.ast.language == "typescript"
+    assert go_morphism.ast.language == "go"
 
 
 def test_capability_matrix_tracks_native_and_uast_support():
@@ -76,6 +92,9 @@ def test_capability_matrix_tracks_native_and_uast_support():
     assert matrix["javascript"]["supports_uast"] is True
     assert matrix["typescript"]["supports_uast"] is True
     assert matrix["cpp"]["supports_tree_sitter"] is True
+    assert matrix["go"]["supports_native"] is False
+    assert matrix["go"]["supports_tree_sitter"] is True
+    assert matrix["go"]["supports_uast"] is True
 
 
 def test_native_ref_parser_identity_per_language():
@@ -85,6 +104,7 @@ def test_native_ref_parser_identity_per_language():
         ("javascript", "function x() { return 1; }", "tree-sitter-javascript"),
         ("typescript", "const x: number = 1;", "tree-sitter-typescript"),
         ("cpp", "int main() { return 0; }", "tree-sitter-cpp"),
+        ("go", "package main\n\nfunc main() {}\n", "tree-sitter-go"),
     ]
     for language, source, expected_parser in cases:
         result = parse_source(source, language=language)
@@ -132,6 +152,7 @@ def test_binarytrees_sources_produce_minimum_uast_invariants():
         ".js": "javascript",
         ".rs": "rust",
         ".cpp": "cpp",
+        ".go": "go",
     }
 
     for file in src_dir.iterdir():

--- a/tests/graphs/cfg/test_cfg.py
+++ b/tests/graphs/cfg/test_cfg.py
@@ -86,6 +86,18 @@ def test_while_loop_generates_back_edge():
     assert EdgeKind.LOOP_BACK in kinds
 
 
+def test_if_with_trailing_comment_on_condition_keeps_then_branch():
+    """A comment on the `if` line is a real named child in some grammars
+    (tree-sitter-python inserts it between the predicate and the block);
+    it must not be mistaken for the then-body, which would merge both
+    branches into "else" and leave "if_then" empty."""
+    cfg = _cfg(
+        "def f(x):\n    if x > 0:  # comment\n        return 1\n    return 0\n"
+    )
+    then_block = next(b for b in cfg.blocks.values() if b.label == "if_then")
+    assert any(s.kind == "ReturnStmt" for s in then_block.statements)
+
+
 def test_nested_callable_return_does_not_poison_outer_sequence():
     """
     Return inside a nested arrow/object method must not leave current_id=None

--- a/tests/graphs/cfg/test_cfg.py
+++ b/tests/graphs/cfg/test_cfg.py
@@ -91,9 +91,7 @@ def test_if_with_trailing_comment_on_condition_keeps_then_branch():
     (tree-sitter-python inserts it between the predicate and the block);
     it must not be mistaken for the then-body, which would merge both
     branches into "else" and leave "if_then" empty."""
-    cfg = _cfg(
-        "def f(x):\n    if x > 0:  # comment\n        return 1\n    return 0\n"
-    )
+    cfg = _cfg("def f(x):\n    if x > 0:  # comment\n        return 1\n    return 0\n")
     then_block = next(b for b in cfg.blocks.values() if b.label == "if_then")
     assert any(s.kind == "ReturnStmt" for s in then_block.statements)
 

--- a/tests/graphs/cfg/test_cfg.py
+++ b/tests/graphs/cfg/test_cfg.py
@@ -141,6 +141,11 @@ def test_break_continue_resolve_to_loop_targets():
             "fn f(x: i32) -> i32 { return x; }\n",
             "fn f(x: i32) -> i32 { if x > 0 { return 1; } return 0; }\n",
         ),
+        (
+            "go",
+            "func f(x int) int { return x }\n",
+            "func f(x int) int {\n\tif x > 0 {\n\t\treturn 1\n\t}\n\treturn 0\n}\n",
+        ),
     ],
 )
 def test_cyclomatic_grows_with_branching_across_languages(language, linear, branchy):

--- a/tests/graphs/cfg/test_go_cfg.py
+++ b/tests/graphs/cfg/test_go_cfg.py
@@ -128,6 +128,30 @@ def test_go_if_with_init_clause_keeps_then_branch():
     assert any(s.kind == "ReturnStmt" for s in then_block.statements)
 
 
+def test_go_bare_for_loop_keeps_body():
+    """A condition-less `for { }` has a single named child (the block
+    itself), so slicing off "the first child" as the condition must not
+    slice away the entire body."""
+    src = (
+        "package main\n\n"
+        "func loop() int {\n"
+        "\ttotal := 0\n"
+        "\tfor {\n"
+        "\t\ttotal++\n"
+        "\t\tif total > 3 {\n"
+        "\t\t\tbreak\n"
+        "\t\t}\n"
+        "\t}\n"
+        "\treturn total\n"
+        "}\n"
+    )
+    cfg = _cfg(src)
+    kinds = {e.kind for e in cfg.edges}
+    assert EdgeKind.BREAK in kinds
+    body_block = next(b for b in cfg.blocks.values() if b.label == "loop_body")
+    assert body_block.statements
+
+
 def test_go_for_loop_break_continue_resolve_to_loop_targets():
     src = (
         "package main\n\n"

--- a/tests/graphs/cfg/test_go_cfg.py
+++ b/tests/graphs/cfg/test_go_cfg.py
@@ -1,0 +1,134 @@
+"""
+Go-specific CFG shape regression tests.
+
+Go's tree-sitter grammar has two shapes not exercised by any other
+currently-supported language:
+
+1. Function/if/for bodies wrap their statements in an intermediate
+   ``statement_list`` node (``block`` -> ``statement_list`` -> statements),
+   one level deeper than Python's ``suite`` or C++'s ``compound_statement``.
+2. ``switch``/``select`` can omit a discriminant entirely (``switch { case
+   ...}``, ``select { case ... }``), so the first non-predicate child of the
+   statement is itself a case arm rather than a subject expression.
+
+These tests pin down the resulting CFG shape so future grammar-mapping or
+builder changes don't silently regress them.
+"""
+
+from __future__ import annotations
+
+from topos.core.morphism import ProgramMorphism
+from topos.graphs.cfg.models import EdgeKind
+from topos.graphs.cfg.object import ControlFlowGraph
+
+
+def _cfg(source: str) -> ControlFlowGraph:
+    morphism = ProgramMorphism(source=source, language="go")
+    cfg = morphism.build_cfg()
+    assert cfg is not None
+    return cfg
+
+
+def test_go_if_else_if_chain_creates_nested_decision():
+    src = (
+        "package main\n\n"
+        "func classify(n int) string {\n"
+        "\tif n < 0 {\n"
+        "\t\treturn \"neg\"\n"
+        "\t} else if n == 0 {\n"
+        "\t\treturn \"zero\"\n"
+        "\t} else {\n"
+        "\t\treturn \"other\"\n"
+        "\t}\n"
+        "}\n"
+    )
+    cfg = _cfg(src)
+    # Two independent if-decisions (outer + nested else-if) => 3, plus 1 for
+    # the synthetic module-level callable that every real .go file triggers
+    # (its `package` clause is a non-function top-level child, same as any
+    # other language's top-level statements outside a function).
+    assert cfg.metrics()["cfg.cyclomatic"] == 4.0
+    kinds = [e.kind for e in cfg.edges]
+    assert kinds.count(EdgeKind.TRUE) == 2
+    assert kinds.count(EdgeKind.FALSE) == 2
+    assert kinds.count(EdgeKind.RETURN) == 3
+
+
+def test_go_tagless_switch_creates_one_arm_per_case():
+    src = (
+        "package main\n\n"
+        "func classify(n int) string {\n"
+        "\tswitch {\n"
+        "\tcase n < 0:\n"
+        "\t\treturn \"neg\"\n"
+        "\tcase n == 0:\n"
+        "\t\treturn \"zero\"\n"
+        "\tdefault:\n"
+        "\t\treturn \"pos\"\n"
+        "\t}\n"
+        "}\n"
+    )
+    cfg = _cfg(src)
+    kinds = [e.kind for e in cfg.edges]
+    assert kinds.count(EdgeKind.SWITCH_CASE) == 3
+    assert kinds.count(EdgeKind.RETURN) == 3
+
+
+def test_go_type_switch_creates_one_arm_per_case():
+    src = (
+        "package main\n\n"
+        "func typesw(x interface{}) string {\n"
+        "\tswitch x.(type) {\n"
+        "\tcase int:\n"
+        "\t\treturn \"int\"\n"
+        "\tdefault:\n"
+        "\t\treturn \"other\"\n"
+        "\t}\n"
+        "}\n"
+    )
+    cfg = _cfg(src)
+    kinds = [e.kind for e in cfg.edges]
+    assert kinds.count(EdgeKind.SWITCH_CASE) == 2
+    assert kinds.count(EdgeKind.RETURN) == 2
+
+
+def test_go_select_statement_creates_one_arm_per_case():
+    src = (
+        "package main\n\n"
+        "func sel(ch chan int, done chan bool) int {\n"
+        "\tselect {\n"
+        "\tcase v := <-ch:\n"
+        "\t\treturn v\n"
+        "\tcase <-done:\n"
+        "\t\treturn 0\n"
+        "\t}\n"
+        "}\n"
+    )
+    cfg = _cfg(src)
+    kinds = [e.kind for e in cfg.edges]
+    assert kinds.count(EdgeKind.SWITCH_CASE) == 2
+    assert kinds.count(EdgeKind.RETURN) == 2
+
+
+def test_go_for_loop_break_continue_resolve_to_loop_targets():
+    src = (
+        "package main\n\n"
+        "func loopy(items []int) int {\n"
+        "\ttotal := 0\n"
+        "\tfor i := 0; i < len(items); i++ {\n"
+        "\t\tif items[i] < 0 {\n"
+        "\t\t\tcontinue\n"
+        "\t\t}\n"
+        "\t\tif items[i] == 0 {\n"
+        "\t\t\tbreak\n"
+        "\t\t}\n"
+        "\t\ttotal += items[i]\n"
+        "\t}\n"
+        "\treturn total\n"
+        "}\n"
+    )
+    cfg = _cfg(src)
+    kinds = {e.kind for e in cfg.edges}
+    assert EdgeKind.LOOP_BACK in kinds
+    assert EdgeKind.BREAK in kinds
+    assert EdgeKind.CONTINUE in kinds

--- a/tests/graphs/cfg/test_go_cfg.py
+++ b/tests/graphs/cfg/test_go_cfg.py
@@ -34,11 +34,11 @@ def test_go_if_else_if_chain_creates_nested_decision():
         "package main\n\n"
         "func classify(n int) string {\n"
         "\tif n < 0 {\n"
-        "\t\treturn \"neg\"\n"
+        '\t\treturn "neg"\n'
         "\t} else if n == 0 {\n"
-        "\t\treturn \"zero\"\n"
+        '\t\treturn "zero"\n'
         "\t} else {\n"
-        "\t\treturn \"other\"\n"
+        '\t\treturn "other"\n'
         "\t}\n"
         "}\n"
     )
@@ -60,11 +60,11 @@ def test_go_tagless_switch_creates_one_arm_per_case():
         "func classify(n int) string {\n"
         "\tswitch {\n"
         "\tcase n < 0:\n"
-        "\t\treturn \"neg\"\n"
+        '\t\treturn "neg"\n'
         "\tcase n == 0:\n"
-        "\t\treturn \"zero\"\n"
+        '\t\treturn "zero"\n'
         "\tdefault:\n"
-        "\t\treturn \"pos\"\n"
+        '\t\treturn "pos"\n'
         "\t}\n"
         "}\n"
     )
@@ -80,9 +80,9 @@ def test_go_type_switch_creates_one_arm_per_case():
         "func typesw(x interface{}) string {\n"
         "\tswitch x.(type) {\n"
         "\tcase int:\n"
-        "\t\treturn \"int\"\n"
+        '\t\treturn "int"\n'
         "\tdefault:\n"
-        "\t\treturn \"other\"\n"
+        '\t\treturn "other"\n'
         "\t}\n"
         "}\n"
     )

--- a/tests/graphs/cfg/test_go_cfg.py
+++ b/tests/graphs/cfg/test_go_cfg.py
@@ -110,6 +110,24 @@ def test_go_select_statement_creates_one_arm_per_case():
     assert kinds.count(EdgeKind.RETURN) == 2
 
 
+def test_go_if_with_init_clause_keeps_then_branch():
+    """`if x := f(); cond {}` has no wrapper grouping the init statement
+    with the condition, so the then-block is not the second child — it
+    must be located by kind, not position."""
+    src = (
+        "package main\n\n"
+        "func f(err error) int {\n"
+        "\tif err := g(); err != nil {\n"
+        "\t\treturn 1\n"
+        "\t}\n"
+        "\treturn 0\n"
+        "}\n"
+    )
+    cfg = _cfg(src)
+    then_block = next(b for b in cfg.blocks.values() if b.label == "if_then")
+    assert any(s.kind == "ReturnStmt" for s in then_block.statements)
+
+
 def test_go_for_loop_break_continue_resolve_to_loop_targets():
     src = (
         "package main\n\n"

--- a/tests/mcp/test_evaluate.py
+++ b/tests/mcp/test_evaluate.py
@@ -364,7 +364,7 @@ def test_evaluate_file_go_clean_snippet_passes_secure(
     path = tmp_path / "clean.go"
     path.write_text(
         "package main\n\n"
-        "import \"fmt\"\n\n"
+        'import "fmt"\n\n'
         "func greet(name string) string {\n"
         '\treturn fmt.Sprintf("Hello, %s!", name)\n'
         "}\n",

--- a/tests/mcp/test_evaluate.py
+++ b/tests/mcp/test_evaluate.py
@@ -321,6 +321,67 @@ def test_evaluate_file_reports_security_findings(
     assert r.security_findings[0].line == 2
 
 
+def test_evaluate_file_reports_security_findings_for_go(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from topos.mcp import security
+
+    monkeypatch.setenv("TOPOS_MCP_FILE_ROOT", str(tmp_path))
+    security.reset_file_root_cache()
+    path = tmp_path / "danger.go"
+    path.write_text(
+        "package main\n\n"
+        "import (\n"
+        '\t"os"\n'
+        '\t"os/exec"\n'
+        ")\n\n"
+        "func run() {\n"
+        '\tcmd := exec.Command("sh", "-c", os.Getenv("USER_INPUT"))\n'
+        "\tcmd.Run()\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    r = _eval(
+        topos_evaluate_file(
+            EvaluateFileInput(filepath="danger.go", preferences=_PREFS, verbose=True)
+        )
+    )
+
+    assert r.security_findings
+    assert r.security_findings[0].callee == "exec.Command"
+    assert r.raw_metrics["cpg.dangerous_calls"] >= 1.0
+    assert "cpg.taint_flows" in r.raw_metrics
+
+
+def test_evaluate_file_go_clean_snippet_passes_secure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from topos.mcp import security
+
+    monkeypatch.setenv("TOPOS_MCP_FILE_ROOT", str(tmp_path))
+    security.reset_file_root_cache()
+    path = tmp_path / "clean.go"
+    path.write_text(
+        "package main\n\n"
+        "import \"fmt\"\n\n"
+        "func greet(name string) string {\n"
+        '\treturn fmt.Sprintf("Hello, %s!", name)\n'
+        "}\n",
+        encoding="utf-8",
+    )
+
+    r = _eval(
+        topos_evaluate_file(
+            EvaluateFileInput(filepath="clean.go", preferences=_PREFS, verbose=True)
+        )
+    )
+
+    assert r.security_findings == []
+    assert r.raw_metrics["cpg.dangerous_calls"] == 0.0
+    assert r.pillars["secure"].achieved is True
+
+
 def test_evaluate_file_applies_topos_allowlist(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -415,6 +476,47 @@ def test_evaluate_file_uses_depgraph_when_gitnexus_dir_exists() -> None:
             topos_evaluate_file(
                 EvaluateFileInput(
                     filepath="topos/__init__.py",
+                    gitnexus_dir="/fake/.gitnexus",
+                    preferences=_PREFS,
+                )
+            )
+        )
+    mock_load.assert_called_once()
+    assert r.coupling_available is True
+    assert "composable" in r.scores, (
+        "composable dimension must be present when a ModuleDependencyGraph is attached"
+    )
+
+
+def test_evaluate_go_file_uses_depgraph_when_gitnexus_dir_exists() -> None:
+    """COMPOSABLE for Go: mocked GitNexus-shaped data, independent of whether
+    a live `gitnexus analyze` run is available in this environment (verified
+    separately — GitNexus 1.6.8 fully supports Go, producing File nodes with
+    correct filePath values and IMPORTS/CALLS edges across package
+    boundaries)."""
+    fake_graph = MagicMock()
+    fake_graph.name = "mdg"
+    fake_graph.dimension = "composable"
+    fake_graph.metrics.return_value = {
+        "mdg.coupling": 1.0,
+        "mdg.instability": 1.0,
+        "mdg.fan_in": 0.0,
+        "mdg.fan_out": 1.0,
+        "mdg.dep_depth": 1.0,
+    }
+    with (
+        patch(
+            "topos.mcp.evaluation.load_dep_graph", return_value=fake_graph
+        ) as mock_load,
+        patch(
+            "topos.mcp.evaluation.resolve_gitnexus_dir",
+            return_value=Path("/fake/.gitnexus"),
+        ),
+    ):
+        r = _eval(
+            topos_evaluate_file(
+                EvaluateFileInput(
+                    filepath="tests/fixtures/binarytrees/binarytrees.go",
                     gitnexus_dir="/fake/.gitnexus",
                     preferences=_PREFS,
                 )

--- a/topos/cli/commands/quality.py
+++ b/topos/cli/commands/quality.py
@@ -295,6 +295,7 @@ def inspect(
     from topos.core.morphism import ProgramMorphism
     from topos.evaluation.policies.simple import describe_entropy_ratio
     from topos.functors.probes.ast.entropy import calculate_kolmogorov_proxy
+    from topos.mcp.evaluation import detect_language
 
     # Use the first preference as the priority for CLI output
     if preferences:
@@ -303,7 +304,7 @@ def inspect(
             click.echo(f"Error: Invalid preference '{priority}'", err=True)
             sys.exit(1)
 
-    morphism = ProgramMorphism.from_file(path)
+    morphism = ProgramMorphism.from_file(path, language=detect_language(Path(path)))
     result = run_classify_file(Path(path), priority=priority, gitnexus_dir=gitnexus_dir)
 
     config = merge_cli_allows(load_topos_config(Path(path)), allows)

--- a/topos/cli/diagnostics.py
+++ b/topos/cli/diagnostics.py
@@ -60,8 +60,11 @@ def collect_findings_and_verdict(
 def _build_cpg(path: str | Path):  # type: ignore[no-untyped-def]
     try:
         from topos.core.morphism import ProgramMorphism
+        from topos.mcp.evaluation import detect_language
 
-        return ProgramMorphism.from_file(str(path)).build_cpg()
+        return ProgramMorphism.from_file(
+            str(path), language=detect_language(Path(path))
+        ).build_cpg()
     except (OSError, ValueError):
         return None
 

--- a/topos/functors/probes/cpg/danger.py
+++ b/topos/functors/probes/cpg/danger.py
@@ -61,6 +61,13 @@ DANGEROUS_APIS: dict[str, set[str]] = {
         "scanf",
         "system",
     },
+    "go": {
+        "exec.Command",
+        "exec.CommandContext",
+        "os.StartProcess",
+        "syscall.Exec",
+        "syscall.ForkExec",
+    },
 }
 
 _CALL_PREFIX = re.compile(r"^([A-Za-z_][A-Za-z0-9_.]*)\s*\(")

--- a/topos/functors/probes/cpg/taint.py
+++ b/topos/functors/probes/cpg/taint.py
@@ -57,6 +57,13 @@ TAINT_SOURCES: dict[str, set[str]] = {
         "getenv",
         "scanf",
     },
+    "go": {
+        "os.Getenv",
+        "os.Args",
+        "r.FormValue",
+        "r.URL",
+        "flag.String",
+    },
 }
 
 

--- a/topos/graphs/ast/languages.py
+++ b/topos/graphs/ast/languages.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-SUPPORTED_LANGUAGES = frozenset({"python", "rust", "javascript", "typescript", "cpp"})
+SUPPORTED_LANGUAGES = frozenset(
+    {"python", "rust", "javascript", "typescript", "cpp", "go"}
+)
 
 LANGUAGE_FILE_SUFFIXES: dict[str, tuple[str, ...]] = {
     "python": (".py",),
@@ -10,6 +12,7 @@ LANGUAGE_FILE_SUFFIXES: dict[str, tuple[str, ...]] = {
     "javascript": (".js", ".mjs", ".cjs"),
     "typescript": (".ts", ".tsx"),
     "cpp": (".cpp", ".cc", ".cxx", ".hpp", ".hh", ".hxx"),
+    "go": (".go",),
 }
 
 

--- a/topos/graphs/ast/providers/tree_sitter_provider.py
+++ b/topos/graphs/ast/providers/tree_sitter_provider.py
@@ -5,12 +5,14 @@ from dataclasses import dataclass
 from topos.graphs.ast.types import ParseResult, ParserProvenance
 from topos.graphs.uast.mapper_common import parser_identity
 from topos.graphs.uast.mapper_cpp import map_cpp_tree_to_uast
+from topos.graphs.uast.mapper_go import map_go_tree_to_uast
 from topos.graphs.uast.mapper_javascript import map_javascript_tree_to_uast
 from topos.graphs.uast.mapper_python import map_python_tree_to_uast
 from topos.graphs.uast.mapper_rust import map_rust_tree_to_uast
 from topos.graphs.uast.mapper_typescript import map_typescript_tree_to_uast
 from topos.utils.tree_sitter import (
     parse_cpp,
+    parse_go,
     parse_javascript,
     parse_python,
     parse_rust,
@@ -23,6 +25,7 @@ _TREE_SITTER_PARSE = {
     "javascript": parse_javascript,
     "typescript": parse_typescript,
     "cpp": parse_cpp,
+    "go": parse_go,
 }
 
 _TREE_SITTER_UAST = {
@@ -31,6 +34,7 @@ _TREE_SITTER_UAST = {
     "javascript": map_javascript_tree_to_uast,
     "typescript": map_typescript_tree_to_uast,
     "cpp": map_cpp_tree_to_uast,
+    "go": map_go_tree_to_uast,
 }
 
 

--- a/topos/graphs/cfg/builder.py
+++ b/topos/graphs/cfg/builder.py
@@ -325,24 +325,30 @@ _STATEMENT_KINDS = frozenset(
     }
 )
 
+# Native tree-sitter node kinds for a Go switch/select case arm (tagged,
+# tagless, or type-switch) — also block containers, since each arm holds
+# its own statement list.
+_CASE_ARM_NATIVE_KINDS = frozenset(
+    {"expression_case", "type_case", "default_case", "communication_case"}
+)
+
 # Native tree-sitter node kinds that act as transparent block containers
 # (no UAST kind of their own — mapped to "Unknown").
-_BLOCK_NATIVE_KINDS = frozenset(
-    {
-        "block",
-        "suite",
-        "compound_statement",
-        "statement_block",
-        "function_body",
-        "do_statement",
-        "else_clause",
-        "elif_clause",
-        "statement_list",  # Go wraps a `block`'s statements one level deeper
-        "expression_case",  # Go `switch` arm (tagged or tagless)
-        "type_case",  # Go `switch x.(type)` arm
-        "default_case",  # Go `switch`/`select` default arm
-        "communication_case",  # Go `select` arm
-    }
+_BLOCK_NATIVE_KINDS = (
+    frozenset(
+        {
+            "block",
+            "suite",
+            "compound_statement",
+            "statement_block",
+            "function_body",
+            "do_statement",
+            "else_clause",
+            "elif_clause",
+            "statement_list",  # Go wraps a `block`'s statements one level deeper
+        }
+    )
+    | _CASE_ARM_NATIVE_KINDS
 )
 
 
@@ -416,11 +422,6 @@ def _loop_body(stmt: UASTNode) -> list[UASTNode]:
         if _is_block_container(child):
             return _unwrap_to_statements([child])
     return []
-
-
-_CASE_ARM_NATIVE_KINDS = frozenset(
-    {"expression_case", "type_case", "default_case", "communication_case"}
-)
 
 
 def _match_arms(stmt: UASTNode) -> list[UASTNode]:

--- a/topos/graphs/cfg/builder.py
+++ b/topos/graphs/cfg/builder.py
@@ -405,12 +405,17 @@ def _if_branches(stmt: UASTNode) -> tuple[list[UASTNode], list[UASTNode]]:
 
 
 def _loop_body(stmt: UASTNode) -> list[UASTNode]:
-    """Extract loop-body statements, skipping test/iterator clauses."""
-    if not stmt.children:
-        return []
-    # The first child is the loop test / iterator binding.  Everything
-    # after is body — but the body is wrapped in a block.
-    return _unwrap_to_statements(stmt.children[1:])
+    """Extract loop-body statements, skipping test/iterator clauses.
+
+    The body is located by kind (the first block-container child), not by
+    position — a condition-less Go ``for { }`` has no leading test/clause
+    child at all, so the body is the *first* child rather than "everything
+    after the first child".
+    """
+    for child in stmt.children:
+        if _is_block_container(child):
+            return _unwrap_to_statements([child])
+    return []
 
 
 _CASE_ARM_NATIVE_KINDS = frozenset(

--- a/topos/graphs/cfg/builder.py
+++ b/topos/graphs/cfg/builder.py
@@ -376,8 +376,13 @@ def _function_body(callable_node: UASTNode) -> list[UASTNode]:
 def _if_branches(stmt: UASTNode) -> tuple[list[UASTNode], list[UASTNode]]:
     """Return ``(then_statements, else_statements)`` for an IfStmt.
 
-    UAST shape is consistently: predicate, then-body, optional else-content.
-    Grammars differ only in how the else-content is shaped:
+    The then-block is located by *kind* (the first block-container child),
+    not by a fixed position — the children preceding it vary by grammar and
+    aren't otherwise meaningful here: a bare predicate (most grammars), a
+    predicate plus an init-clause (Go's ``if x := f(); cond {}``, C++17's
+    ``if (init; cond) {}``), or a predicate with an intervening comment.
+    Everything after the then-block is else-content, one level of
+    unwrapping happening via ``_unwrap_to_statements`` either way:
 
     * Python / JS wrap it in an explicit ``else_clause`` / ``elif_clause``
       node, whose own children are the actual else statements (or, for
@@ -385,22 +390,17 @@ def _if_branches(stmt: UASTNode) -> tuple[list[UASTNode], list[UASTNode]]:
       intentionally flattened into one ``else_body`` bucket rather than
       nested; this is an existing, accepted structural approximation).
     * Go / C++ / Rust have no such wrapper: the child *is* either a plain
-      block (``else { ... }``) or a nested ``if_statement`` (``else if``),
-      appearing directly as the third child.
-
-    Both shapes are handled uniformly: the second post-predicate child (and
-    any further siblings) form the else-body, one level of unwrapping
-    happening either way via ``_unwrap_to_statements``.
+      block (``else { ... }``) or a nested ``if_statement`` (``else if``).
     """
-    if not stmt.children:
-        return [], []
-
     children = list(stmt.children)
-    if len(children) < 2:
+    then_idx = next(
+        (i for i, child in enumerate(children) if _is_block_container(child)), None
+    )
+    if then_idx is None:
         return [], []
 
-    then_body = _unwrap_to_statements([children[1]])
-    else_body = _unwrap_to_statements(children[2:]) if len(children) > 2 else []
+    then_body = _unwrap_to_statements([children[then_idx]])
+    else_body = _unwrap_to_statements(children[then_idx + 1 :])
     return then_body, else_body
 
 

--- a/topos/graphs/cfg/builder.py
+++ b/topos/graphs/cfg/builder.py
@@ -337,6 +337,11 @@ _BLOCK_NATIVE_KINDS = frozenset(
         "do_statement",
         "else_clause",
         "elif_clause",
+        "statement_list",  # Go wraps a `block`'s statements one level deeper
+        "expression_case",  # Go `switch` arm (tagged or tagless)
+        "type_case",  # Go `switch x.(type)` arm
+        "default_case",  # Go `switch`/`select` default arm
+        "communication_case",  # Go `select` arm
     }
 )
 
@@ -371,38 +376,31 @@ def _function_body(callable_node: UASTNode) -> list[UASTNode]:
 def _if_branches(stmt: UASTNode) -> tuple[list[UASTNode], list[UASTNode]]:
     """Return ``(then_statements, else_statements)`` for an IfStmt.
 
-    UAST shape (Python / JS / TS / Rust / C++) is consistently:
-        IfStmt
-          ├── <predicate expression>
-          ├── Unknown[block]     ← then-body
-          └── (optional) Unknown[else_clause | block]  ← else-body
-                            └── (optional Unknown[block])
+    UAST shape is consistently: predicate, then-body, optional else-content.
+    Grammars differ only in how the else-content is shaped:
 
-    We treat the *first* child as the predicate, then walk the rest:
-    consecutive block-shaped Unknown nodes become the then-body until we
-    encounter an explicit else-clause-shaped node, after which content
-    becomes the else-body.
+    * Python / JS wrap it in an explicit ``else_clause`` / ``elif_clause``
+      node, whose own children are the actual else statements (or, for
+      ``elif``, another predicate + body — multiple ``elif`` clauses are
+      intentionally flattened into one ``else_body`` bucket rather than
+      nested; this is an existing, accepted structural approximation).
+    * Go / C++ / Rust have no such wrapper: the child *is* either a plain
+      block (``else { ... }``) or a nested ``if_statement`` (``else if``),
+      appearing directly as the third child.
+
+    Both shapes are handled uniformly: the second post-predicate child (and
+    any further siblings) form the else-body, one level of unwrapping
+    happening either way via ``_unwrap_to_statements``.
     """
     if not stmt.children:
         return [], []
 
     children = list(stmt.children)
-    # Skip the predicate (children[0])
-    then_body: list[UASTNode] = []
-    else_body: list[UASTNode] = []
-    saw_else = False
-    for child in children[1:]:
-        if child.kind == "Unknown" and child.native.node_kind in {
-            "else_clause",
-            "elif_clause",
-        }:
-            saw_else = True
-            else_body.extend(_unwrap_to_statements(child.children))
-            continue
-        if saw_else:
-            else_body.extend(_unwrap_to_statements([child]))
-        else:
-            then_body.extend(_unwrap_to_statements([child]))
+    if len(children) < 2:
+        return [], []
+
+    then_body = _unwrap_to_statements([children[1]])
+    else_body = _unwrap_to_statements(children[2:]) if len(children) > 2 else []
     return then_body, else_body
 
 
@@ -415,11 +413,27 @@ def _loop_body(stmt: UASTNode) -> list[UASTNode]:
     return _unwrap_to_statements(stmt.children[1:])
 
 
+_CASE_ARM_NATIVE_KINDS = frozenset(
+    {"expression_case", "type_case", "default_case", "communication_case"}
+)
+
+
 def _match_arms(stmt: UASTNode) -> list[UASTNode]:
-    """Extract case arms from a MatchStmt; first child is the discriminant."""
+    """Extract case arms from a MatchStmt.
+
+    Usually the first child is the discriminant/subject (Python ``match``,
+    Rust ``match``, Go's tagged ``switch``/``type switch``) and is skipped.
+    Go also has discriminant-less forms (``switch { case ... }``,
+    ``select { case ... }``) where the first child is itself a case arm —
+    detected via its native node kind so every arm is kept.
+    """
     if not stmt.children:
         return []
-    return _unwrap_to_statements(stmt.children[1:])
+    children = list(stmt.children)
+    first = children[0]
+    if first.kind == "Unknown" and first.native.node_kind in _CASE_ARM_NATIVE_KINDS:
+        return _unwrap_to_statements(children)
+    return _unwrap_to_statements(children[1:])
 
 
 def _children_with_control_flow(node: UASTNode) -> list[UASTNode]:

--- a/topos/graphs/uast/mapper_common.py
+++ b/topos/graphs/uast/mapper_common.py
@@ -32,6 +32,7 @@ _TREE_SITTER_PACKAGE = {
     "javascript": "tree-sitter-javascript",
     "typescript": "tree-sitter-typescript",
     "cpp": "tree-sitter-cpp",
+    "go": "tree-sitter-go",
 }
 
 

--- a/topos/graphs/uast/mapper_go.py
+++ b/topos/graphs/uast/mapper_go.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from tree_sitter import Node
+
+from topos.graphs.uast.mapper_common import map_tree_sitter_to_uast
+from topos.graphs.uast.models import UASTNode
+
+_DECLARATION_TYPES = {
+    "function_declaration": "FunctionDecl",
+    "method_declaration": "MethodDecl",
+    "type_declaration": "TypeDecl",
+    "const_declaration": "VarDecl",
+    "var_declaration": "VarDecl",
+    "short_var_declaration": "VarDecl",  # `x := expr`
+}
+
+_STATEMENT_TYPES = {
+    "if_statement": "IfStmt",
+    "for_statement": "ForStmt",  # Go's single loop keyword covers all forms
+    "expression_switch_statement": "MatchStmt",
+    "type_switch_statement": "MatchStmt",
+    "select_statement": "MatchStmt",  # channel-select: structurally a multi-way branch
+    "return_statement": "ReturnStmt",
+    "break_statement": "BreakStmt",
+    "continue_statement": "ContinueStmt",
+    "expression_statement": "ExprStmt",
+    "assignment_statement": "AssignExpr",
+    "inc_statement": "AssignExpr",  # `x++` / `x--`
+    # Neither has a dedicated UAST control-flow kind; mapped structurally
+    # (by node type, not callee identifier) as plain expression statements,
+    # consistent with how `panic(...)` below stays an ordinary CallExpr.
+    "go_statement": "ExprStmt",  # `go f()` goroutine launch
+    "defer_statement": "ExprStmt",
+}
+
+_EXPRESSION_TYPES = {
+    "binary_expression": "BinaryExpr",
+    "unary_expression": "UnaryExpr",
+    "call_expression": "CallExpr",  # covers panic(...) too
+    "selector_expression": "MemberExpr",  # `x.y`, `pkg.Func`, method targets
+    "index_expression": "MemberExpr",
+}
+
+_LITERAL_TYPES = {
+    "int_literal",
+    "float_literal",
+    "imaginary_literal",
+    "rune_literal",
+    "interpreted_string_literal",
+    "raw_string_literal",
+    "true",
+    "false",
+    "nil",
+}
+
+_IDENTIFIER_TYPES = {
+    "identifier",
+    "field_identifier",
+    "type_identifier",
+    "package_identifier",
+}
+
+
+def map_node_kind(node: Node) -> str:
+    if node.type in _DECLARATION_TYPES:
+        return _DECLARATION_TYPES[node.type]
+    if node.type in _STATEMENT_TYPES:
+        return _STATEMENT_TYPES[node.type]
+    if node.type in _EXPRESSION_TYPES:
+        return _EXPRESSION_TYPES[node.type]
+    if node.type in _IDENTIFIER_TYPES:
+        return "Identifier"
+    if node.type in _LITERAL_TYPES:
+        return "Literal"
+    if node.type == "source_file":
+        return "File"
+    return "Unknown"
+
+
+def map_go_tree_to_uast(root: Node, file: str | None = None) -> UASTNode:
+    return map_tree_sitter_to_uast(
+        root=root,
+        language="go",
+        map_node_kind=map_node_kind,
+        file=file,
+    )

--- a/topos/mcp/diagnostics.py
+++ b/topos/mcp/diagnostics.py
@@ -65,7 +65,9 @@ def overlay_for_file(
     if not _secure_failed(result):
         return None
 
-    cpg = ProgramMorphism.from_file(path).build_cpg()
+    from .evaluation import detect_language
+
+    cpg = ProgramMorphism.from_file(path, language=detect_language(path)).build_cpg()
     findings = security_findings(cpg)
     verdict = apply_allowlist(result, findings, config, file_path=str(path), cpg=cpg)
     active = verdict.active_findings if include_security_findings else []

--- a/topos/utils/tree_sitter.py
+++ b/topos/utils/tree_sitter.py
@@ -36,6 +36,7 @@ from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
 
 import tree_sitter_cpp as ts_cpp
+import tree_sitter_go as ts_go
 import tree_sitter_javascript as ts_javascript
 import tree_sitter_python as ts_python
 import tree_sitter_rust as ts_rust
@@ -181,12 +182,29 @@ class CppParser:
         return tree.root_node
 
 
+@dataclass
+class GoParser:
+    """Parser for Go source code using tree-sitter."""
+
+    language: str = "go"
+
+    def __post_init__(self) -> None:
+        self._language = Language(ts_go.language())
+        self._parser = Parser(self._language)
+
+    def parse(self, source: str) -> Node:
+        source_bytes = source.encode("utf-8")
+        tree = self._parser.parse(source_bytes)
+        return tree.root_node
+
+
 _default_python_parser: PythonParser | None = None
 _default_rust_parser: RustParser | None = None
 _default_javascript_parser: JavaScriptParser | None = None
 _default_cpp_parser: CppParser | None = None
 _default_typescript_parser: TypeScriptParser | None = None
 _default_tsx_parser: TypeScriptParser | None = None
+_default_go_parser: GoParser | None = None
 
 
 def get_python_parser() -> PythonParser:
@@ -247,6 +265,14 @@ def get_cpp_parser() -> CppParser:
     return _default_cpp_parser
 
 
+def get_go_parser() -> GoParser:
+    """Get the shared Go parser instance."""
+    global _default_go_parser
+    if _default_go_parser is None:
+        _default_go_parser = GoParser()
+    return _default_go_parser
+
+
 def parse_python(source: str) -> Node:
     """
     Parse Python source code into an AST.
@@ -290,6 +316,11 @@ def parse_typescript(source: str, file: str | None = None) -> Node:
 def parse_cpp(source: str) -> Node:
     """Parse C++ source code into an AST."""
     return get_cpp_parser().parse(source)
+
+
+def parse_go(source: str) -> Node:
+    """Parse Go source code into an AST."""
+    return get_go_parser().parse(source)
 
 
 def node_text(node: Node, source: str) -> str:


### PR DESCRIPTION
## Summary

Adds Go as a supported language across all three quality dimensions (SIMPLE, SECURE, COMPOSABLE), following the existing per-language pattern (Python/Rust/JS/TS/C++).

### Issues solved

- **#72 (SIMPLE)** — `tree-sitter-go` + `GoParser` + `mapper_go.py` UAST mapper. Registered `go`/`.go` in the language registry and provider dispatch.
- **#73 (SECURE)** — Go entries in the CPG dangerous-API (`exec.Command`, `syscall.Exec`, ...) and taint-source (`os.Getenv`, `os.Args`, ...) registries.
- **#74 (COMPOSABLE)** — verified GitNexus 1.6.8 supports Go end-to-end (correct `File`/`IMPORTS`/`CALLS` edges); just registry wiring, no upstream workaround needed.

### Bugs surfaced and fixed

Go's grammar shape exposed two **generic, non-language-keyed** CFG builder bugs, plus one pre-existing cross-language bug — all fixed with regression tests, zero impact on the existing suite:

- **`_if_branches` used a fixed child position for the then-block** — broke on Go's `if x := f(); cond {}` (init clause) *and*, independently, on a same-line trailing comment on any `if` condition in **Python/C++/Rust** (a pre-existing regression risk, not Go-specific). Now locates the then-block by kind instead of position.
- **`_loop_body` unconditionally sliced off "the first child" as the loop test** — silently dropped the entire body of Go's condition-less `for { }` (a single-child node with nothing to slice off). Same fix pattern: locate the body by kind.
- **CLI security-findings/entropy paths defaulted every non-Python file to a Python-parsed CPG/AST** (`ProgramMorphism.from_file` defaults `language="python"`). The MCP path already had this fixed; two CLI call sites (`inspect`/`evaluate`'s CPG build, `inspect`'s entropy morphism) still had it — now thread `detect_language(path)` through.
- **Cleanup:** deduped four Go case-arm node-kind strings that were hand-typed in two separate frozensets, risking silent divergence on a future grammar change.

## Test plan

- [x] Full repo suite: 463 passed, 10 skipped (pre-existing, unrelated to this change)
- [x] `ruff format --check` / `ruff check` clean
- [x] New regression tests for each fix: if-with-trailing-comment (Python), if-with-init-clause (Go), bare `for {}` (Go), CLI inspect on a `.go` file with a dangerous call
- [x] `pytest tests/graphs/cfg/` / `tests/graphs/ast/` / `tests/mcp/test_evaluate.py` / `tests/cli/`
