### PR TITLE
perf(cli): avoid eager numpy/eval import in quality.py registration (#119)

### DIFF
--- a/tests/cli/test_quality.py
+++ b/tests/cli/test_quality.py
@@ -344,3 +344,14 @@ def test_evaluate_verbose_lists_findings(tmp_path: Path):
     out = _strip_ansi(result.output)
     assert "Security Findings" in out
     assert "eval" in out
+
+
+def test_priority_choice_matches_priority_enum():
+    """quality.py's module-level ``_PRIORITY_VALUES`` literal (kept import-free
+    to avoid eagerly loading the eval stack / numpy at CLI-registration time)
+    must not drift from ``Priority``, the enum it mirrors."""
+    from topos.cli.commands.quality import _PRIORITY_CHOICE, _PRIORITY_VALUES
+    from topos.evaluation.policies.base import Priority
+
+    assert set(_PRIORITY_VALUES) == {p.value for p in Priority}
+    assert set(_PRIORITY_CHOICE.choices) == {p.value for p in Priority}

--- a/tests/cli/test_registration_imports.py
+++ b/tests/cli/test_registration_imports.py
@@ -27,3 +27,30 @@ assert not tree_sitter, f"unexpected tree_sitter imports: {tree_sitter}"
         text=True,
     )
     assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def test_register_commands_does_not_import_numpy_or_evaluation() -> None:
+    """Registering commands (incl. quality.py's ``--priority`` option) must
+    not eagerly pull in numpy or the evaluation stack. Those are heavy and
+    only needed once a command actually evaluates code, inside lazy-imported
+    callbacks (see issue #119)."""
+    script = """
+import sys
+
+from topos.cli.main import _register_commands
+
+_register_commands()
+
+heavy = [
+    name for name in sys.modules
+    if name == "numpy" or name.startswith("numpy.")
+    or name == "topos.evaluation" or name.startswith("topos.evaluation.")
+]
+assert not heavy, f"unexpected eager imports: {heavy}"
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr

--- a/topos/cli/commands/quality.py
+++ b/topos/cli/commands/quality.py
@@ -5,11 +5,16 @@ from pathlib import Path
 
 import click
 
-from topos.evaluation.policies.base import Priority
 from topos.graphs.ast.languages import SUPPORTED_LANGUAGES, language_file_suffixes
 
 _EVALUATE_LANGUAGE_CHOICE = click.Choice(sorted(SUPPORTED_LANGUAGES))
-_PRIORITY_CHOICE = click.Choice([p.value for p in Priority])
+
+# Mirrors topos.evaluation.policies.base.Priority's values without importing
+# the eval stack (and transitively numpy) at CLI-registration time. Covered
+# by a parity test asserting this literal cannot silently drift from the
+# enum.
+_PRIORITY_VALUES = ("simple", "composable", "secure")
+_PRIORITY_CHOICE = click.Choice(_PRIORITY_VALUES)
 _PRIORITY_HELP = (
     "Which quality generator to emphasize in result metadata "
     "(simple / composable / secure). Pass/fail uses fixed per-metric "
@@ -48,7 +53,7 @@ _ALLOW_HELP = (
 @click.option(
     "--priority",
     type=_PRIORITY_CHOICE,
-    default=Priority.SECURE.value,
+    default="secure",
     show_default=True,
     help=_PRIORITY_HELP,
 )
@@ -120,7 +125,7 @@ def evaluate(
     # Use the first preference as the priority for CLI output
     if preferences:
         priority = preferences.split(",")[0].strip().lower()
-        if priority not in [p.value for p in Priority]:
+        if priority not in _PRIORITY_VALUES:
             click.echo(f"Error: Invalid preference '{priority}'", err=True)
             sys.exit(1)
 
@@ -251,7 +256,7 @@ def compare(source: str, target: str, verbose: bool) -> None:
 @click.option(
     "--priority",
     type=_PRIORITY_CHOICE,
-    default=Priority.SECURE.value,
+    default="secure",
     show_default=True,
     help=_PRIORITY_HELP,
 )
@@ -300,7 +305,7 @@ def inspect(
     # Use the first preference as the priority for CLI output
     if preferences:
         priority = preferences.split(",")[0].strip().lower()
-        if priority not in [p.value for p in Priority]:
+        if priority not in _PRIORITY_VALUES:
             click.echo(f"Error: Invalid preference '{priority}'", err=True)
             sys.exit(1)
 


### PR DESCRIPTION
## Summary

Closes #119.

`_register_commands()` imported `topos/cli/commands/quality.py`, whose module-level `from topos.evaluation.policies.base import Priority` transitively pulled in the full evaluation stack (`characteristic_morphism`, `functors.profunctors.ast.compare`) and `numpy`, on every real subcommand invocation — even commands that never evaluate code.

Implements the recommended fix from the issue (not the two rejected alternatives — relocating `Priority` or making `policies` lazy via PEP 562):

- `topos/cli/commands/quality.py`: replaced the module-scope `Priority` import with a module-level literal `_PRIORITY_VALUES = ("simple", "composable", "secure")`, used to build `_PRIORITY_CHOICE` and the `--priority` option defaults (`"secure"`). `Priority` is no longer imported anywhere in this file — the `evaluate`/`inspect` callbacks already lazy-import their heavy deps (`run_classify_file`, which internally does `Priority(priority)`), and the module-scope preference-validation checks now compare against `_PRIORITY_VALUES` directly.
- `tests/cli/test_quality.py`: added `test_priority_choice_matches_priority_enum`, a parity test asserting `_PRIORITY_VALUES`/`_PRIORITY_CHOICE.choices` match `{p.value for p in Priority}`, so the literal can't silently drift from the enum.
- `tests/cli/test_registration_imports.py`: added `test_register_commands_does_not_import_numpy_or_evaluation`, extending the existing tree-sitter import guard to also assert `numpy` and `topos.evaluation.*` stay out of `sys.modules` after `_register_commands()`.

## Acceptance criteria

- [x] `_register_commands()` no longer loads `numpy` / `topos.evaluation.*` — verified empirically and via the new guard test.
- [x] `--priority` still accepts exactly the `Priority` values, guarded by a parity test.
- [x] Registration-import guard test covers numpy/eval, not just tree-sitter.

## Test plan

- [x] `uv run pytest --no-cov -q` — 465 passed, 10 skipped, no failures/regressions.
- [x] `uv run pytest --no-cov -q tests/cli/test_registration_imports.py tests/cli/test_quality.py` — 22 passed.
- [x] `uv run ruff check --fix` / `uv run ruff format` on changed files — clean, no changes needed.
- [x] Manually confirmed `_register_commands()` leaves `numpy` / `topos.evaluation.*` out of `sys.modules`.

No deviations from the plan in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)