### PR TITLE
fix(entropy): blend ast.entropy toward neutral baseline below a size floor

### DIFF
--- a/src/probes_ast.rs
+++ b/src/probes_ast.rs
@@ -1,5 +1,31 @@
 use pyo3::prelude::*;
 
+const ENTROPY_SIZE_FLOOR_BYTES: usize = 200;
+const ENTROPY_NEUTRAL_RATIO: f64 = 0.5; // mirrors SIMPLE.entropy_ideal
+
+/// Raw zlib compressed/original byte ratio, blended toward a neutral
+/// baseline below `ENTROPY_SIZE_FLOOR_BYTES`.  zlib's fixed per-stream
+/// overhead (header + Adler-32 trailer + minimum block cost) dominates the
+/// ratio on tiny inputs, so below the floor the raw ratio isn't trusted
+/// outright — it's blended proportionally toward `ENTROPY_NEUTRAL_RATIO`
+/// instead of gating a handful of source bytes on compression trivia.
+fn compressed_ratio(source_bytes: &[u8]) -> (usize, f64) {
+    let mut encoder = flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::new(9));
+    use std::io::Write;
+    encoder.write_all(source_bytes).unwrap();
+    let compressed = encoder.finish().unwrap();
+    let compressed_len = compressed.len();
+
+    let raw_ratio = compressed_len as f64 / source_bytes.len() as f64;
+    let ratio = if source_bytes.len() >= ENTROPY_SIZE_FLOOR_BYTES {
+        raw_ratio
+    } else {
+        let confidence = source_bytes.len() as f64 / ENTROPY_SIZE_FLOOR_BYTES as f64;
+        confidence * raw_ratio + (1.0 - confidence) * ENTROPY_NEUTRAL_RATIO
+    };
+    (compressed_len, ratio)
+}
+
 #[pyfunction]
 pub fn calculate_kolmogorov_proxy(source: &str) -> f64 {
     if source.is_empty() {
@@ -8,12 +34,9 @@ pub fn calculate_kolmogorov_proxy(source: &str) -> f64 {
 
     let binding = source.replace("\r\n", "\n");
     let source_bytes = binding.as_bytes();
-    let mut encoder = flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::new(9));
-    use std::io::Write;
-    encoder.write_all(source_bytes).unwrap();
-    let compressed = encoder.finish().unwrap();
+    let (_, ratio) = compressed_ratio(source_bytes);
 
-    compressed.len() as f64 / source_bytes.len() as f64
+    ratio
 }
 
 #[pyclass(get_all)]
@@ -37,12 +60,7 @@ pub fn calculate_entropy_detailed(source: &str) -> EntropyResult {
 
     let binding = source.replace("\r\n", "\n");
     let source_bytes = binding.as_bytes();
-    let mut encoder = flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::new(9));
-    use std::io::Write;
-    encoder.write_all(source_bytes).unwrap();
-    let compressed = encoder.finish().unwrap();
-
-    let ratio = compressed.len() as f64 / source_bytes.len() as f64;
+    let (compressed_size, ratio) = compressed_ratio(source_bytes);
 
     let interpretation = if ratio < 0.2 {
         "extreme redundancy (possible boilerplate or repetitive data)"
@@ -56,7 +74,7 @@ pub fn calculate_entropy_detailed(source: &str) -> EntropyResult {
 
     EntropyResult {
         ratio,
-        compressed_size: compressed.len(),
+        compressed_size,
         original_size: source_bytes.len(),
         interpretation: interpretation.to_string(),
     }
@@ -144,5 +162,40 @@ mod tests {
         let s = "a".repeat(10) + &"b".repeat(10);
         let variance = calculate_entropy_variance(&s, 5);
         assert!(variance >= 0.0);
+    }
+
+    /// Issue #152: a tiny, structurally-simple array-lookup function must no
+    /// longer score above the SIMPLE `max_entropy` gate (0.8) just because
+    /// zlib's fixed per-stream overhead dominates the ratio on short input.
+    #[test]
+    fn test_kolmogorov_proxy_tiny_dense_function_stays_in_band() {
+        let array_lookup = "pub fn probe(x: u8) -> &'static str {\n    const T: [&str; 8] = [\"a\", \"b\", \"c\", \"d\", \"e\", \"f\", \"g\", \"h\"];\n    T[x as usize]\n}\n";
+        let ratio = calculate_kolmogorov_proxy(array_lookup);
+        assert!(
+            ratio <= 0.8,
+            "expected tiny array-lookup fn to pass the entropy gate, got {ratio}"
+        );
+    }
+
+    /// Above the size floor, the blend must be a no-op: the ratio should
+    /// equal the plain compressed/original byte ratio exactly.
+    #[test]
+    fn test_kolmogorov_proxy_unaffected_above_size_floor() {
+        let s = "x".repeat(ENTROPY_SIZE_FLOOR_BYTES + 1);
+        let (compressed_len, ratio) = compressed_ratio(s.as_bytes());
+        let raw_ratio = compressed_len as f64 / s.len() as f64;
+        assert_eq!(ratio, raw_ratio);
+    }
+
+    /// Below the size floor, the blended ratio must sit strictly between
+    /// the raw (unblended) ratio and the neutral baseline.
+    #[test]
+    fn test_kolmogorov_proxy_blends_toward_neutral_below_floor() {
+        let s = "x=1";
+        let (compressed_len, blended) = compressed_ratio(s.as_bytes());
+        let raw_ratio = compressed_len as f64 / s.len() as f64;
+        assert!(raw_ratio > ENTROPY_NEUTRAL_RATIO);
+        assert!(blended < raw_ratio);
+        assert!(blended > ENTROPY_NEUTRAL_RATIO);
     }
 }

--- a/tests/cli/test_quality.py
+++ b/tests/cli/test_quality.py
@@ -125,20 +125,24 @@ def test_evaluate_progress_bar_for_interactive_text(tmp_path: Path, monkeypatch)
 def test_evaluate_lowest_hanging_fruit(tmp_path: Path):
     d = tmp_path / "src"
     d.mkdir()
-    # Five hard failures on `simple` (score 0%, gap 60).
+    # Five hard failures on `simple` (score 24%, gap 36) via genuinely
+    # redundant boilerplate — large enough (240 bytes) to be well above the
+    # entropy probe's tiny-input size floor, so this fails on real
+    # repetitiveness rather than a single-line file's fixed-overhead
+    # artifact.
     for idx in range(5):
-        (d / f"trivial_{idx}.py").write_text(f"x = {idx}\n", encoding="utf-8")
-    # One clear near-miss on `simple` (~52%, the smallest failing gap).
+        (d / f"trivial_{idx}.py").write_text("x = 1\n" * 40, encoding="utf-8")
+    # One clear near-miss on `simple` (55%, the smallest failing gap) via a
+    # chain of 8 independent ifs — cyclomatic/max-function-complexity carry
+    # the score down close to (but under) the 60% threshold, comfortably
+    # sized (276 bytes) to be unaffected by the entropy size floor too.
     near = d / "near_miss.py"
-    near.write_text(
-        "def f(a, b):\n"
-        "    if a:\n"
-        "        return b\n"
-        "    if b:\n"
-        "        return a\n"
-        "    return 0\n",
-        encoding="utf-8",
-    )
+    near_lines = ["def f(" + ", ".join(f"a{i}" for i in range(1, 9)) + "):"]
+    for i in range(1, 9):
+        near_lines.append(f"    if a{i}:")
+        near_lines.append(f"        return {i}")
+    near_lines.append("    return 0")
+    near.write_text("\n".join(near_lines) + "\n", encoding="utf-8")
 
     runner = CliRunner()
     result = runner.invoke(cli, ["evaluate", str(d), "-r"])
@@ -151,7 +155,7 @@ def test_evaluate_lowest_hanging_fruit(tmp_path: Path):
     assert "near_miss.py" in fruit_section
     # The near-miss is the cheapest win: ranked first with the smallest gap.
     assert re.search(r"1\.\s+.*near_miss\.py", fruit_section)
-    assert "simple 52% → 60%" in fruit_section
+    assert "simple 55% → 60%" in fruit_section
 
 
 def test_evaluate_lowest_hanging_fruit_all_pass_message(tmp_path: Path):

--- a/tests/functors/probes/ast/test_ast_metrics.py
+++ b/tests/functors/probes/ast/test_ast_metrics.py
@@ -37,6 +37,37 @@ def test_block_entropy():
     assert calculate_entropy_variance("") == 0.0
 
 
+def test_kolmogorov_proxy_tiny_dense_function_passes_simple_gate():
+    """Issue #152: a 3-line array-lookup refactor of an 8-arm match must not
+    score worse than the match it replaced, and must fall within the SIMPLE
+    entropy band -- previously zlib's fixed per-stream overhead dominated
+    the ratio on such a short input and flagged this textbook simplifying
+    refactor as a regression."""
+    from topos.evaluation.policies.calibration import SIMPLE
+
+    array_lookup = (
+        "pub fn probe(x: u8) -> &'static str {\n"
+        '    const T: [&str; 8] = ["a", "b", "c", "d", "e", "f", "g", "h"];\n'
+        "    T[x as usize]\n"
+        "}\n"
+    )
+    match8 = (
+        "pub fn probe(x: u8) -> &'static str {\n"
+        "    match x {\n"
+        '        0 => "a", 1 => "b", 2 => "c", 3 => "d",\n'
+        '        4 => "e", 5 => "f", 6 => "g", _ => "h",\n'
+        "    }\n"
+        "}\n"
+    )
+
+    array_ratio = calculate_kolmogorov_proxy(array_lookup)
+    match_ratio = calculate_kolmogorov_proxy(match8)
+
+    assert SIMPLE.min_entropy <= array_ratio <= SIMPLE.max_entropy
+    assert SIMPLE.min_entropy <= match_ratio <= SIMPLE.max_entropy
+    assert array_ratio <= match_ratio + 0.1
+
+
 def test_distance_metrics():
     source1 = "x = 1"
     source2 = "y = 2"

--- a/tests/mcp/test_assess.py
+++ b/tests/mcp/test_assess.py
@@ -325,8 +325,15 @@ def test_assess_improvement_has_no_regression_diff() -> None:
         )
     )
     r = _assess(tr)
-    # Unpatched, added branching scores as an improvement here.
-    assert r.status == AssessmentStatus.IMPROVEMENT
+    # Unpatched, added branching scores as an improvement here. _SIMPLE_FN
+    # already legitimately achieves SIMPLE on its own (a correctly-scored
+    # tiny function), so whether _BRANCHY_FN crosses a lattice tier
+    # (IMPROVEMENT) or stays within the same tier with a better score
+    # (IMPROVEMENT_SCORE) is incidental — either is a non-regression verdict.
+    assert r.status in {
+        AssessmentStatus.IMPROVEMENT,
+        AssessmentStatus.IMPROVEMENT_SCORE,
+    }
     assert r.regression_diff is None
     assert "## Regression diff" not in _content_text(tr)
 


### PR DESCRIPTION
## Summary
- `calculate_kolmogorov_proxy` (`src/probes_ast.rs`) computed a raw `zlib(source).len() / source.len()` ratio with zero size normalization. zlib's fixed per-stream overhead (header + Adler-32 trailer + minimum block cost) dominates the ratio on short inputs.
- Reported symptom: a 3-line array-lookup refactor of an 8-arm match scored *worse* (entropy 0.880, failing the `<=0.8` SIMPLE gate) than the verbose match it replaced (0.549, passing) — a textbook simplifying refactor flagged as a regression.
- Fix: below a 200-byte floor, blend the raw ratio proportionally toward the neutral `entropy_ideal` (0.5) instead of trusting it outright. At/above the floor, behavior is byte-for-byte unchanged (verified with a dedicated test).
- Two existing tests (`test_evaluate_lowest_hanging_fruit`, `test_assess_improvement_has_no_regression_diff`) had fixtures that unintentionally relied on the old tiny-input entropy bug to produce "hard failure" / lattice-tier-jump behavior; reworked both to fail/pass for legitimate structural reasons (repetitive boilerplate size padded above the floor, cyclomatic-complexity-driven near-miss, broadened accepted status set) so they're no longer coupled to this bug.

## Test plan
- [x] New Rust unit tests in `src/probes_ast.rs`: tiny-dense-function regression test (the issue's own array-lookup snippet), and a test confirming the blend is a no-op at/above the size floor.
- [x] New Python regression test in `tests/functors/probes/ast/test_ast_metrics.py` reproducing the issue's exact array-lookup vs. match snippets end-to-end through the SIMPLE gate band.
- [x] `cargo test` (24 passed) and full `pytest` (672 passed, 10 skipped) green; `ruff check --fix` / `ruff format` and `cargo fmt --check` clean.
- [x] Manually reproduced the exact issue snippet before/after the fix via `uv run maturin develop`.

Fixes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)