### PR TITLE
fix(composable): gate on Distance from Main Sequence, not raw instability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **COMPOSABLE no longer gates raw instability alone for languages with Abstractness support**: the `mdg.instability` gate (fixed `[0.3, 0.7]` band) flagged well-structured layered modules as failing — stable leaves (constants, error types, I≈0) and unstable orchestrators (`main.rs`/bootstrap wiring, I≈1) both got penalized even when architecturally intentional, because a raw-instability band ignores Robert Martin's own second axis. `Φ_COMPOSABLE` now pairs instability with a new `mdg.abstractness` metric (fraction of a module's type declarations that are abstract — trait/interface/protocol vs. concrete struct/class/enum) and gates on Distance from the Main Sequence (`mdg.main_sequence_distance = |A + I - 1|`, threshold `≤ 0.5`) instead, whenever abstractness is available. A concrete, unstable orchestrator now sits on the main sequence (D≈0) and is not penalized. Added a symmetric role-based exemption (`is_stable_leaf_module`: a declarations-only module with no branching control flow) for the "stable concrete leaf" case, which distance alone doesn't resolve — mirroring Martin's own accepted "Zone of Pain" exception. Scoped to Python, Rust, Go, and TypeScript files with countable type declarations; JavaScript and C++ (whose UAST mapper has an independent, pre-existing type-declaration bug) keep the original instability-band gate unchanged. `main_sequence_distance_max` (0.5) and `stable_leaf_instability_max` (0.05) are first-pass provisional thresholds, not yet run through the PyPI corpus ECDF calibration the other COMPOSABLE constants received. Closes [#124](https://github.com/Krv-Labs/topos/issues/124).
+
 ## [0.3.10] - 2026-07-11
 
 ### Added

--- a/docs/uast-industry-standards.md
+++ b/docs/uast-industry-standards.md
@@ -170,7 +170,19 @@ export interface MethodDeclNode extends UNodeBase {
 
 export interface TypeDeclNode extends UNodeBase {
   kind: "TypeDecl";
-  typeKind: "class" | "struct" | "enum" | "interface" | "typeAlias" | "union";
+  typeKind:
+    | "class"
+    | "struct"
+    | "enum"
+    | "interface"
+    | "typeAlias"
+    | "union"
+    | "trait"
+    | "abstractClass"
+    | "protocol";
+  // "trait" | "abstractClass" | "protocol" are abstract; the rest are
+  // concrete. Drives Martin's Abstractness metric (mdg.abstractness,
+  // topos/functors/probes/uast/abstractness.py) — see issue #124.
   name: IdentifierNode;
   members: UNode[];
   bases?: TypeRefNode[];

--- a/tests/evaluation/test_calibration.py
+++ b/tests/evaluation/test_calibration.py
@@ -172,3 +172,63 @@ def test_composable_high_instability_still_fails_without_entrypoint_flag():
         fan_out=2.0,
     )
     assert decision.achieved is False
+
+
+# ---------------------------------------------------------------------------
+# Distance-from-Main-Sequence gate (issue #124) — abstractness present
+# ---------------------------------------------------------------------------
+
+
+def test_composable_orchestrator_passes_via_distance_without_entrypoint_flag():
+    # I=1, A=0 (concrete, unstable orchestrator, e.g. main.rs) sits on the
+    # main sequence (D=0) — should pass without needing is_entrypoint_module.
+    decision = score_coupling(instability=1.0, abstractness=0.0, fan_in=0.0)
+    assert decision.achieved is True
+    assert "within tolerance" in decision.interpretation["mdg.main_sequence_distance"]
+    # Informational only — mdg.instability itself is not gated here, but is
+    # still surfaced so users see why a "too high" reading isn't a failure.
+    assert "too high" in decision.interpretation["mdg.instability"]
+
+
+def test_composable_stable_leaf_fails_distance_without_exemption():
+    # I=0, A=0 (concrete, stable leaf, e.g. constants.rs) is Martin's "Zone
+    # of Pain" — D=1, maximal distance — and fails without the leaf role.
+    decision = score_coupling(instability=0.0, abstractness=0.0)
+    assert decision.achieved is False
+
+
+def test_composable_stable_leaf_passes_with_exemption():
+    decision = score_coupling(
+        instability=0.0, abstractness=0.0, is_stable_leaf_module=True
+    )
+    assert decision.achieved is True
+    assert "tolerated" in decision.interpretation["mdg.main_sequence_distance"]
+
+
+def test_composable_tangled_module_still_fails_with_abstractness():
+    # I=0.9, A=0.9 -> D=0.8, well past the distance gate: neither role
+    # exemption applies, so this must still fail.
+    decision = score_coupling(instability=0.9, abstractness=0.9)
+    assert decision.achieved is False
+
+
+def test_composable_distance_boundary_uses_calibration():
+    max_d = COMPOSABLE.main_sequence_distance_max
+    # A + I - 1 = max_d exactly, at the boundary -> should pass (inclusive).
+    instability = 1.0
+    abstractness = max_d  # |A + I - 1| = |max_d + 1 - 1| = max_d
+    decision = score_coupling(instability=instability, abstractness=abstractness)
+    assert decision.achieved is True
+
+    # Just past the boundary -> should fail.
+    decision = score_coupling(instability=instability, abstractness=abstractness + 0.01)
+    assert decision.achieved is False
+
+
+def test_composable_without_abstractness_keeps_instability_gate_untouched():
+    # No abstractness supplied -> mdg.instability remains the gated metric,
+    # byte-identical to pre-issue-124 behavior (fallback path).
+    decision = score_coupling(instability=1.0, fan_in=0.0, fan_out=2.0)
+    assert decision.achieved is False
+    assert "mdg.main_sequence_distance" not in decision.interpretation
+    assert "mdg.instability" in decision.interpretation

--- a/tests/evaluation/test_file_roles.py
+++ b/tests/evaluation/test_file_roles.py
@@ -1,0 +1,46 @@
+"""Tests for topos.evaluation.file_roles, notably the new
+`is_stable_leaf_module` predicate (issue #124)."""
+
+from __future__ import annotations
+
+from topos.core.morphism import ProgramMorphism
+from topos.evaluation.file_roles import is_stable_leaf_module
+
+
+def test_declarations_only_module_is_stable_leaf():
+    morphism = ProgramMorphism(
+        source="pub const X: i32 = 5;\npub const Y: i32 = 10;\n",
+        language="rust",
+    )
+    assert is_stable_leaf_module(morphism) is True
+
+
+def test_module_with_branching_control_flow_is_not_stable_leaf():
+    morphism = ProgramMorphism(
+        source="fn f(x: i32) -> i32 { if x > 0 { x } else { -x } }",
+        language="rust",
+    )
+    assert is_stable_leaf_module(morphism) is False
+
+
+def test_trivial_return_only_function_is_still_stable_leaf():
+    # CallExpr/ReturnStmt are deliberately excluded from the disqualifying
+    # set — a trivial accessor shouldn't disqualify an otherwise frozen
+    # leaf module.
+    morphism = ProgramMorphism(
+        source="def get_x():\n    return compute_default()\n",
+        language="python",
+    )
+    assert is_stable_leaf_module(morphism) is True
+
+
+def test_module_with_loop_is_not_stable_leaf():
+    source = (
+        "def f(xs):\n"
+        "    total = 0\n"
+        "    for x in xs:\n"
+        "        total += x\n"
+        "    return total\n"
+    )
+    morphism = ProgramMorphism(source=source, language="python")
+    assert is_stable_leaf_module(morphism) is False

--- a/tests/evaluation/test_gate_parity.py
+++ b/tests/evaluation/test_gate_parity.py
@@ -772,6 +772,79 @@ CASES = [
         False,
         {"mdg.fan_out": "fan-out (16) exceeds threshold (> 15.0)"},
     ),
+    # --- Distance-from-Main-Sequence (issue #124) — abstractness present,
+    # straddling main_sequence_distance_max=0.5 and
+    # stable_leaf_instability_max=0.05 ---
+    (
+        "composable",
+        {"instability": 1.0, "abstractness": 0.0},
+        1.0,
+        True,
+        {
+            "mdg.main_sequence_distance": "main-sequence distance (0.00) within tolerance (<= 0.5) — instability and abstractness are balanced",
+            "mdg.instability": "instability (1.00) is too high (module depends on too many things)",
+        },
+    ),
+    (
+        "composable",
+        {"instability": 1.0, "abstractness": 0.49},
+        0.020000000000000018,
+        True,
+        {
+            "mdg.main_sequence_distance": "main-sequence distance (0.49) within tolerance (<= 0.5) — instability and abstractness are balanced",
+            "mdg.instability": "instability (1.00) is too high (module depends on too many things)",
+        },
+    ),
+    (
+        "composable",
+        {"instability": 1.0, "abstractness": 0.5},
+        0.0,
+        True,
+        {
+            "mdg.main_sequence_distance": "main-sequence distance (0.50) within tolerance (<= 0.5) — instability and abstractness are balanced",
+            "mdg.instability": "instability (1.00) is too high (module depends on too many things)",
+        },
+    ),
+    (
+        "composable",
+        {"instability": 1.0, "abstractness": 0.51},
+        0.0,
+        False,
+        {
+            "mdg.main_sequence_distance": "main-sequence distance (0.51) exceeds threshold (> 0.5) — module is too concrete-and-stable (rigid) or too abstract-and-unstable (speculative) for its role",
+            "mdg.instability": "instability (1.00) is too high (module depends on too many things)",
+        },
+    ),
+    (
+        "composable",
+        {"instability": 0.05, "abstractness": 0.0, "is_stable_leaf_module": True},
+        0.0,
+        True,
+        {
+            "mdg.main_sequence_distance": "main-sequence distance (0.95) is high, but tolerated for frozen, declarations-only leaf modules",
+            "mdg.instability": "instability (0.05) is too low (module is too stable)",
+        },
+    ),
+    (
+        "composable",
+        {"instability": 0.05, "abstractness": 0.0, "is_stable_leaf_module": False},
+        0.0,
+        False,
+        {
+            "mdg.main_sequence_distance": "main-sequence distance (0.95) exceeds threshold (> 0.5) — module is too concrete-and-stable (rigid) or too abstract-and-unstable (speculative) for its role",
+            "mdg.instability": "instability (0.05) is too low (module is too stable)",
+        },
+    ),
+    (
+        "composable",
+        {"instability": 0.051, "abstractness": 0.0, "is_stable_leaf_module": True},
+        0.0,
+        False,
+        {
+            "mdg.main_sequence_distance": "main-sequence distance (0.95) exceeds threshold (> 0.5) — module is too concrete-and-stable (rigid) or too abstract-and-unstable (speculative) for its role",
+            "mdg.instability": "instability (0.05) is too low (module is too stable)",
+        },
+    ),
     (
         "secure",
         {"dangerous_calls": 0.0},

--- a/tests/graphs/uast/test_abstractness.py
+++ b/tests/graphs/uast/test_abstractness.py
@@ -1,0 +1,133 @@
+"""Tests for Martin's Abstractness metric (issue #124): per-language
+`typeKind` extraction in the UAST mappers, and `calculate_abstractness`
+aggregation over a parsed tree.
+"""
+
+from __future__ import annotations
+
+from topos.functors.probes.uast.abstractness import calculate_abstractness
+from topos.graphs.uast.mapper_go import map_go_tree_to_uast
+from topos.graphs.uast.mapper_python import map_python_tree_to_uast
+from topos.graphs.uast.mapper_rust import map_rust_tree_to_uast
+from topos.graphs.uast.mapper_typescript import map_typescript_tree_to_uast
+from topos.utils.tree_sitter import (
+    parse_go,
+    parse_python,
+    parse_rust,
+    parse_typescript,
+)
+
+
+def _type_kinds(root) -> list[str]:
+    kinds: list[str] = []
+
+    def walk(node):
+        tk = node.attributes.get("typeKind")
+        if tk is not None:
+            kinds.append(tk)
+        for child in node.children:
+            walk(child)
+
+    walk(root)
+    return kinds
+
+
+def test_rust_trait_is_abstract_struct_enum_are_concrete():
+    src = """
+trait Shape { fn area(&self) -> f64; }
+struct Circle { r: f64 }
+enum Color { Red, Blue }
+impl Shape for Circle { fn area(&self) -> f64 { 1.0 } }
+"""
+    root = map_rust_tree_to_uast(parse_rust(src))
+    assert sorted(_type_kinds(root)) == ["enum", "struct", "trait"]
+    assert calculate_abstractness(root) == 1 / 3
+
+
+def test_rust_impl_block_not_double_counted():
+    # A trait + its impl for one struct should count exactly 2 TypeDecls
+    # (trait, struct), not 3 — impl_item is not a type declaration.
+    src = """
+trait Shape { fn area(&self) -> f64; }
+struct Circle { r: f64 }
+impl Shape for Circle { fn area(&self) -> f64 { 1.0 } }
+"""
+    root = map_rust_tree_to_uast(parse_rust(src))
+    assert len(_type_kinds(root)) == 2
+
+
+def test_rust_orchestrator_with_no_types_is_fully_concrete():
+    src = "fn main() { let x = foo(); bar(x); }"
+    root = map_rust_tree_to_uast(parse_rust(src))
+    assert _type_kinds(root) == []
+    assert calculate_abstractness(root) == 0.0
+
+
+def test_python_abc_and_protocol_are_abstract():
+    src = """
+import abc
+from abc import ABC
+from typing import Protocol
+
+class Shape(ABC):
+    @abc.abstractmethod
+    def area(self): ...
+
+class Circle(Shape):
+    def area(self): return 1.0
+
+class Reader(Protocol):
+    def read(self) -> str: ...
+
+class Plain:
+    x: int = 1
+"""
+    root = map_python_tree_to_uast(parse_python(src))
+    kinds = _type_kinds(root)
+    assert kinds.count("abstractClass") == 2  # Shape, Reader
+    assert kinds.count("class") == 2  # Circle, Plain
+    assert calculate_abstractness(root) == 0.5
+
+
+def test_python_subclass_of_abstract_is_still_concrete():
+    # Concrete-ness is per-declaration, not inherited: Circle subclasses an
+    # ABC but has no abstract markers of its own.
+    src = """
+from abc import ABC
+class Shape(ABC):
+    pass
+class Circle(Shape):
+    pass
+"""
+    root = map_python_tree_to_uast(parse_python(src))
+    kinds = _type_kinds(root)
+    assert kinds == ["abstractClass", "class"]
+
+
+def test_go_interface_is_abstract_struct_is_concrete():
+    src = """
+package main
+type Shape interface { Area() float64 }
+type Circle struct { R float64 }
+type Alias = int
+"""
+    root = map_go_tree_to_uast(parse_go(src))
+    kinds = _type_kinds(root)
+    assert kinds == ["interface", "struct"]  # Alias -> no typeKind, excluded
+    assert calculate_abstractness(root) == 0.5
+
+
+def test_typescript_interface_and_abstract_class_are_abstract():
+    src = """
+interface Shape { area(): number }
+abstract class Base { abstract area(): number }
+class Circle implements Shape { area() { return 1.0 } }
+enum Color { Red, Blue }
+"""
+    root = map_typescript_tree_to_uast(parse_typescript(src))
+    kinds = _type_kinds(root)
+    assert kinds.count("interface") == 1
+    assert kinds.count("abstractClass") == 1
+    assert kinds.count("class") == 1
+    assert kinds.count("enum") == 1
+    assert calculate_abstractness(root) == 0.5

--- a/topos/core/morphism.py
+++ b/topos/core/morphism.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
     from topos.graphs.cfg.object import ControlFlowGraph
     from topos.graphs.cpg.object import CodePropertyGraph
     from topos.graphs.pdg.object import ProgramDependenceGraph
+    from topos.graphs.uast.object import AbstractnessRepresentation
 
 
 @dataclass
@@ -69,6 +70,9 @@ class ProgramMorphism:
     _cfg: ControlFlowGraph | None = field(default=None, repr=False, compare=False)
     _pdg: ProgramDependenceGraph | None = field(default=None, repr=False, compare=False)
     _cpg: CodePropertyGraph | None = field(default=None, repr=False, compare=False)
+    _abstractness: AbstractnessRepresentation | None = field(
+        default=None, repr=False, compare=False
+    )
 
     def __post_init__(self) -> None:
         """Parse the source code into an AST if not provided."""
@@ -174,6 +178,17 @@ class ProgramMorphism:
 
         self._cpg = CodePropertyGraph.from_uast(self.ast.uast_root, source=self.source)
         return self._cpg
+
+    def build_abstractness(self) -> AbstractnessRepresentation | None:
+        """Build (and cache) the Abstractness representation."""
+        if self._abstractness is not None:
+            return self._abstractness
+        if self.ast is None or self.ast.uast_root is None:
+            return None
+        from topos.graphs.uast.object import AbstractnessRepresentation
+
+        self._abstractness = AbstractnessRepresentation(uast_root=self.ast.uast_root)
+        return self._abstractness
 
     @property
     def name(self) -> str:

--- a/topos/evaluation/characteristic_morphism.py
+++ b/topos/evaluation/characteristic_morphism.py
@@ -49,7 +49,7 @@ from topos.core.omega import (
     Omega,
     verdict_from_generators,
 )
-from topos.evaluation.file_roles import is_entrypoint_module
+from topos.evaluation.file_roles import is_entrypoint_module, is_stable_leaf_module
 from topos.evaluation.policies import (
     Priority,
     ScoredDecision,
@@ -75,6 +75,7 @@ def _score_simple_dim(
     raw: dict[str, float],
     priority: Priority,
     is_entrypoint_module: bool = False,
+    is_stable_leaf_module: bool = False,  # noqa: ARG001 — uniform dispatcher signature
 ) -> ScoredDecision | None:
     # The SIMPLE dimension is fed by both CFG (cyclomatic) and AST (entropy, max_func).
     # We pass all available metrics to score_simple; it handles the independent
@@ -99,6 +100,7 @@ def _score_composable_dim(
     raw: dict[str, float],
     priority: Priority,
     is_entrypoint_module: bool = False,
+    is_stable_leaf_module: bool = False,
 ) -> ScoredDecision | None:
     if (
         "mdg.instability" not in raw
@@ -110,7 +112,9 @@ def _score_composable_dim(
         instability=raw.get("mdg.instability"),
         fan_in=raw.get("mdg.fan_in"),
         fan_out=raw.get("mdg.fan_out"),
+        abstractness=raw.get("mdg.abstractness"),
         is_entrypoint_module=is_entrypoint_module,
+        is_stable_leaf_module=is_stable_leaf_module,
         priority=priority,
     )
 
@@ -119,6 +123,7 @@ def _score_secure_dim(
     raw: dict[str, float],
     priority: Priority,
     is_entrypoint_module: bool = False,
+    is_stable_leaf_module: bool = False,  # noqa: ARG001 — uniform dispatcher signature
 ) -> ScoredDecision | None:
     if "cpg.dangerous_calls" not in raw and "cpg.taint_flows" not in raw:
         return None
@@ -131,7 +136,7 @@ def _score_secure_dim(
 
 _DIMENSION_SCORE_DISPATCHERS: dict[
     str,
-    Callable[[dict[str, float], Priority, bool], ScoredDecision | None],
+    Callable[[dict[str, float], Priority, bool, bool], ScoredDecision | None],
 ] = {
     "simple": _score_simple_dim,
     "composable": _score_composable_dim,
@@ -265,6 +270,7 @@ class CharacteristicMorphism:
         for rep in all_reps:
             by_dimension[rep.dimension].append(rep)
         is_entrypoint = is_entrypoint_module(morphism)
+        is_stable_leaf = is_stable_leaf_module(morphism)
 
         raw_metrics: dict[str, float] = {}
         interpretation: dict[str, str] = {}
@@ -281,7 +287,7 @@ class CharacteristicMorphism:
             if not scorer:
                 continue
 
-            decision = scorer(dim_raw, priority, is_entrypoint)
+            decision = scorer(dim_raw, priority, is_entrypoint, is_stable_leaf)
             if decision is None:
                 continue
 

--- a/topos/evaluation/file_roles.py
+++ b/topos/evaluation/file_roles.py
@@ -32,6 +32,28 @@ def is_entrypoint_module(morphism: ProgramMorphism) -> bool:
     return _is_entrypoint_source_only(morphism.source, morphism.language)
 
 
+def is_stable_leaf_module(morphism: ProgramMorphism) -> bool:
+    """True iff *morphism* is a declarations-only module with no branching
+    control flow — Martin's accepted "Zone of Pain" exception for frozen,
+    rarely-changing foundation/utility code (constants, error types).
+
+    Deliberately filename-agnostic (unlike :func:`is_entrypoint_module`):
+    the whole point of pairing Abstractness with Instability is to avoid
+    per-language filename lists, and that principle extends here where
+    possible. ``CallExpr``/``ReturnStmt`` are excluded from the
+    disqualifying set on purpose — a ``constants.py`` computing a default
+    via a function call, or a trivial ``def get_x(): return X``, should
+    still qualify.
+    """
+    if morphism.ast is None or morphism.ast.uast_root is None:
+        return False
+    from topos.functors.probes.uast.signature import control_flow_profile
+
+    profile = control_flow_profile(morphism.ast.uast_root)
+    branching_kinds = ("IfStmt", "ForStmt", "WhileStmt", "MatchStmt", "TryStmt")
+    return all(profile.get(kind, 0) == 0 for kind in branching_kinds)
+
+
 def _entrypoint_filename_hint(path: Path, language: str) -> bool:
     filename = path.name
     lower_name = filename.lower()

--- a/topos/evaluation/policies/calibration.py
+++ b/topos/evaluation/policies/calibration.py
@@ -60,6 +60,20 @@ class ComposablePolicyThresholds:
     # Entrypoint carve-out: import/export-only entrypoint modules with zero
     # fan-in may sit at or above this instability without failing the gate.
     entrypoint_instability_min: float = 0.95
+    # Distance from Martin's Main Sequence (D = |A + I - 1|), gated in place
+    # of raw instability whenever Abstractness (mdg.abstractness) is
+    # available — see topos.evaluation.policies.composable.score_coupling
+    # and issue #124. PROVISIONAL: a first-pass estimate (roughly Martin's
+    # commonly-cited "principal zone" radius), not yet run through the PyPI
+    # corpus ECDF calibration the other constants in this class received.
+    main_sequence_distance_max: float = 0.5
+    # Zone-of-Pain carve-out: a declarations-only, no-branching "stable
+    # leaf" module (constants, error types — see
+    # topos.evaluation.file_roles.is_stable_leaf_module) may sit at or
+    # below this instability without failing the gate, mirroring
+    # entrypoint_instability_min for the low-instability extreme. Also
+    # PROVISIONAL.
+    stable_leaf_instability_max: float = 0.05
     # Normalization (score only)
     max_fan_in_cap: float = 40.0
     max_fan_out_cap: float = 40.0

--- a/topos/evaluation/policies/composable.py
+++ b/topos/evaluation/policies/composable.py
@@ -3,9 +3,10 @@
 --------------------------------------------------------------
 
 Maps ModuleDependencyGraph metric observations (Martin instability,
-fan-in, fan-out) into a :class:`~topos.evaluation.policies.base.ScoredDecision`.
-``achieved`` is the AND of independent raw thresholds on each metric;
-``score`` is ``min(per-metric qualities)`` for reporting only.
+fan-in, fan-out) plus Abstractness (mdg.abstractness, when available) into
+a :class:`~topos.evaluation.policies.base.ScoredDecision`. ``achieved`` is
+the AND of independent raw thresholds on each metric; ``score`` is
+``min(per-metric qualities)`` for reporting only.
 
 Quality functions:
     instability_quality = piecewise flat-top tent over [low, high]:
@@ -16,10 +17,29 @@ Quality functions:
     fan_quality         = 1 - min(fan / cap, 1.0)
                           Linear fall from 1.0 to 0.0 at the cap.
 
-The COMPOSABLE badge is achieved if all three metrics pass their
+The COMPOSABLE badge is achieved if all present metrics pass their
 independent thresholds (AND logic). Gate comparisons and interpretation
 prose live in :mod:`topos.evaluation.policies.gates`; thresholds in
 :mod:`topos.evaluation.policies.calibration`.
+
+Distance from the Main Sequence (issue #124)
+---------------------------------------------
+Gating raw instability against a fixed band conflates two independent
+concerns Robert Martin's own metric family keeps separate: how unstable a
+module is (I), and how abstract it is (A). A concrete, unstable
+orchestrator (main.rs: I≈1, A≈0) is *architecturally expected* — it sits
+exactly on Martin's "Main Sequence" (A + I = 1) — but a raw-instability
+band flags it anyway.
+
+When ``abstractness`` is supplied, this scorer gates on
+``mdg.main_sequence_distance = |A + I - 1|`` **instead of** raw
+``mdg.instability`` (conditional replacement, not an additional stacked
+gate — stacking would resurrect the false positive, since the old band
+would still fail the orchestrator even though D says it's fine). Files/
+languages without Abstractness data (``abstractness is None``) keep
+gating on ``mdg.instability`` exactly as before — this is what makes the
+change non-flag-day: it only changes behavior for files where Abstractness
+is actually measured.
 """
 
 from __future__ import annotations
@@ -29,17 +49,19 @@ from topos.evaluation.policies.base import (
     ScoredDecision,
 )
 from topos.evaluation.policies.calibration import COMPOSABLE
-from topos.evaluation.policies.gates import evaluate_gates
+from topos.evaluation.policies.gates import evaluate_gates, interpret_metric
 
 
 def score_coupling(
     instability: float | None = None,
     fan_in: float | None = None,
     fan_out: float | None = None,
+    abstractness: float | None = None,
     priority: Priority = Priority.SECURE,
     threshold: float | None = None,
     *,
     is_entrypoint_module: bool = False,
+    is_stable_leaf_module: bool = False,
 ) -> ScoredDecision:
     """
     Φ_COMPOSABLE — score the COMPOSABLE generator using independent raw thresholds.
@@ -48,26 +70,43 @@ def score_coupling(
         instability: Martin's instability metric, in [0.0, 1.0].
         fan_in:      Number of unique modules that depend on this module.
         fan_out:     Number of unique modules this module depends on.
+        abstractness: Martin's abstractness metric, in [0.0, 1.0]. When
+            provided (alongside ``instability``), gates on distance from
+            the main sequence instead of raw instability — see module
+            docstring.
         priority:    Retained for API compatibility; not read by this Φᵢ.
         threshold:   Retained for API compatibility; not read by this Φᵢ.
-        is_entrypoint_module: When True, tolerate high instability for
-            import/export-only entrypoint modules with zero fan-in.
+        is_entrypoint_module: When True, tolerate high instability (or high
+            main-sequence distance) for import/export-only entrypoint
+            modules with zero fan-in.
+        is_stable_leaf_module: When True, tolerate maximal main-sequence
+            distance for frozen, declarations-only leaf modules (Martin's
+            "Zone of Pain" exception).
 
     Returns:
         A ScoredDecision; ``achieved`` is the truth value of the COMPOSABLE
         generator for this program.
     """
+    use_distance = instability is not None and abstractness is not None
     metrics = {
         key: value
         for key, value in {
-            "mdg.instability": instability,
+            "mdg.instability": None if use_distance else instability,
+            "mdg.abstractness": abstractness if use_distance else None,
+            "mdg.main_sequence_distance": (
+                abs(abstractness + instability - 1.0) if use_distance else None
+            ),
             "mdg.fan_in": fan_in,
             "mdg.fan_out": fan_out,
         }.items()
         if value is not None
     }
     results = evaluate_gates(
-        metrics, pillar="composable", is_entrypoint_module=is_entrypoint_module
+        metrics,
+        pillar="composable",
+        is_entrypoint_module=is_entrypoint_module,
+        is_stable_leaf_module=is_stable_leaf_module,
+        instability=instability,
     )
     if not results:
         # If no metrics are provided, we vacuously satisfy COMPOSABLE.
@@ -76,12 +115,22 @@ def score_coupling(
     # Score shaping (reporting only): quality curves stay local to Φ_COMPOSABLE.
     qualities = [_quality(r.spec.metric, r.value) for r in results]
 
+    interpretation = {r.spec.metric: r.interpretation for r in results}
+    if use_distance:
+        # `mdg.instability` is deliberately not gated when distance is
+        # active, but users should still see why a high/low instability
+        # reading isn't itself a failure — surface it as an informational
+        # (non-gating) line alongside the distance verdict.
+        interpretation["mdg.instability"] = interpret_metric(
+            "mdg.instability", instability
+        )
+
     return ScoredDecision(
         # The combined score is the minimum of the individual qualities
         # (conservative AND).
         score=min(qualities),
         achieved=all(r.passed for r in results),
-        interpretation={r.spec.metric: r.interpretation for r in results},
+        interpretation=interpretation,
     )
 
 
@@ -94,6 +143,8 @@ def _quality(metric: str, value: float) -> float:
     """Normalize one raw metric to a [0, 1] quality (never gates achieved)."""
     if metric == "mdg.instability":
         return _instability_tent(value)
+    if metric == "mdg.main_sequence_distance":
+        return _distance_quality(value)
     cap = (
         COMPOSABLE.max_fan_in_cap
         if metric == "mdg.fan_in"
@@ -116,3 +167,8 @@ def _instability_tent(instability: float) -> float:
         return instability / low
     # instability > high
     return max(0.0, (1.0 - instability) / (1.0 - high))
+
+
+def _distance_quality(distance: float) -> float:
+    """Linear fall from 1.0 (on the main sequence) to 0.0 at the cap."""
+    return 1.0 - min(distance / COMPOSABLE.main_sequence_distance_max, 1.0)

--- a/topos/evaluation/policies/gates.py
+++ b/topos/evaluation/policies/gates.py
@@ -44,6 +44,14 @@ class GateContext:
     value: float
     metrics: Mapping[str, float]
     is_entrypoint_module: bool
+    is_stable_leaf_module: bool = False
+    # Raw Martin instability, threaded separately from `metrics` because
+    # `mdg.instability` is deliberately absent from the gated metrics dict
+    # whenever `mdg.main_sequence_distance` is active (see
+    # topos.evaluation.policies.composable.score_coupling) — re-adding it
+    # under its own key would re-trigger the (now-superseded)
+    # `mdg.instability` GateSpec for the same file.
+    instability: float | None = None
 
 
 @dataclass(frozen=True)
@@ -121,6 +129,19 @@ def _instability_entrypoint_exempt(ctx: GateContext) -> bool:
     )
 
 
+def _distance_stable_leaf_exempt(ctx: GateContext) -> bool:
+    """Frozen, declarations-only leaf modules may sit at maximal distance
+    from the main sequence — Martin's accepted "Zone of Pain" exception for
+    foundation/utility code (constants, error types) that is stable *and*
+    concrete by design, not because it's poorly layered.
+    """
+    return (
+        ctx.is_stable_leaf_module
+        and ctx.instability is not None
+        and ctx.instability <= COMPOSABLE.stable_leaf_instability_max
+    )
+
+
 # ---------------------------------------------------------------------------
 # Interpretation renderers (canonical prose, byte-identical to the legacy
 # per-scorer helpers)
@@ -179,6 +200,25 @@ def _interpret_instability(value: float, outcome: GateOutcome) -> str:
             "import/export-only entrypoint modules"
         )
     return f"instability ({value:.2f}) is too high (module depends on too many things)"
+
+
+def _interpret_main_sequence_distance(value: float, outcome: GateOutcome) -> str:
+    max_d = COMPOSABLE.main_sequence_distance_max
+    if outcome is GateOutcome.PASS:
+        return (
+            f"main-sequence distance ({value:.2f}) within tolerance "
+            f"(<= {max_d}) — instability and abstractness are balanced"
+        )
+    if outcome is GateOutcome.EXEMPT_HIGH:
+        return (
+            f"main-sequence distance ({value:.2f}) is high, but tolerated "
+            "for frozen, declarations-only leaf modules"
+        )
+    return (
+        f"main-sequence distance ({value:.2f}) exceeds threshold (> {max_d}) "
+        "— module is too concrete-and-stable (rigid) or too abstract-and-"
+        "unstable (speculative) for its role"
+    )
 
 
 def _interpret_fan_in(value: float, outcome: GateOutcome) -> str:
@@ -259,6 +299,16 @@ GATE_SPECS: tuple[GateSpec, ...] = (
         operations_high=("rebalance_dependencies", "extract_boundary"),
     ),
     GateSpec(
+        metric="mdg.main_sequence_distance",
+        pillar="composable",
+        low=None,
+        high=COMPOSABLE.main_sequence_distance_max,
+        granularity="module",
+        interpret=_interpret_main_sequence_distance,
+        exempt=_distance_stable_leaf_exempt,
+        operations_high=("rebalance_dependencies", "extract_boundary"),
+    ),
+    GateSpec(
         metric="mdg.fan_in",
         pillar="composable",
         low=None,
@@ -317,6 +367,8 @@ def evaluate_gates(
     *,
     pillar: str | None = None,
     is_entrypoint_module: bool = False,
+    is_stable_leaf_module: bool = False,
+    instability: float | None = None,
 ) -> list[GateResult]:
     """Apply every (optionally pillar-filtered) spec whose metric is present."""
     results: list[GateResult] = []
@@ -330,7 +382,14 @@ def evaluate_gates(
             GateResult(
                 spec=spec,
                 value=value,
-                outcome=_classify(spec, value, metrics, is_entrypoint_module),
+                outcome=_classify(
+                    spec,
+                    value,
+                    metrics,
+                    is_entrypoint_module,
+                    is_stable_leaf_module,
+                    instability,
+                ),
             )
         )
     return results
@@ -339,7 +398,7 @@ def evaluate_gates(
 def interpret_metric(metric: str, value: float) -> str:
     """Canonical prose for a single metric value (no exemption context)."""
     spec = GATES_BY_METRIC[metric]
-    return spec.interpret(value, _classify(spec, value, {}, False))
+    return spec.interpret(value, _classify(spec, value, {}, False, False, None))
 
 
 def _classify(
@@ -347,6 +406,8 @@ def _classify(
     value: float,
     metrics: Mapping[str, float],
     is_entrypoint_module: bool,
+    is_stable_leaf_module: bool = False,
+    instability: float | None = None,
 ) -> GateOutcome:
     if spec.low is not None and value < spec.low:
         fail, exempt = GateOutcome.FAIL_LOW, GateOutcome.EXEMPT_LOW
@@ -354,7 +415,9 @@ def _classify(
         fail, exempt = GateOutcome.FAIL_HIGH, GateOutcome.EXEMPT_HIGH
     else:
         return GateOutcome.PASS
-    ctx = GateContext(value, metrics, is_entrypoint_module)
+    ctx = GateContext(
+        value, metrics, is_entrypoint_module, is_stable_leaf_module, instability
+    )
     if spec.exempt is not None and spec.exempt(ctx):
         return exempt
     return fail

--- a/topos/functors/probes/uast/__init__.py
+++ b/topos/functors/probes/uast/__init__.py
@@ -6,6 +6,7 @@ live in :mod:`topos.functors.profunctors.uast`; this package holds only
 the per-program probes ``P : E → ℝ`` that those profunctors compose.
 """
 
+from topos.functors.probes.uast.abstractness import calculate_abstractness
 from topos.functors.probes.uast.signature import (
     CONTROL_FLOW_KINDS,
     StructuralSummary,
@@ -18,6 +19,7 @@ from topos.functors.probes.uast.signature import (
 __all__ = [
     "CONTROL_FLOW_KINDS",
     "StructuralSummary",
+    "calculate_abstractness",
     "control_flow_profile",
     "structural_summary",
     "uast_dfs_kind_sequence",

--- a/topos/functors/probes/uast/abstractness.py
+++ b/topos/functors/probes/uast/abstractness.py
@@ -1,0 +1,64 @@
+"""
+UAST Abstractness Probe
+------------------------
+Martin's Abstractness (A): the fraction of a module's type declarations
+that are abstract (trait / interface / protocol / abstract class) rather
+than concrete (struct / class / enum / union / type alias).
+
+Paired with Instability (``mdg.instability``), this drives the Distance
+from the Main Sequence gate (``mdg.main_sequence_distance``,
+:mod:`topos.evaluation.policies.composable`) instead of gating raw
+instability against a fixed band — see issue #124.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+_ABSTRACT_TYPE_KINDS = frozenset({"trait", "interface", "abstractClass", "protocol"})
+_CONCRETE_TYPE_KINDS = frozenset({"class", "struct", "enum", "union", "typeAlias"})
+
+
+def _walk(root) -> Iterable[object]:
+    yield root
+    for child in getattr(root, "children", []):
+        yield from _walk(child)
+
+
+def calculate_abstractness(root) -> float:
+    """
+    Fraction of classifiable ``TypeDecl`` nodes in *root* that are abstract.
+
+    Args:
+        root: A UAST root node (duck-typed: exposes ``kind``, ``children``,
+            ``attributes``).
+
+    Returns:
+        ``abstract_count / (abstract_count + concrete_count)``, or ``0.0``
+        when the module declares zero classifiable type declarations. This
+        is a real, meaningful value — a functions-only module (e.g. a
+        typical ``main.rs`` orchestrator with no struct/trait/enum) is
+        legitimately 0% abstract, not "undefined." Whether Abstractness is
+        *applicable at all* for a given file is a language-support
+        question, decided by the caller
+        (:class:`~topos.graphs.uast.object.AbstractnessRepresentation`),
+        not by this function. ``TypeDecl`` nodes with no recognized
+        ``typeKind`` attribute (e.g. Rust ``impl_item`` blocks, Go type
+        aliases to primitives) are excluded from both the numerator and
+        the denominator.
+    """
+    abstract_count = 0
+    concrete_count = 0
+    for node in _walk(root):
+        if getattr(node, "kind", None) != "TypeDecl":
+            continue
+        type_kind = getattr(node, "attributes", {}).get("typeKind")
+        if type_kind in _ABSTRACT_TYPE_KINDS:
+            abstract_count += 1
+        elif type_kind in _CONCRETE_TYPE_KINDS:
+            concrete_count += 1
+
+    total = abstract_count + concrete_count
+    if total == 0:
+        return 0.0
+    return abstract_count / total

--- a/topos/graphs/uast/mapper_common.py
+++ b/topos/graphs/uast/mapper_common.py
@@ -76,6 +76,7 @@ def map_tree_sitter_to_uast(
     language: str,
     map_node_kind: Callable[[Node], str],
     file: str | None = None,
+    extract_attributes: Callable[[Node], dict[str, object]] | None = None,
 ) -> UASTNode:
     parser_name, parser_version = parser_identity(language)
 
@@ -155,12 +156,15 @@ def map_tree_sitter_to_uast(
             parser_version=parser_version,
             node_kind=node.type,
         )
+        attributes: dict[str, object] = {"named": node.is_named}
+        if extract_attributes is not None:
+            attributes.update(extract_attributes(node) or {})
         uast_nodes[node.id] = UASTNode(
             kind=map_node_kind(node),
             lang=language,
             span=span,
             native=native,
-            attributes={"named": node.is_named},
+            attributes=attributes,
             children=children,
             id=node_stable_id,
         )

--- a/topos/graphs/uast/mapper_go.py
+++ b/topos/graphs/uast/mapper_go.py
@@ -61,6 +61,29 @@ _IDENTIFIER_TYPES = {
 }
 
 
+_TYPE_SPEC_KIND = {
+    "interface_type": "interface",
+    "struct_type": "struct",
+}
+
+
+def extract_type_attributes(node: Node) -> dict[str, object]:
+    """Classify a `type_declaration` as interface/struct via its `type_spec`
+    grandchild — the discriminating grammar node lives one level below the
+    `TypeDecl`-mapped node itself (Go wraps every type declaration, whether
+    interface, struct, or alias, in the same outer `type_declaration`)."""
+    if node.type != "type_declaration":
+        return {}
+    for child in node.named_children:
+        if child.type != "type_spec":
+            continue
+        for grandchild in child.named_children:
+            type_kind = _TYPE_SPEC_KIND.get(grandchild.type)
+            if type_kind is not None:
+                return {"typeKind": type_kind}
+    return {}
+
+
 def map_node_kind(node: Node) -> str:
     if node.type in _DECLARATION_TYPES:
         return _DECLARATION_TYPES[node.type]
@@ -83,4 +106,5 @@ def map_go_tree_to_uast(root: Node, file: str | None = None) -> UASTNode:
         language="go",
         map_node_kind=map_node_kind,
         file=file,
+        extract_attributes=extract_type_attributes,
     )

--- a/topos/graphs/uast/mapper_javascript.py
+++ b/topos/graphs/uast/mapper_javascript.py
@@ -65,6 +65,14 @@ def map_node_kind(node: Node) -> str:
 
 
 def map_javascript_tree_to_uast(root: Node, file: str | None = None) -> UASTNode:
+    # Deliberately no `extract_attributes`/`typeKind` hook here, unlike the
+    # Rust/Python/Go/TypeScript mappers: plain JS has no `interface` or
+    # `abstract class` syntax at all (that's a TypeScript-only extension of
+    # this shared grammar — see mapper_typescript.py), so there's nothing
+    # in a .js file's grammar to ever classify as abstract vs. concrete.
+    # Martin's Abstractness metric (mdg.abstractness, issue #124) is
+    # therefore not meaningful for JavaScript; see the language allowlist
+    # in topos/graphs/uast/object.py.
     return map_tree_sitter_to_uast(
         root=root,
         language="javascript",

--- a/topos/graphs/uast/mapper_python.py
+++ b/topos/graphs/uast/mapper_python.py
@@ -44,6 +44,42 @@ _EXPRESSION_TYPES = {
 }
 
 
+# First-pass, name-based Abstractness heuristic — no import-alias resolution,
+# so `from foo import ABC as Base` won't be recognized. Good enough for the
+# overwhelmingly common `abc.ABC` / `typing.Protocol` spellings.
+_ABSTRACT_BASE_MARKERS = (b"ABC", b"Protocol", b"ABCMeta")
+
+
+def _has_abstract_base(node: Node) -> bool:
+    superclasses = node.child_by_field_name("superclasses")
+    if superclasses is None:
+        return False
+    text = superclasses.text or b""
+    return any(marker in text for marker in _ABSTRACT_BASE_MARKERS)
+
+
+def _has_abstractmethod(node: Node) -> bool:
+    body = node.child_by_field_name("body")
+    if body is None:
+        return False
+    for child in body.named_children:
+        if child.type != "decorated_definition":
+            continue
+        for grandchild in child.named_children:
+            if grandchild.type == "decorator" and b"abstractmethod" in (
+                grandchild.text or b""
+            ):
+                return True
+    return False
+
+
+def extract_type_attributes(node: Node) -> dict[str, object]:
+    if node.type != "class_definition":
+        return {}
+    is_abstract = _has_abstract_base(node) or _has_abstractmethod(node)
+    return {"typeKind": "abstractClass" if is_abstract else "class"}
+
+
 def map_node_kind(node: Node) -> str:
     if node.type in _DECLARATION_TYPES:
         return _DECLARATION_TYPES[node.type]
@@ -66,4 +102,5 @@ def map_python_tree_to_uast(root: Node, file: str | None = None) -> UASTNode:
         language="python",
         map_node_kind=map_node_kind,
         file=file,
+        extract_attributes=extract_type_attributes,
     )

--- a/topos/graphs/uast/mapper_rust.py
+++ b/topos/graphs/uast/mapper_rust.py
@@ -11,10 +11,20 @@ _DECLARATION_TYPES = {
     "struct_item": "TypeDecl",
     "enum_item": "TypeDecl",
     "impl_item": "TypeDecl",
+    "trait_item": "TypeDecl",
     "function_item": "FunctionDecl",
     "method_definition": "MethodDecl",
     "lexical_declaration": "VarDecl",
     "variable_declaration": "VarDecl",
+}
+
+# Martin Abstractness classification for TypeDecl nodes. `impl_item` is
+# intentionally absent: it implements an existing type rather than declaring
+# a new one, so it must not be double-counted in the abstract/concrete ratio.
+_TYPE_KIND = {
+    "trait_item": "trait",
+    "struct_item": "struct",
+    "enum_item": "enum",
 }
 
 _STATEMENT_TYPES = {
@@ -71,10 +81,16 @@ def map_node_kind(node: Node) -> str:
     return "Unknown"
 
 
+def extract_type_attributes(node: Node) -> dict[str, object]:
+    type_kind = _TYPE_KIND.get(node.type)
+    return {"typeKind": type_kind} if type_kind is not None else {}
+
+
 def map_rust_tree_to_uast(root: Node, file: str | None = None) -> UASTNode:
     return map_tree_sitter_to_uast(
         root=root,
         language="rust",
         map_node_kind=map_node_kind,
         file=file,
+        extract_attributes=extract_type_attributes,
     )

--- a/topos/graphs/uast/mapper_typescript.py
+++ b/topos/graphs/uast/mapper_typescript.py
@@ -26,10 +26,24 @@ _TS_EXTRA = {
 }
 
 
+_TYPE_KIND = {
+    "interface_declaration": "interface",
+    "abstract_class_declaration": "abstractClass",
+    "class_declaration": "class",
+    "enum_declaration": "enum",
+    "type_alias_declaration": "typeAlias",
+}
+
+
 def map_node_kind(node: Node) -> str:
     if node.type in _TS_EXTRA:
         return _TS_EXTRA[node.type]
     return map_javascript_node_kind(node)
+
+
+def extract_type_attributes(node: Node) -> dict[str, object]:
+    type_kind = _TYPE_KIND.get(node.type)
+    return {"typeKind": type_kind} if type_kind is not None else {}
 
 
 def map_typescript_tree_to_uast(root: Node, file: str | None = None) -> UASTNode:
@@ -38,4 +52,5 @@ def map_typescript_tree_to_uast(root: Node, file: str | None = None) -> UASTNode
         language="typescript",
         map_node_kind=map_node_kind,
         file=file,
+        extract_attributes=extract_type_attributes,
     )

--- a/topos/graphs/uast/object.py
+++ b/topos/graphs/uast/object.py
@@ -1,0 +1,57 @@
+"""
+Abstractness Representation
+----------------------------
+Adapts Martin's Abstractness metric (fraction of a module's type
+declarations that are abstract) to the :class:`~topos.graphs.base.Representation`
+protocol, so it merges into the same ``composable``-dimension metrics dict
+as :class:`~topos.graphs.mdg.object.ModuleDependencyGraph`.
+
+Unlike ``ModuleDependencyGraph`` (built from GitNexus graph data),
+Abstractness is purely a property of a single file's UAST — no dependency
+graph is required, so it is available for any file in a language whose
+UAST mapper classifies type declarations as abstract/concrete
+(``typeKind``) — see ``mapper_rust.py``, ``mapper_python.py``,
+``mapper_go.py``, ``mapper_typescript.py``.
+
+Languages without that classification (JavaScript has no abstract-class/
+interface concept at all; C++'s mapper has an independent, pre-existing
+bug — see issue #124 discussion) are deliberately excluded here rather
+than silently reporting ``0.0`` for every file, which would be
+indistinguishable from "this file happens to declare no types."
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from topos.graphs.uast.models import UASTNode
+
+# Languages whose UAST mappers populate the `typeKind` attribute needed to
+# classify type declarations as abstract vs. concrete.
+_ABSTRACTNESS_SUPPORTED_LANGUAGES = frozenset({"python", "rust", "go", "typescript"})
+
+
+@dataclass
+class AbstractnessRepresentation:
+    """Representation adapter exposing ``mdg.abstractness``."""
+
+    uast_root: UASTNode
+
+    @property
+    def name(self) -> str:
+        return "abstractness"
+
+    @property
+    def dimension(self) -> str:
+        # Merges into the same raw-metrics dict as ModuleDependencyGraph so
+        # Φ_COMPOSABLE can pair instability with abstractness (issue #124).
+        return "composable"
+
+    def metrics(self) -> dict[str, float]:
+        if self.uast_root.lang not in _ABSTRACTNESS_SUPPORTED_LANGUAGES:
+            return {}
+        from topos.functors.probes.uast.abstractness import calculate_abstractness
+
+        return {"mdg.abstractness": calculate_abstractness(self.uast_root)}

--- a/topos/graphs/uast/object.py
+++ b/topos/graphs/uast/object.py
@@ -13,11 +13,25 @@ UAST mapper classifies type declarations as abstract/concrete
 (``typeKind``) — see ``mapper_rust.py``, ``mapper_python.py``,
 ``mapper_go.py``, ``mapper_typescript.py``.
 
-Languages without that classification (JavaScript has no abstract-class/
-interface concept at all; C++'s mapper has an independent, pre-existing
-bug — see issue #124 discussion) are deliberately excluded here rather
-than silently reporting ``0.0`` for every file, which would be
-indistinguishable from "this file happens to declare no types."
+Two languages are deliberately excluded from
+``_ABSTRACTNESS_SUPPORTED_LANGUAGES`` below rather than silently reporting
+``0.0`` for every file, which would be indistinguishable from "this file
+happens to declare no types":
+
+- **JavaScript** — not a mapper gap, a language fact. Plain JS has no
+  ``interface``/``abstract class`` syntax at all (that's a TypeScript-only
+  extension to the shared grammar); there is nothing in a ``.js`` file's
+  grammar to ever classify as abstract, so Abstractness is not a
+  meaningful metric for it, full stop. Nothing to fix here.
+- **C++** — a real, independent, pre-existing bug: ``mapper_cpp.py``'s
+  ``_DECLARATION_TYPES`` was copy-pasted from the Python/Rust mappers and
+  uses node names that don't exist in the ``tree-sitter-cpp`` grammar
+  (e.g. ``class_definition``/``struct_item`` instead of the real
+  ``class_specifier``/``struct_specifier``), so every C++ class/struct/
+  enum/union currently maps to ``Unknown`` — there is no ``TypeDecl`` node
+  to attach a ``typeKind`` to yet. Tracked in issue #158; add ``"cpp"``
+  here once that mapper is fixed and gains an ``extract_type_attributes``
+  hook (pure-virtual-method detection for ``abstractClass``).
 """
 
 from __future__ import annotations
@@ -29,7 +43,10 @@ if TYPE_CHECKING:
     from topos.graphs.uast.models import UASTNode
 
 # Languages whose UAST mappers populate the `typeKind` attribute needed to
-# classify type declarations as abstract vs. concrete.
+# classify type declarations as abstract vs. concrete. JavaScript is
+# permanently absent (no abstract-type concept in the language — see
+# module docstring); C++ is absent pending issue #158 (mapper bug), not a
+# language limitation.
 _ABSTRACTNESS_SUPPORTED_LANGUAGES = frozenset({"python", "rust", "go", "typescript"})
 
 

--- a/topos/mcp/evaluation.py
+++ b/topos/mcp/evaluation.py
@@ -546,9 +546,10 @@ def _intrinsic_representations(
     morphism: ProgramMorphism,
 ) -> list[Representation]:
     """
-    Build the three intrinsic representations derived from the UAST: CFG,
-    academic PDG, CPG.  These require no external tooling so they are
-    always attached.  Missing UAST (parse failure) yields an empty list.
+    Build the intrinsic representations derived from the UAST: CFG,
+    academic PDG, CPG, Abstractness.  These require no external tooling so
+    they are always attached.  Missing UAST (parse failure) yields an
+    empty list.
     """
     reps: list[Representation] = []
     cfg = morphism.build_cfg()
@@ -560,6 +561,9 @@ def _intrinsic_representations(
     cpg = morphism.build_cpg()
     if cpg is not None:
         reps.append(cpg)
+    abstractness = morphism.build_abstractness()
+    if abstractness is not None:
+        reps.append(abstractness)
     return reps
 
 

--- a/topos/mcp/resources/content/metrics.md
+++ b/topos/mcp/resources/content/metrics.md
@@ -23,21 +23,41 @@ Computed from the Control Flow Graph built on UAST.  Always available.
 max-function cap 20, entropy bell peak at 0.5). **`achieved`** is the AND
 of the raw gates above — not a single score floor.
 
-## COMPOSABLE generator (← Dependency Graph)
+## COMPOSABLE generator (← Dependency Graph + UAST Abstractness)
 
-Requires a `ModuleDependencyGraph` parsed from `.gitnexus/`.  Only populated when
-`gitnexus_dir` is provided or auto-detected.
+`mdg.instability`/`mdg.coupling`/`mdg.fan_in`/`mdg.fan_out`/`mdg.dep_depth`
+require a `ModuleDependencyGraph` parsed from `.gitnexus/` (only populated
+when `gitnexus_dir` is provided or auto-detected). `mdg.abstractness` is
+UAST-derived and needs no GitNexus directory — it is available whenever
+the language's UAST mapper classifies type declarations (Python, Rust,
+Go, TypeScript today; not JavaScript, which has no abstract-type concept).
 
 | Key | What it measures | Gate / good range |
 |---|---|---|
 | `mdg.coupling`    | Ca + Ce (afferent + efferent coupling).  | Diagnostic |
-| `mdg.instability` | `Ce / (Ca + Ce)`.                        | **[0.3, 0.7]** (achieved gate) |
+| `mdg.instability` | `Ce / (Ca + Ce)`.                        | **[0.3, 0.7]** — only gated when `mdg.abstractness` is unavailable for the file's language (see below) |
+| `mdg.abstractness` | Fraction of the module's type declarations that are abstract (trait/interface/protocol/abstract class) vs. concrete (struct/class/enum). `0.0` for a functions-only module (no type declarations at all) — that is a real, meaningful "fully concrete" reading, not "unmeasured." | Diagnostic |
+| `mdg.main_sequence_distance` | Martin's Distance from the Main Sequence, `D = \|A + I − 1\|`. Replaces the raw `mdg.instability` gate whenever abstractness is available — a concrete, unstable orchestrator (I≈1, A≈0, e.g. `main.rs`) sits *on* the main sequence (D≈0) and is not penalized, unlike a fixed instability band. | **≤ 0.5** (achieved gate, when active) |
 | `mdg.fan_in`      | Incoming `CALLS` edges.                  | **≤ 15** (achieved gate) |
 | `mdg.fan_out`     | Outgoing `CALLS` edges.                  | **≤ 15** (achieved gate) |
 | `mdg.dep_depth`   | Longest `IMPORTS` chain.                 | Diagnostic |
 
+**Why two instability gates?** Gating raw `mdg.instability` against a
+fixed band flags both stable leaf modules (constants, error types) and
+unstable orchestrators (`main.rs`, bootstrap/wiring code) even when those
+extremes are architecturally intentional — see issue #124. Pairing
+instability with Abstractness and gating on distance from the main
+sequence fixes this for languages where Abstractness is measured; other
+languages (currently: JavaScript, C++) keep the original band gate
+unchanged until their UAST mappers gain type-declaration classification.
+A separate role-based exemption (`is_stable_leaf_module` — a
+declarations-only module with no branching control flow) tolerates
+maximal main-sequence distance for frozen, concrete foundation/utility
+code, mirroring Martin's own accepted "Zone of Pain" exception.
+
 `Φ_COMPOSABLE` uses fan caps of 40 for score normalization. **`achieved`**
-is the AND of instability band + fan-in + fan-out gates.
+is the AND of whichever instability-family gate is active, plus fan-in and
+fan-out.
 
 ## SECURE generator (← Code Property Graph)
 


### PR DESCRIPTION
## Summary

- COMPOSABLE gated Martin's instability (`I = Ce/(Ca+Ce)`) against a fixed `[0.3, 0.7]` band, flagging well-structured layered modules as failing: stable leaves (constants, error types, I≈0) and unstable orchestrators (`main.rs`, bootstrap/wiring code, I≈1) both failed even when architecturally intentional. This is a known limitation of using raw instability alone — Martin's own metric family pairs it with a second axis, **Abstractness (A)**, and gates on **Distance from the Main Sequence** (`D = |A + I - 1|`) instead.
- Added `mdg.abstractness` (fraction of a module's type declarations that are abstract — trait/interface/protocol vs. concrete struct/class/enum) computed from the UAST, and gate on `mdg.main_sequence_distance` instead of raw `mdg.instability` whenever abstractness is available. A concrete, unstable orchestrator (`main.rs`: I≈1, A≈0) now sits *on* the main sequence (D≈0) and passes — no per-language filename exemption list needed.
- Distance alone doesn't fix the "stable concrete leaf" case (constants.rs: I≈0, A≈0 still gives D=1) — that's Martin's accepted "Zone of Pain" exception. Added a symmetric `is_stable_leaf_module` role exemption (declarations-only module, no branching control flow), mirroring the existing entrypoint-exemption pattern in `file_roles.py`/`gates.py`.
- Scoped to Python, Rust, Go, and TypeScript (their UAST mappers now populate `typeKind`). JavaScript (no abstract-type concept in the language) and C++ (independent, pre-existing mapper bug — real tree-sitter-cpp node names were never wired up) keep the original instability-band gate completely unchanged, so files/languages without abstractness data see byte-identical behavior to before this change.
- `main_sequence_distance_max` (0.5) and `stable_leaf_instability_max` (0.05) are explicitly provisional first-pass thresholds, flagged for a follow-up empirical calibration pass (the existing `[0.3, 0.7]` band came from a PyPI-corpus ECDF calibration this repo doesn't have local access to reproduce).

Closes #124.

## Test plan

- [x] New `tests/graphs/uast/test_abstractness.py` — per-language `typeKind` extraction (Python ABC/Protocol/abstractmethod, Rust trait vs. struct/enum, Go interface vs. struct, TypeScript interface/abstract class/class/enum) and `calculate_abstractness` aggregation.
- [x] New `tests/evaluation/test_file_roles.py` — `is_stable_leaf_module` predicate (declarations-only passes, branching/loop bodies correctly excluded, trivial-return functions still qualify).
- [x] Extended `tests/evaluation/test_calibration.py` with the orchestrator-passes / leaf-fails-without-exemption / leaf-passes-with-exemption / tangled-module-still-fails / distance-boundary / fallback-untouched cases.
- [x] Extended `tests/evaluation/test_gate_parity.py`'s characterization grid with cases straddling `main_sequence_distance_max` and `stable_leaf_instability_max`.
- [x] Full suite: `pytest tests/` — 695 passed, 10 skipped, no regressions.
- [x] `ruff check topos tests` / `ruff format --check topos tests` — clean (matches CI).
- [x] Manual end-to-end check via `CharacteristicMorphism.classify_detailed` with synthetic `main.rs`/`constants.rs`/tangled-module/`main.js` morphisms confirming the exact before/after behavior described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)