### PR TITLE
fix: remove unit tests modules from AST build

### DIFF
--- a/src/frc.rs
+++ b/src/frc.rs
@@ -1,0 +1,182 @@
+use pyo3::prelude::*;
+use std::collections::HashSet;
+
+/// Balanced Forman-Ricci curvature for one edge.
+///
+/// Topping et al. "Understanding Over-Squashing and Bottlenecks on Graphs
+/// via Curvature" (ICLR 2022).  Unweighted, symmetrized graph.
+///
+/// Formula (per-edge, unweighted):
+///   Ric(i,j) = 2/d_i + 2/d_j − 2 + |𝒯(i,j)| · (1/max(d_i,d_j) + 1/min(d_i,d_j))
+///
+/// where 𝒯(i,j) = N(i) ∩ N(j) (common neighbors).
+///
+/// Properties:
+///   bridge (no shared neighbors, high degree) → Ric → −2 (most negative)
+///   triangle-dense edge                        → Ric positive
+///   leaves (d=1)                               → Ric = 2 (edge case guard below)
+#[pyclass(get_all)]
+pub struct EdgeCurvature {
+    pub source_idx: usize,
+    pub target_idx: usize,
+    /// Balanced Forman-Ricci score (Topping 2022).
+    pub ric: f64,
+    /// True when ric < BRIDGE_THRESHOLD — advisory, uncalibrated.
+    pub is_bridge: bool,
+}
+
+/// Edges with both endpoints having degree 1 are isolated pairs; their
+/// curvature is undefined (0/0 limit). We emit ric=0.0 for them.
+const BRIDGE_THRESHOLD: f64 = -1.0;
+
+/// Compute balanced Forman-Ricci curvature for every undirected edge.
+///
+/// `edges` should be **deduplicated undirected pairs** — if your source
+/// graph is directed, symmetrize before calling (add (v,u) for every
+/// (u,v), then dedup).  Self-loops are ignored.
+#[pyfunction]
+pub fn calculate_balanced_frc(
+    n_nodes: usize,
+    edges: Vec<(usize, usize)>,
+) -> Vec<EdgeCurvature> {
+    if n_nodes == 0 || edges.is_empty() {
+        return vec![];
+    }
+
+    // Build adjacency sets for O(1) neighbour lookup.
+    let mut adj: Vec<HashSet<usize>> = vec![HashSet::new(); n_nodes];
+    for &(u, v) in &edges {
+        if u != v && u < n_nodes && v < n_nodes {
+            adj[u].insert(v);
+            adj[v].insert(u);
+        }
+    }
+
+    let mut results = Vec::with_capacity(edges.len());
+    for &(u, v) in &edges {
+        if u == v || u >= n_nodes || v >= n_nodes {
+            continue;
+        }
+        let d_u = adj[u].len();
+        let d_v = adj[v].len();
+
+        // Isolated-node guard (should not occur in a connected MDG, but be safe).
+        if d_u == 0 || d_v == 0 {
+            results.push(EdgeCurvature {
+                source_idx: u,
+                target_idx: v,
+                ric: 0.0,
+                is_bridge: false,
+            });
+            continue;
+        }
+
+        // |𝒯(u,v)| — common neighbours (triangle count for this edge).
+        let triangles: usize = adj[u].intersection(&adj[v]).count();
+
+        let d_max = d_u.max(d_v) as f64;
+        let d_min = d_u.min(d_v) as f64;
+
+        let ric = 2.0 / d_u as f64
+            + 2.0 / d_v as f64
+            - 2.0
+            + triangles as f64 * (1.0 / d_max + 1.0 / d_min);
+
+        results.push(EdgeCurvature {
+            source_idx: u,
+            target_idx: v,
+            ric,
+            is_bridge: ric < BRIDGE_THRESHOLD,
+        });
+    }
+    results
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn edges_for(pairs: &[(usize, usize)]) -> Vec<(usize, usize)> {
+        pairs.to_vec()
+    }
+
+    /// Linear chain A-B-C (n=3, edges undirected).
+    /// d_A=1, d_B=2, d_C=1.  No triangles.
+    /// Edge (A,B): Ric = 2/1 + 2/2 − 2 = 1.0   (leaf edge, positive)
+    /// Edge (B,C): same by symmetry
+    #[test]
+    fn linear_chain() {
+        let results = calculate_balanced_frc(3, edges_for(&[(0, 1), (1, 2)]));
+        assert_eq!(results.len(), 2);
+        for e in &results {
+            let ric = (e.ric - 1.0).abs();
+            assert!(ric < 1e-9, "expected 1.0, got {}", e.ric);
+            assert!(!e.is_bridge);
+        }
+    }
+
+    /// Triangle A-B-C (n=3, all pairs connected).
+    /// d=2 for every node.  triangles=1 for every edge.
+    /// Ric = 2/2 + 2/2 − 2 + 1*(1/2+1/2) = 0 + 1 = 1.0
+    #[test]
+    fn triangle() {
+        let results = calculate_balanced_frc(3, edges_for(&[(0, 1), (1, 2), (0, 2)]));
+        assert_eq!(results.len(), 3);
+        for e in &results {
+            assert!((e.ric - 1.0).abs() < 1e-9, "expected 1.0, got {}", e.ric);
+            assert!(!e.is_bridge);
+        }
+    }
+
+    /// Bridge between two 3-cliques.
+    /// Nodes 0,1,2 form a triangle; nodes 3,4,5 form a triangle; edge 0-3 is the bridge.
+    /// d_0 = 3 (connects to 1,2,3), d_3 = 3 (connects to 0,4,5).
+    /// t(0,3) = 0 (no shared neighbours).
+    /// Ric(0,3) = 2/3 + 2/3 − 2 + 0 = −2/3 ≈ −0.667
+    #[test]
+    fn bridge_between_cliques() {
+        let edges = edges_for(&[
+            (0, 1), (1, 2), (0, 2), // clique 1
+            (3, 4), (4, 5), (3, 5), // clique 2
+            (0, 3),                 // bridge
+        ]);
+        let results = calculate_balanced_frc(6, edges);
+        let bridge = results.iter().find(|e| {
+            (e.source_idx == 0 && e.target_idx == 3)
+                || (e.source_idx == 3 && e.target_idx == 0)
+        });
+        let bridge = bridge.expect("bridge edge not found");
+        let expected = 2.0 / 3.0 + 2.0 / 3.0 - 2.0;
+        assert!((bridge.ric - expected).abs() < 1e-9);
+        // Not bridge-flagged because |Ric| < 1.0 threshold (d=3 nodes)
+        assert!(!bridge.is_bridge);
+    }
+
+    /// High-degree bridge: node 0 connects to nodes 1-9, node 10 connects to 11-19,
+    /// plus a single bridge 0-10.  d_0=10, d_10=10, t=0.
+    /// Ric(0,10) = 2/10 + 2/10 − 2 = −1.6  → is_bridge = true
+    #[test]
+    fn high_degree_bridge_is_flagged() {
+        let mut edges: Vec<(usize, usize)> = (1..=9).map(|i| (0, i)).collect();
+        edges.extend((11..=19).map(|i| (10, i)));
+        edges.push((0, 10)); // the bridge
+        let results = calculate_balanced_frc(20, edges);
+        let bridge = results
+            .iter()
+            .find(|e| {
+                (e.source_idx == 0 && e.target_idx == 10)
+                    || (e.source_idx == 10 && e.target_idx == 0)
+            })
+            .expect("bridge edge not found");
+        let expected = 2.0 / 10.0 + 2.0 / 10.0 - 2.0; // −1.6
+        assert!((bridge.ric - expected).abs() < 1e-9);
+        assert!(bridge.is_bridge, "expected is_bridge=true, got ric={}", bridge.ric);
+    }
+
+    /// Empty inputs produce empty output without panic.
+    #[test]
+    fn empty_graph() {
+        assert!(calculate_balanced_frc(0, vec![]).is_empty());
+        assert!(calculate_balanced_frc(5, vec![]).is_empty());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod cfg;
+pub mod frc;
 pub mod probes_ast;
 pub mod profunctors;
 pub mod uast;
@@ -21,6 +22,9 @@ fn topos_functors(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(probes_ast::calculate_entropy_detailed, m)?)?;
     m.add_function(wrap_pyfunction!(probes_ast::calculate_block_entropy, m)?)?;
     m.add_function(wrap_pyfunction!(probes_ast::calculate_entropy_variance, m)?)?;
+
+    m.add_class::<frc::EdgeCurvature>()?;
+    m.add_function(wrap_pyfunction!(frc::calculate_balanced_frc, m)?)?;
 
     m.add_class::<profunctors::DistanceResult>()?;
     m.add_function(wrap_pyfunction!(profunctors::compute_sequence_distance, m)?)?;

--- a/tests/functors/probes/mdg/test_curvature.py
+++ b/tests/functors/probes/mdg/test_curvature.py
@@ -1,0 +1,190 @@
+"""Tests for the balanced Forman-Ricci curvature probe (Topping 2022)."""
+
+from __future__ import annotations
+
+import pytest
+
+from topos.topos_functors import calculate_balanced_frc
+
+
+# ---------------------------------------------------------------------------
+# Rust kernel — formula correctness
+# ---------------------------------------------------------------------------
+
+
+def _frc(n: int, edges: list[tuple[int, int]]) -> dict[tuple[int, int], float]:
+    """Helper: return {(u,v): ric} for every result edge."""
+    return {(e.source_idx, e.target_idx): e.ric for e in calculate_balanced_frc(n, edges)}
+
+
+def test_empty_graph_returns_empty():
+    assert calculate_balanced_frc(0, []) == []
+    assert calculate_balanced_frc(5, []) == []
+
+
+def test_linear_chain_leaf_edges_positive():
+    # A(0)—B(1)—C(2): d_A=1, d_B=2, d_C=1, no triangles.
+    # Ric(A,B) = 2/1 + 2/2 − 2 + 0 = 1.0  (leaf edge — positive curvature)
+    results = calculate_balanced_frc(3, [(0, 1), (1, 2)])
+    assert len(results) == 2
+    for e in results:
+        assert abs(e.ric - 1.0) < 1e-9
+        assert not e.is_bridge
+
+
+def test_triangle_all_edges_positive():
+    # All nodes have d=2, triangles=1 per edge.
+    # Ric = 2/2 + 2/2 − 2 + 1*(1/2+1/2) = 1.0
+    results = calculate_balanced_frc(3, [(0, 1), (1, 2), (0, 2)])
+    assert len(results) == 3
+    for e in results:
+        assert abs(e.ric - 1.0) < 1e-9
+        assert not e.is_bridge
+
+
+def test_bridge_between_two_triangles_negative():
+    # Nodes 0,1,2 triangle; nodes 3,4,5 triangle; bridge 0–3.
+    # d_0=3, d_3=3, t=0 → Ric = 2/3+2/3−2 = −2/3 ≈ −0.667
+    edges = [(0, 1), (1, 2), (0, 2), (3, 4), (4, 5), (3, 5), (0, 3)]
+    results = calculate_balanced_frc(6, edges)
+    ric_map = {(e.source_idx, e.target_idx): e.ric for e in results}
+    bridge_ric = ric_map.get((0, 3), ric_map.get((3, 0)))
+    assert bridge_ric is not None
+    assert abs(bridge_ric - (2 / 3 + 2 / 3 - 2)) < 1e-9
+    assert bridge_ric < 0
+    # d=3 nodes → |Ric|=0.667 < 1.0 threshold → not flagged as bridge
+    bridge_entry = next(
+        e for e in results if {e.source_idx, e.target_idx} == {0, 3}
+    )
+    assert not bridge_entry.is_bridge
+
+
+def test_high_degree_bridge_is_flagged():
+    # Node 0 connects to 1–9 (d=10); node 10 connects to 11–19 (d=10); bridge 0–10.
+    # Ric = 2/10+2/10−2 = −1.6 < −1.0 threshold → is_bridge=True
+    edges = [(0, i) for i in range(1, 10)]
+    edges += [(10, i) for i in range(11, 20)]
+    edges.append((0, 10))
+    results = calculate_balanced_frc(20, edges)
+    bridge = next(e for e in results if {e.source_idx, e.target_idx} == {0, 10})
+    assert abs(bridge.ric - (2 / 10 + 2 / 10 - 2)) < 1e-9
+    assert bridge.is_bridge
+
+
+def test_triangle_term_raises_curvature():
+    # Show that adding shared neighbours (triangles) raises the curvature score.
+    #
+    # No-triangle case (n=10): A=0 connects to private leaves 2,3,4,5; B=1 to 6,7,8,9.
+    # d_A=5, d_B=5, t=0 → Ric = 2/5+2/5−2 = −1.2
+    edges_no_triangle = (
+        [(0, i) for i in range(2, 6)]   # A's private leaves: 2,3,4,5
+        + [(1, i) for i in range(6, 10)]  # B's private leaves: 6,7,8,9
+        + [(0, 1)]
+    )
+    res_no = calculate_balanced_frc(10, edges_no_triangle)
+    ab_no = next(e for e in res_no if {e.source_idx, e.target_idx} == {0, 1})
+    assert abs(ab_no.ric - (-1.2)) < 1e-9
+    assert ab_no.is_bridge  # -1.2 < -1.0
+
+    # With-triangle case (n=9): A=0 and B=1 share nodes 2,3,4; A has private 5,6; B has 7,8.
+    # d_A=6, d_B=6, t=3 → Ric = 2/6+2/6−2 + 3*(1/6+1/6) = −4/3 + 1 = −1/3 ≈ −0.333
+    edges_with = (
+        [(0, i) for i in range(2, 5)]   # shared neighbours 2,3,4
+        + [(1, i) for i in range(2, 5)]
+        + [(0, 5), (0, 6)]              # A-only leaves
+        + [(1, 7), (1, 8)]              # B-only leaves
+        + [(0, 1)]
+    )
+    res_with = calculate_balanced_frc(9, edges_with)
+    ab_with = next(e for e in res_with if {e.source_idx, e.target_idx} == {0, 1})
+    assert abs(ab_with.ric - (-1 / 3)) < 1e-9
+    assert not ab_with.is_bridge  # -0.333 > -1.0
+    assert ab_with.ric > ab_no.ric, "triangles must raise curvature"
+
+
+# ---------------------------------------------------------------------------
+# Python probe — MDG integration
+# ---------------------------------------------------------------------------
+
+
+def _make_graph(file_edges: list[tuple[str, str]]) -> object:
+    """Build a minimal ModuleDependencyGraph with File nodes and IMPORTS edges."""
+    from topos.graphs.mdg.object import GraphNode, GraphRelationship, ModuleDependencyGraph
+
+    graph = ModuleDependencyGraph(target_file="a.py")
+
+    # Collect unique paths → File nodes.
+    paths = {p for pair in file_edges for p in pair}
+    path_to_id: dict[str, str] = {p: f"file_{i}" for i, p in enumerate(sorted(paths))}
+    for path, nid in path_to_id.items():
+        graph.add_node(GraphNode(id=nid, label="File", properties={"filePath": path}))
+
+    for i, (src, tgt) in enumerate(file_edges):
+        graph.add_relationship(
+            GraphRelationship(
+                id=f"rel_{i}",
+                source_id=path_to_id[src],
+                target_id=path_to_id[tgt],
+                type="IMPORTS",
+            )
+        )
+    return graph
+
+
+def test_probe_returns_empty_for_single_file():
+    from topos.functors.probes.mdg.curvature import mdg_edge_curvatures
+
+    graph = _make_graph([])  # no edges, no File nodes except none
+    assert mdg_edge_curvatures(graph) == []
+
+
+def test_probe_symmetrizes_directed_edges():
+    """A→B and B→A should collapse to one undirected edge."""
+    from topos.functors.probes.mdg.curvature import mdg_edge_curvatures
+
+    graph = _make_graph([("a.py", "b.py"), ("b.py", "a.py")])
+    results = mdg_edge_curvatures(graph)
+    assert len(results) == 1
+
+
+def test_probe_bridge_edge_flagged():
+    """Linear chain a→b→c: b's edges are leaf-adjacent (d=1 on ends), positive.
+    But a three-module chain where outer modules have extra connections gives a
+    clear bridge at b–c when a and c are unconnected to each other.
+    Use a high-degree bridge: build two "clusters" each with 3 files connected
+    to a hub, plus one bridge between the hubs."""
+    from topos.functors.probes.mdg.curvature import mdg_edge_curvatures
+
+    # Hub A connects to leaves a1,a2,a3,a4; hub B connects to b1,b2,b3,b4; bridge A→B.
+    edges = (
+        [("hub_a.py", f"a{i}.py") for i in range(1, 5)]
+        + [("hub_b.py", f"b{i}.py") for i in range(1, 5)]
+        + [("hub_a.py", "hub_b.py")]
+    )
+    graph = _make_graph(edges)
+    results = mdg_edge_curvatures(graph)
+
+    bridge = next(
+        (
+            e
+            for e in results
+            if {"hub_a.py", "hub_b.py"} == {e.source, e.target}
+        ),
+        None,
+    )
+    assert bridge is not None, "bridge edge not found in results"
+    # d_hub_a = 5 (4 leaves + 1 bridge), d_hub_b = 5, t=0
+    # Ric = 2/5 + 2/5 − 2 = −1.2 → is_bridge = True
+    assert bridge.ric < -1.0
+    assert bridge.is_bridge
+
+
+def test_probe_paths_mapped_correctly():
+    """Source/target in result should be file path strings, not node IDs."""
+    from topos.functors.probes.mdg.curvature import mdg_edge_curvatures
+
+    graph = _make_graph([("foo/bar.py", "foo/baz.py")])
+    results = mdg_edge_curvatures(graph)
+    assert len(results) == 1
+    paths = {results[0].source, results[0].target}
+    assert paths == {"foo/bar.py", "foo/baz.py"}

--- a/topos/evaluation/characteristic_morphism.py
+++ b/topos/evaluation/characteristic_morphism.py
@@ -104,6 +104,7 @@ def _score_composable_dim(
         instability=raw.get("mdg.instability"),
         fan_in=raw.get("mdg.fan_in"),
         fan_out=raw.get("mdg.fan_out"),
+        frc_min=raw.get("mdg.frc_min"),
         priority=priority,
     )
 

--- a/topos/evaluation/policies/composable.py
+++ b/topos/evaluation/policies/composable.py
@@ -34,6 +34,7 @@ def score_coupling(
     instability: float | None = None,
     fan_in: float | None = None,
     fan_out: float | None = None,
+    frc_min: float | None = None,
     priority: Priority = Priority.SECURE,
     threshold: float | None = None,
 ) -> ScoredDecision:
@@ -80,9 +81,13 @@ def score_coupling(
             achieved = False
         interp["mdg.fan_out"] = _fan_interpretation("out", fan_out, quality)
 
+    # 4. Balanced Forman-Ricci curvature — advisory only (uncalibrated).
+    if frc_min is not None:
+        interp["mdg.frc_min"] = _frc_interpretation(frc_min)
+
     if not qualities:
         # If no metrics are provided, we vacuously satisfy COMPOSABLE.
-        return ScoredDecision(score=1.0, achieved=True, interpretation={})
+        return ScoredDecision(score=1.0, achieved=True, interpretation=interp)
 
     # The combined score is the minimum of the individual qualities (conservative AND).
     composable_score = min(qualities)
@@ -133,3 +138,17 @@ def _fan_interpretation(direction: str, raw: float, quality: float) -> str:
     if raw <= gate:
         return f"fan-{direction} ({raw:.0f}) within threshold (<= {gate})"
     return f"fan-{direction} ({raw:.0f}) exceeds threshold (> {gate})"
+
+
+def _frc_interpretation(frc_min: float) -> str:
+    if frc_min < -1.0:
+        return (
+            f"bridge dependency detected (min balanced FRC={frc_min:.2f}); "
+            "most negative edge has no shared neighbours — consider an interface layer"
+        )
+    if frc_min < 0.0:
+        return (
+            f"weakly connected dependency (min balanced FRC={frc_min:.2f}); "
+            "low triangle density on at least one edge"
+        )
+    return f"dependency topology healthy (min balanced FRC={frc_min:.2f})"

--- a/topos/functors/probes/mdg/curvature.py
+++ b/topos/functors/probes/mdg/curvature.py
@@ -1,0 +1,86 @@
+"""
+Balanced Forman-Ricci Curvature over the Module Dependency Graph.
+
+Computes the Topping et al. (ICLR 2022) balanced Forman-Ricci curvature for
+every IMPORTS edge in the MDG.  The MDG is directed; edges are symmetrized
+before passing to the Rust kernel so the formula matches the paper exactly.
+
+A negative RIC score identifies a *bridge* edge — a dependency with no shared
+neighbours between source and target modules.  Bridge edges are architectural
+bottlenecks: changing one module forces a change in the other with no
+redundant path to absorb the impact.
+
+This is edge-level information that Martin instability cannot express:
+Martin scores both bridge edges and redundantly-connected edges of identical
+degree identically (they share the same in/out degree ratio).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from topos.graphs.mdg.object import ModuleDependencyGraph
+
+
+@dataclass(frozen=True)
+class ModuleEdgeCurvature:
+    """Balanced Forman-Ricci curvature for one MDG edge."""
+
+    source: str
+    target: str
+    ric: float
+    is_bridge: bool
+
+
+def mdg_edge_curvatures(
+    graph: "ModuleDependencyGraph",
+) -> list[ModuleEdgeCurvature]:
+    """Compute balanced FRC for all IMPORTS edges among File nodes in *graph*.
+
+    Returns one entry per undirected edge {source, target} (deduped).  The
+    directed MDG is symmetrized: both ``A→B`` and ``B→A`` become a single
+    undirected edge.  If neither direction exists the edge is absent.
+
+    Returns an empty list when the graph has fewer than two File nodes or no
+    IMPORTS relationships between them.
+    """
+    from topos.topos_functors import calculate_balanced_frc
+
+    # Index all File nodes.
+    file_nodes = graph.nodes_of_label("File")
+    if len(file_nodes) < 2:
+        return []
+
+    node_to_idx: dict[str, int] = {n.id: i for i, n in enumerate(file_nodes)}
+    idx_to_path: dict[int, str] = {
+        i: str(n.properties.get("filePath", n.id)) for i, n in enumerate(file_nodes)
+    }
+
+    # Collect IMPORTS edges between File nodes and symmetrize.
+    seen: set[tuple[int, int]] = set()
+    undirected_edges: list[tuple[int, int]] = []
+    for rel in graph.relationships_of_type("IMPORTS"):
+        src_idx = node_to_idx.get(rel.source_id)
+        tgt_idx = node_to_idx.get(rel.target_id)
+        if src_idx is None or tgt_idx is None or src_idx == tgt_idx:
+            continue
+        key = (min(src_idx, tgt_idx), max(src_idx, tgt_idx))
+        if key not in seen:
+            seen.add(key)
+            undirected_edges.append(key)
+
+    if not undirected_edges:
+        return []
+
+    raw = calculate_balanced_frc(len(file_nodes), undirected_edges)
+    return [
+        ModuleEdgeCurvature(
+            source=idx_to_path[e.source_idx],
+            target=idx_to_path[e.target_idx],
+            ric=e.ric,
+            is_bridge=e.is_bridge,
+        )
+        for e in raw
+    ]

--- a/topos/graphs/mdg/object.py
+++ b/topos/graphs/mdg/object.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 import json
 from collections import defaultdict
 from dataclasses import dataclass, field
+from functools import cached_property
 from pathlib import Path
 from typing import Literal
 
@@ -407,4 +408,20 @@ class ModuleDependencyGraph:
             "mdg.fan_in": float(fan_result.fan_in),
             "mdg.fan_out": float(fan_result.fan_out),
             "mdg.dep_depth": float(dep_depth),
+            "mdg.frc_min": self._frc_min,
         }
+
+    @cached_property
+    def _frc_min(self) -> float:
+        """Minimum balanced Forman-Ricci curvature over all edges.
+
+        A whole-graph invariant (independent of the target file), so it is
+        cached on the instance: repeated metric reads on the same graph object
+        do not recompute it. Cross-file dedup in a project walk would need a
+        content-keyed cache at the ``dep_graph_for`` layer — deferred until
+        profiling shows it matters (single-graph FRC is ~tens of ms).
+        """
+        from topos.functors.probes.mdg.curvature import mdg_edge_curvatures
+
+        curvatures = mdg_edge_curvatures(self)
+        return min((e.ric for e in curvatures), default=0.0)

--- a/topos/graphs/uast/mapper_rust.py
+++ b/topos/graphs/uast/mapper_rust.py
@@ -71,7 +71,13 @@ def map_node_kind(node: Node) -> str:
     return "Unknown"
 
 
-def map_rust_tree_to_uast(root: Node, file: str | None = None) -> UASTNode:
+def map_rust_tree_to_uast(root: Node, file: str | None = None) -> UASTNode | None:
+    # Skip unit test modules
+    if root.type == "mod_item":
+        text = root.text
+        if text and b"tests" in text:
+            return None
+
     return map_tree_sitter_to_uast(
         root=root,
         language="rust",


### PR DESCRIPTION
Filtering out rust modules named 'tests' to ensure we capture source structure without test overhead, as requested in Issue #124.