### PR TITLE
fix(cfg): count match/case arms toward cfg.cyclomatic for Rust and Python

### DIFF
--- a/tests/graphs/cfg/test_python_match_cfg.py
+++ b/tests/graphs/cfg/test_python_match_cfg.py
@@ -1,0 +1,89 @@
+"""
+Python-specific `match`/`case` CFG shape regression tests.
+
+Python's tree-sitter grammar wraps `match` arms similarly to Rust:
+`match_statement` -> [subject, block], and that `block`'s children are
+`case_clause` nodes.  Prior to this fix, `_match_arms()` didn't recognize
+`case_clause` as an arm boundary, so every Python `match` silently
+collapsed to a single unconditional edge regardless of case count — the
+same class of bug reported for Rust in issue #151, confirmed to affect
+Python too during investigation.
+
+These tests pin down the corrected CFG shape so future grammar-mapping or
+builder changes don't silently regress it.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+from topos.core.morphism import ProgramMorphism
+from topos.graphs.cfg.models import EdgeKind
+from topos.graphs.cfg.object import ControlFlowGraph
+
+
+def _cfg(source: str) -> ControlFlowGraph:
+    morphism = ProgramMorphism(source=source, language="python")
+    cfg = morphism.build_cfg()
+    assert cfg is not None
+    return cfg
+
+
+def test_python_match_creates_one_arm_per_case():
+    src = (
+        "def classify(n):\n"
+        "    match n:\n"
+        "        case 0:\n"
+        '            return "zero"\n'
+        "        case 1:\n"
+        '            return "one"\n'
+        "        case _:\n"
+        '            return "other"\n'
+    )
+    cfg = _cfg(src)
+    kinds = [e.kind for e in cfg.edges]
+    assert kinds.count(EdgeKind.SWITCH_CASE) == 3
+    assert kinds.count(EdgeKind.RETURN) == 3
+
+
+def test_python_match_with_multistatement_case_keeps_one_arm_per_case():
+    """A `case` body with multiple statements must still contribute exactly
+    one SWITCH_CASE edge — regression guard against flattening case bodies
+    into the enclosing statement list."""
+    src = (
+        "def classify(n):\n"
+        "    match n:\n"
+        "        case 0:\n"
+        "            do_a()\n"
+        "            do_b()\n"
+        '            return "zero"\n'
+        "        case 1:\n"
+        '            return "one"\n'
+        "        case _:\n"
+        '            return "other"\n'
+    )
+    cfg = _cfg(src)
+    kinds = [e.kind for e in cfg.edges]
+    assert kinds.count(EdgeKind.SWITCH_CASE) == 3
+    assert kinds.count(EdgeKind.RETURN) == 3
+
+
+def test_python_match_surfaces_nested_if_inside_case():
+    src = (
+        "def classify(n, y):\n"
+        "    match n:\n"
+        "        case 0:\n"
+        "            if y > 0:\n"
+        '                return "pos"\n'
+        "            else:\n"
+        '                return "nonpos"\n'
+        "        case 1:\n"
+        '            return "one"\n'
+        "        case _:\n"
+        '            return "other"\n'
+    )
+    cfg = _cfg(src)
+    kinds = Counter(e.kind for e in cfg.edges)
+    assert kinds[EdgeKind.SWITCH_CASE] == 3
+    assert kinds[EdgeKind.TRUE] == 1
+    assert kinds[EdgeKind.FALSE] == 1

--- a/tests/graphs/cfg/test_rust_cfg.py
+++ b/tests/graphs/cfg/test_rust_cfg.py
@@ -1,0 +1,87 @@
+"""
+Rust-specific CFG shape regression tests.
+
+Rust's tree-sitter grammar wraps `match` arms one level deeper than the
+generic case: `match_expression` -> [scrutinee, match_block], and
+`match_block`'s children are `match_arm` nodes.  Prior to this fix,
+`_match_arms()` didn't recognize `match_block`/`match_arm`, so every Rust
+`match` silently collapsed to a single unconditional edge regardless of
+arm count (issue #151: an 8-arm match read `cfg.cyclomatic == 1.0`,
+identical to straight-line code).
+
+These tests pin down the corrected CFG shape so future grammar-mapping or
+builder changes don't silently regress it.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+from topos.core.morphism import ProgramMorphism
+from topos.graphs.cfg.models import EdgeKind
+from topos.graphs.cfg.object import ControlFlowGraph
+
+
+def _cfg(source: str) -> ControlFlowGraph:
+    morphism = ProgramMorphism(source=source, language="rust")
+    cfg = morphism.build_cfg()
+    assert cfg is not None
+    return cfg
+
+
+def test_rust_eight_arm_match_grows_cyclomatic_complexity():
+    """Direct reproduction of issue #151: an 8-arm match must not read as
+    cyclomatic complexity 1 (identical to no branching)."""
+    src = (
+        "pub fn probe(x: u8) -> &'static str {\n"
+        "    match x {\n"
+        '        0 => "a", 1 => "b", 2 => "c", 3 => "d",\n'
+        '        4 => "e", 5 => "f", 6 => "g", _ => "h",\n'
+        "    }\n"
+        "}\n"
+    )
+    cfg = _cfg(src)
+    assert cfg.metrics()["cfg.cyclomatic"] == 8.0
+    kinds = [e.kind for e in cfg.edges]
+    assert kinds.count(EdgeKind.SWITCH_CASE) == 8
+
+
+def test_rust_match_with_multistatement_arm_keeps_one_arm_per_case():
+    """A match arm with a multi-statement block body must still contribute
+    exactly one SWITCH_CASE edge — not one per inner statement.  This is a
+    regression guard against flattening arm bodies into the enclosing
+    statement list (the trap that would occur from naively reusing Go's
+    case-arm allowlist for Rust's match_arm nodes)."""
+    src = (
+        "pub fn probe(x: u8) -> &'static str {\n"
+        "    match x {\n"
+        '        0 => { do_a(); do_b(); "a" },\n'
+        '        1 => "b",\n'
+        '        _ => "c",\n'
+        "    }\n"
+        "}\n"
+    )
+    cfg = _cfg(src)
+    kinds = [e.kind for e in cfg.edges]
+    assert kinds.count(EdgeKind.SWITCH_CASE) == 3
+    assert cfg.metrics()["cfg.cyclomatic"] == 3.0
+
+
+def test_rust_match_surfaces_nested_if_inside_arm():
+    """A decision nested inside one arm's body must still be surfaced as
+    its own TRUE/FALSE branch, on top of the arm's own SWITCH_CASE edge."""
+    src = (
+        "pub fn probe(x: u8, y: u8) -> &'static str {\n"
+        "    match x {\n"
+        '        0 => { if y > 0 { "pos" } else { "nonpos" } },\n'
+        '        1 => "b",\n'
+        '        _ => "c",\n'
+        "    }\n"
+        "}\n"
+    )
+    cfg = _cfg(src)
+    kinds = Counter(e.kind for e in cfg.edges)
+    assert kinds[EdgeKind.SWITCH_CASE] == 3
+    assert kinds[EdgeKind.TRUE] == 1
+    assert kinds[EdgeKind.FALSE] == 1
+    assert cfg.metrics()["cfg.cyclomatic"] == 4.0

--- a/topos/graphs/cfg/builder.py
+++ b/topos/graphs/cfg/builder.py
@@ -351,6 +351,13 @@ _BLOCK_NATIVE_KINDS = (
     | _CASE_ARM_NATIVE_KINDS
 )
 
+# Native tree-sitter node kinds for an individual match arm whose body may
+# itself be a multi-statement block (Rust `match_arm`, Python `case_clause`).
+# Kept out of _BLOCK_NATIVE_KINDS deliberately: unlike Go's single-statement
+# case arms, unwrapping these further would flatten a multi-statement arm
+# body into the surrounding list and lose the arm boundary the CFG needs.
+_MATCH_ARM_NATIVE_KINDS = frozenset({"match_arm", "case_clause"})
+
 
 def _is_block_container(node: UASTNode) -> bool:
     return node.kind == "Unknown" and node.native.node_kind in _BLOCK_NATIVE_KINDS
@@ -432,6 +439,12 @@ def _match_arms(stmt: UASTNode) -> list[UASTNode]:
     Go also has discriminant-less forms (``switch { case ... }``,
     ``select { case ... }``) where the first child is itself a case arm —
     detected via its native node kind so every arm is kept.
+
+    Rust (``match_expression`` -> [scrutinee, match_block]) and Python
+    (``match_statement`` -> [subject, block]) both wrap their arms one level
+    deeper in a container whose *direct* children are ``match_arm`` /
+    ``case_clause`` nodes.  Those arm nodes are returned as one opaque unit
+    each rather than unwrapped further (see ``_MATCH_ARM_NATIVE_KINDS``).
     """
     if not stmt.children:
         return []
@@ -439,7 +452,18 @@ def _match_arms(stmt: UASTNode) -> list[UASTNode]:
     first = children[0]
     if first.kind == "Unknown" and first.native.node_kind in _CASE_ARM_NATIVE_KINDS:
         return _unwrap_to_statements(children)
-    return _unwrap_to_statements(children[1:])
+
+    rest = children[1:]
+    if len(rest) == 1 and rest[0].kind == "Unknown":
+        arm_nodes = [
+            c
+            for c in rest[0].children
+            if c.kind == "Unknown" and c.native.node_kind in _MATCH_ARM_NATIVE_KINDS
+        ]
+        if arm_nodes:
+            return arm_nodes
+
+    return _unwrap_to_statements(rest)
 
 
 def _children_with_control_flow(node: UASTNode) -> list[UASTNode]:


### PR DESCRIPTION
## Summary
- `_match_arms()` in `topos/graphs/cfg/builder.py` only recognized Go's native case-arm node kinds (`expression_case`, `type_case`, `default_case`, `communication_case`), so Rust's `match_block`/`match_arm` and Python's `case_clause` were never detected as arm boundaries.
- Every Rust `match` / Python `match`/`case` silently collapsed to a single `UNCONDITIONAL` edge regardless of arm count, so `cfg.cyclomatic` for an 8-arm match read `1.0` — identical to straight-line code (false negative on genuinely branchy code).
- Fix adds a dedicated `_MATCH_ARM_NATIVE_KINDS` set, kept separate from the existing Go-oriented allowlists to avoid a flattening trap: naively reusing `_CASE_ARM_NATIVE_KINDS` would recurse into each arm's body and merge multi-statement arms into one flat list, losing arm boundaries.
- Go's own switch/select handling is untouched.

## Test plan
- [x] New `tests/graphs/cfg/test_rust_cfg.py`: 8-arm match reproduces the issue directly (`cfg.cyclomatic == 8.0`, 8 `SWITCH_CASE` edges), a multi-statement-arm regression guard, and a nested-if-inside-arm case.
- [x] New `tests/graphs/cfg/test_python_match_cfg.py`: same coverage for Python `match`/`case` (same latent bug, found during investigation, not in the original report).
- [x] Full `pytest` (677 passed, 10 skipped) and `ruff check --fix` / `ruff format` clean.
- [x] Manually reproduced the exact issue snippet before/after the fix.

Fixes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)