### PR TITLE
docs: streamline README for scannability (#102)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/Krv-Labs/topos/actions/workflows/ci.yml"><img src="https://github.com/Krv-Labs/topos/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://pypi.org/project/topos-mcp/"><img src="https://img.shields.io/pypi/v/topos-mcp.svg" alt="PyPI"></a>
+  <a href="https://pypi.org/project/topos-mcp/"><img src="https://img.shields.io/pypi/pyversions/topos-mcp.svg" alt="Python versions"></a>
+  <a href="https://github.com/Krv-Labs/topos/blob/main/LICENSE"><img src="https://img.shields.io/github/license/Krv-Labs/topos" alt="License"></a>
+  <a href="https://glama.ai/mcp/servers/Krv-Labs/topos"><img src="https://glama.ai/mcp/servers/Krv-Labs/topos/badges/score.svg" alt="topos MCP server"></a>
+</p>
+
+<p align="center">
   <b>Structural code quality metrics for agent-written programs.</b><br>
   <a href="https://docs.krv.ai/topos/">Docs</a> ·
   <a href="#quick-start">Quick Start</a> ·

--- a/README.md
+++ b/README.md
@@ -6,22 +6,37 @@
   </picture>
 </p>
 
-> **Structural code quality metrics for agent-written programs.**
+<p align="center">
+  <b>Structural code quality metrics for agent-written programs.</b><br>
+  <a href="https://docs.krv.ai/topos/">Docs</a> ·
+  <a href="#quick-start">Quick Start</a> ·
+  <a href="#mcp-server-for-agents">MCP Server</a> ·
+  <a href="https://github.com/Krv-Labs/topos/issues">Issues</a>
+</p>
 <!-- mcp-name: io.github.Krv-Labs/topos -->
 
-**Topos** gives you structural code quality metrics your agents can act on. Passing unit tests proves your code works, but Topos proves it's built to last. It measures program structure — not just syntax — giving agents concrete metrics to optimize toward on every pass. You set the target; agents handle the iteration.
+Passing unit tests proves your code works. **Topos** proves it's built to last. It measures program structure — complexity, coupling, and data-flow risk — not just syntax, so agents get a concrete target to optimize toward on every pass instead of a vague "clean it up."
 
-### The Quality Pillars
+---
 
-Topos evaluates code along three independent pillars:
+## Quick Start
 
-- **SIMPLE** — Avoids unnecessary complexity (AST entropy & CFG cyclomatic complexity).
-- **COMPOSABLE** — Cleanly decoupled from other modules (MDG Martin instability via GitNexus).
-- **SECURE** — Free of dangerous API reachability and taint paths (CPG analysis).
+```bash
+curl -fsSL https://docs.krv.ai/topos/install.sh | sh
+topos evaluate src/ -r
+```
 
-### The Medal Podium
+`evaluate -r` scores every file in `src/` and prints a ranked digest: which pillars pass, the worst-scoring files, and the cheapest fixes to flip a failing pillar. Add `-h` to any command for help, or `--json` for CI.
 
-Topos checks all three pillars and awards a **Code Quality Medal** based on how many pass:
+Other install paths (PyPI, source checkout) and the full command tour live at **[docs.krv.ai/topos/installation](https://docs.krv.ai/topos/installation.html)**.
+
+## What you get
+
+Topos checks three independent pillars and awards a **Code Quality Medal** for how many pass:
+
+- **SIMPLE** — avoids unnecessary complexity (AST entropy & CFG cyclomatic complexity)
+- **COMPOSABLE** — cleanly decoupled from other modules (MDG Martin instability via [GitNexus](https://github.com/abhigyanpatwari/GitNexus))
+- **SECURE** — free of dangerous API reachability and taint paths (CPG analysis)
 
 | Medal | Criteria |
 | :--- | :--- |
@@ -30,65 +45,7 @@ Topos checks all three pillars and awards a **Code Quality Medal** based on how 
 | 🥉 **BRONZE** | Passes 1 of 3 |
 | ❌ **SLOP** | Passes 0 (or fails to parse) |
 
-Set your **Preferences** (e.g., `simple,composable,secure`) to tell your coding agent which pillars to prioritize when aiming for Gold under token and time budgets.
-
----
-
-### Quick Start
-
-#### Install
-
-```bash
-curl -fsSL https://docs.krv.ai/topos/install.sh | sh
-topos --version
-topos --help
-```
-
-Every command also accepts `-h` / `--help`. See [`docs/cli-startup-benchmarks.md`](docs/cli-startup-benchmarks.md) for release binary size and startup benchmarks.
-
-#### Evaluate code — the 60-second tour
-
-```bash
-topos evaluate path/to/file.py
-topos evaluate src/ -r
-topos evaluate src/ -r --json
-topos inspect path/to/file.py
-topos compare before.py after.py
-```
-
-Use `evaluate` for medals, `inspect` for per-file metrics, `compare` for AST edit distance, and `--json` for CI or automation.
-
-#### Review a whole repo or module
-
-Point `evaluate` at a directory with `-r` for a ranked, actionable digest instead of a per-file wall:
-
-```bash
-topos evaluate src/ -r
-topos evaluate src/mypackage -r
-```
-
-The summary surfaces, in order:
-
-- **Pillars** — per-pillar PASS/FAIL with average & minimum scores across all files.
-- **Directory Floor Verdict** — the worst verdict any single file drags the codebase down to (the pointwise lattice meet).
-- **Needs attention** — the lowest-scoring files (where quality is *worst*).
-- **Lowest-hanging fruit** — the files closest to *flipping* a failing pillar, each with the concrete fix. **Start here for the cheapest wins:**
-
-```text
-Lowest-hanging fruit
-  Smallest improvement that flips a failing pillar.
-  1.  src/mypackage/__init__.py
-      simple 59% → 60% (+1 pts)
-  2.  src/mypackage/util.py
-      simple 55% → 60% (+5 pts)
-      ↳ Extract helper functions to cut branching (cyclomatic 21 > 15).
-```
-
-Add `--json` for a machine-readable rollup, or `-v` to expand every file's raw metrics.
-
-#### Score COMPOSABLE — add a dependency graph
-
-`COMPOSABLE` measures how cleanly a module is decoupled, which needs a cross-file **dependency graph**. Topos reads one from a `.gitnexus/` directory produced by [GitNexus](https://github.com/abhigyanpatwari/GitNexus). Without it, `SIMPLE` and `SECURE` still run — but any medal containing `COMPOSABLE` (including 🥇 GOLD) is unreachable.
+`COMPOSABLE` needs a cross-file dependency graph, which the CLI does not build automatically:
 
 ```bash
 npm install -g gitnexus
@@ -96,133 +53,26 @@ topos depgraph generate
 topos evaluate src/ -r --gitnexus-dir .gitnexus
 ```
 
-Install GitNexus once per machine. Run `topos depgraph generate` from each repository you want to score for COMPOSABLE.
+Other commands: `topos inspect` for per-file metrics, `topos compare` for AST edit distance between two versions, `topos coverage` for structural test coverage, and `--preferences simple,composable,secure` to tell agents which pillar to protect first when 🥇 GOLD isn't reachable. Full reference: **[docs.krv.ai/topos/cli](https://docs.krv.ai/topos/cli.html)**.
 
-> The CLI does **not** auto-detect `.gitnexus/` — pass `--gitnexus-dir` explicitly. Regenerate after imports change (new modules, renames, restructures). *(The `topos mcp` server, by contrast, auto-detects `./.gitnexus`.)*
-
-#### Measure test coverage — structural + semantic
-
-`--tests` takes your test files (repeat the flag for several); the positional arguments are the program-under-test files.
-
-```bash
-topos coverage --tests tests/test_foo.py topos/foo.py
-topos coverage --tests tests/test_a.py --tests tests/test_b.py src/a.py src/b.py
-topos coverage --tests tests/test_foo.py topos/foo.py --coverage-threshold 0.8 --json
-```
-
-Reports UAST **declaration coverage**: bipartite matching between PUT and test declarations at the structural level.
-
-#### Steer the verdict
-
-```bash
-topos evaluate src/ -r --preferences simple,composable,secure
-topos evaluate app.py --allow yaml.load
-topos evaluate src/ -r --language typescript
-```
-
-`--preferences` ranks pillars for agents, `--allow` acknowledges a known risky call and caps the grade below Gold, and `--language` supports `python`, `typescript`, `javascript`, `rust`, and `cpp`.
-
----
-
-### MCP Server
+## MCP server (for agents)
 
 Give any MCP-compatible agent — Claude Code, Cursor, Gemini CLI, Windsurf — a live feed of Topos verdicts so it can evaluate and iterate on its own output.
 
-<details>
-<summary><b>Set up <code>topos mcp</code> in your agent</b></summary>
-
-&nbsp;
-
-#### Step 1 — Build the dependency graph (optional but recommended)
-
-> **_⚠️ Recommended:_**
-> Without a dependency graph, Topos cannot score COMPOSABLE — any verdict containing it (including `IDEAL`) is unreachable. `SIMPLE` and `SECURE` always run.
->
-> ```bash
-> npm install -g gitnexus
-> cd /path/to/your/repo
-> topos depgraph generate
-> ```
->
-> Re-run when imports change (new modules, renames, restructures). The cache keys on `.gitnexus/` mtime and invalidates itself.
-
-> **_💡 Tip:_**
-> Verify the binary before wiring it into editors:
->
-> ```bash
-> topos mcp
-> ```
->
-> `topos mcp` prints the FastMCP banner and waits on standard input. Press `Ctrl-C` after the smoke check.
-
-#### Step 2 — Register with your agent
-
-Run from your project root — Topos auto-detects its file-access root by walking up for `.git` or `pyproject.toml`.
-
-##### Claude Code
-
 ```bash
-claude mcp add topos topos mcp
+claude mcp add --transport stdio topos -- topos mcp
 ```
 
-##### Gemini CLI
-
-```bash
-gemini mcp add topos topos mcp
-```
-
-##### Cursor
-
-<a href="cursor://anysphere.cursor-deeplink/mcp/install?name=topos&config=eyJjb21tYW5kIjogInRvcG9zIG1jcCJ9">**➕ Install `topos` in Cursor**</a>
-
-Or edit `.cursor/mcp.json`:
-
-```json
-{ "mcpServers": { "topos": { "command": "topos mcp" } } }
-```
-
-##### Windsurf and everything else
-
-```json
-{ "mcpServers": { "topos": { "command": "topos mcp" } } }
-```
-
-#### Step 3 — Launch from the project root
-
-> *:warning: IMPORTANT*
-> Topos refuses to read files outside a trusted root. If you must launch from elsewhere, set it explicitly:
->
-> ```json
-> {
->   "command": "topos mcp",
->   "env": { "TOPOS_MCP_FILE_ROOT": "/absolute/path/to/repo" }
-> }
-> ```
-
-> ***:bulb: TIP***
-> On the agent's first turn, point it at the workflow doc:
->
-> > "Fetch `topos://docs/workflows` and follow the Topos refactor loop."
->
-> Or invoke the prompt directly: `topos_refactor_until_ideal(filepath="path/to/file.py")`.
-
-#### Smoke test
-
-> "Use topos to find the worst-scoring file in `src/`, propose a refactor, and verify with `topos_assess_improvement`."
-
-A healthy response shows `{simple: 72%, composable: 65%, secure: 95%}` when GitNexus is configured. If the response is missing `composable`, go back to Step 1.
-
-</details>
+Setup for Cursor, VS Code, Gemini CLI, Codex, and Windsurf, plus troubleshooting and the full MCP tool list: **[docs.krv.ai/topos/agents](https://docs.krv.ai/topos/agents.html)**.
 
 ---
 
-### How it works
+## How it works
 
-Topos measures code along the three independent quality generators and maps them to an 8-element evaluation lattice:
+Topos measures code along the three pillars above and maps the result to an 8-element evaluation lattice — the three pillars are pairwise incomparable, and 🥇 GOLD is their intersection.
 
-- **SIMPLE** — Built from the [abstract syntax tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree) (AST) and [control-flow graph](https://en.wikipedia.org/wiki/Control-flow_graph) (CFG). We calculate cyclomatic complexity of the CFG and entropy of the AST to assess complexity.
-- **COMPOSABLE** — Built from the [module dependency graph](https://en.wikipedia.org/wiki/Module_dependency_graph) (MDG) using [GitNexus](https://github.com/abhigyanpatwari/GitNexus), to capture inter-module dependencies. This is slightly different than the usual [program dependence graph](https://en.wikipedia.org/wiki/Program_dependence_graph) (PDG) which is used to capture intra-function dependencies. We calculate Martin Instability and Fanning metrics for the MDG to assess coupling.
-- **SECURE** — Built from the [code property graph](https://en.wikipedia.org/wiki/Code_property_graph) (CPG). We calculate dangerous-API reachability and taint paths from the CPG to assess security.
+<details>
+<summary>Evaluation lattice diagram</summary>
 
 ```mermaid
 graph BT
@@ -258,20 +108,11 @@ graph BT
     style IDEAL      fill:#ffd700,stroke:#856404,color:#000
 ```
 
-> [!TIP]
-> **Three Independent Pillars:** `SIMPLE`, `COMPOSABLE`, and `SECURE` are **pairwise incomparable**. A file can achieve any subset of {S, C, Sc} independently. `🥇 GOLD` is the intersection of all three. 
+</details>
 
-#### Manager Priorities & Agent Iteration
+Set your **Preferences** (e.g. `simple,composable,secure`) to tell your coding agent which pillars to prioritize when aiming for GOLD under token and time budgets, and how to relax that goal when GOLD isn't reachable. Details: [docs.krv.ai/topos/preferences](https://docs.krv.ai/topos/preferences.html) · [docs.krv.ai/topos/measures](https://docs.krv.ai/topos/measures.html) · [docs.krv.ai/topos/concepts](https://docs.krv.ai/topos/concepts.html).
 
-In a perfect world, every file would earn a `🥇 GOLD` medal. In reality, managers and developers have a finite budget of time and tokens. 
-
-Topos allows you to set **Preferences** — an ordering of these medals based on your immediate priorities. Coding agents use this ranking to aim for `🥇 GOLD`. If achieving `🥇 GOLD` isn't feasible within the budget, the preference ranking tells the agent exactly how to *relax* its goals, ensuring it still delivers the highest possible quality medal aligned with your priorities.
-
-
-
----
-
-### Contributing
+## Contributing
 
 Topos is used internally at [Krv Labs](https://krv.ai) to manage AI agent code output. We welcome bugs, ideas, and contributions.
 
@@ -281,6 +122,6 @@ Topos is used internally at [Krv Labs](https://krv.ai) to manage AI agent code o
 
 ---
 
-[Full Documentation](docs/) · [Measures & Metrics](docs/source/measures.rst) · [Category Theory Concepts](docs/source/concepts.rst)
+[Full Documentation](https://docs.krv.ai/topos/) · [Measures & Metrics](https://docs.krv.ai/topos/measures.html) · [Category Theory Concepts](https://docs.krv.ai/topos/concepts.html) · [Engineering notes](docs/)
 
 _Built with ❤️ by [Krv Labs](https://krv.ai)_

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -97,6 +97,37 @@ two different concepts:
 .. important::
    Without ``--gitnexus-dir``, Topos still scores **SIMPLE** and **SECURE**, but **COMPOSABLE** (and any medal requiring it) stays unreachable. Generate the graph once per repo with ``topos depgraph generate``.
 
+Directory digest
+~~~~~~~~~~~~~~~~
+
+Point ``evaluate`` at a directory with ``-r`` for a ranked, actionable digest
+instead of a per-file wall:
+
+.. code-block:: bash
+
+   topos evaluate src/ -r
+   topos evaluate src/mypackage -r
+
+The summary surfaces, in order:
+
+* **Pillars** — per-pillar PASS/FAIL with average & minimum scores across all files.
+* **Directory Floor Verdict** — the worst verdict any single file drags the codebase down to (the pointwise lattice meet).
+* **Needs attention** — the lowest-scoring files (where quality is *worst*).
+* **Lowest-hanging fruit** — the files closest to *flipping* a failing pillar, each with the concrete fix. Start here for the cheapest wins:
+
+.. code-block:: text
+
+   Lowest-hanging fruit
+     Smallest improvement that flips a failing pillar.
+     1.  src/mypackage/__init__.py
+         simple 59% → 60% (+1 pts)
+     2.  src/mypackage/util.py
+         simple 55% → 60% (+5 pts)
+         ↳ Extract helper functions to cut branching (cyclomatic 21 > 15).
+
+Add ``--json`` for a machine-readable rollup, or ``-v`` to expand every
+file's raw metrics.
+
 inspect
 -------
 


### PR DESCRIPTION
## Why

Closes #102. The complaint was specifically about `glama.ai`'s MCP listing: on smaller screens, the README's own content pushed the install command far enough down that it took a lot of scrolling to reach. This is a **draft for a human taste-check** — "keep essentials" is subjective, so please redirect anything I judged wrong.

## What changed

The repo already has a full Sphinx docs site published at [docs.krv.ai/topos](https://docs.krv.ai/topos/) (built from `docs/source/*.rst` via `.github/workflows/docs.yml`), and it already covers almost everything the README was duplicating — often in more depth and more current than the README's copy. So the approach was: **link, don't duplicate.**

**Kept, moved higher:**
- Logo, one-line pitch, `mcp-name` comment (unchanged — needed for MCP registry/branding).
- Install + quickstart (`curl ... | sh` then `topos evaluate src/ -r`) — now the very next thing after the pitch, ahead of the pillars/medal table that used to precede it.
- The three-pillar summary and medal table — condensed, kept near the top since it's a fast scan.
- A short MCP-server section (single `claude mcp add` command) since that's the other primary entry point people care about.

**Condensed and linked out to existing docs (no longer duplicated in the README):**
- The full "Set up `topos mcp` in your agent" walkthrough (Claude Code / Cursor / Gemini / Windsurf / Codex / VS Code, JSON configs, root-override env var, troubleshooting) → this is already more complete and current in `docs/source/agents.rst` (published at `/agents.html`). It even documents Codex and the VS Code extension, which the README didn't.
- CLI option tables for `evaluate`/`inspect`/`compare`/`coverage`/`--preferences`/`--allow`/`--language` → already fully documented in `docs/source/cli.rst` (`/cli.html`).
- Full install-path breakdown (binary/PyPI/source, troubleshooting, upgrade/uninstall) → already in `docs/source/installation.rst`.
- The "Manager Priorities & Agent Iteration" paragraph → verbatim duplicate of `docs/source/index.rst`; cut and linked instead.
- Deep pillar explanations (SIMPLE/COMPOSABLE/SECURE mechanics) → already covered at length in `docs/source/quickstart.rst`, `measures.rst`, and `concepts.rst`.

**Relocated (README-only content, not duplicated anywhere in docs — moved rather than deleted):**
- The `evaluate -r` ranked-digest walkthrough (Pillars → Directory Floor Verdict → Needs attention → Lowest-hanging fruit, with the ASCII example) was unique to the README. I added a new "Directory digest" subsection to `docs/source/cli.rst` with that exact content, and the README now just says what `evaluate -r` gives you in one line + links to the full reference.

**Kept but moved lower:**
- The mermaid evaluation-lattice diagram — still README-only (GitHub renders mermaid natively; the docs site uses an SVG image instead), so I kept it, but tucked it into a collapsed `<details>` under a new "How it works" section near the bottom rather than mid-scroll.
- "Contributing" section — kept essentially as-is near the bottom.

**Net effect:** README went from 287 lines to 127 lines (~56% shorter), and the install command now appears right after the pitch instead of after ~35 lines of pillar/medal content.

## Judgment calls worth a second look

- I inferred `https://docs.krv.ai/topos/` as the docs site root (matches the `install.sh` URL already in the README/docs) and verified with a live fetch that it resolves and that `/agents.html`, `/cli.html` etc. are real pages. Please confirm this is the canonical public URL you want linked from the README.
- I replaced the old "MCP Server" `<details>` walkthrough entirely with a link — if you'd rather keep a slightly longer inline Claude Code + Cursor snippet (since those are probably the two most common clients) and only link out for the rest, easy to add back.
- I left `docs/cli-startup-benchmarks.md` and friends (the loose engineering-notes markdown files under `docs/`, not part of the Sphinx toctree) reachable only via a generic "Engineering notes" link at the bottom, instead of the previous inline link next to the install command. Happy to restore the specific inline link if that's preferred.

## Test plan
- [ ] Preview render on GitHub to confirm the mermaid diagram still renders inside `<details>`.
- [ ] Click through the `docs.krv.ai/topos/...` links once the docs workflow has deployed (they resolve correctly against the current live site; not affected by this branch since docs content changes are additive).
- [ ] Skim on a narrow viewport to confirm install is reachable with minimal scrolling.