### PR TITLE
fix(uast): correct C++ mapper declaration/expression node names

### DIFF
--- a/tests/graphs/uast/test_mapper_cpp.py
+++ b/tests/graphs/uast/test_mapper_cpp.py
@@ -1,0 +1,113 @@
+"""Regression tests for the C++ UAST mapper (issue #158).
+
+Before this fix, `_DECLARATION_TYPES` used node names that don't exist in
+the real `tree-sitter-cpp` grammar (copy-pasted from the Python/Rust
+mappers), so every C++ class/struct/enum/union fell through to `Unknown`
+instead of `TypeDecl`. These tests pin the correct classification against
+the real grammar so that regression can't silently reappear.
+"""
+
+from __future__ import annotations
+
+from topos.graphs.uast.mapper_cpp import map_cpp_tree_to_uast
+from topos.utils.tree_sitter import parse_cpp
+
+
+def _walk(root):
+    yield root
+    for child in root.children:
+        yield from _walk(child)
+
+
+def _kinds(root) -> list[str]:
+    return [n.kind for n in _walk(root)]
+
+
+def _type_kinds(root) -> list[str]:
+    return [n.attributes["typeKind"] for n in _walk(root) if "typeKind" in n.attributes]
+
+
+def test_class_struct_enum_union_are_type_decls_not_unknown():
+    src = """
+class Shape { public: virtual double area() const = 0; };
+struct Circle : public Shape { double r; double area() const override { return 1.0; } };
+enum class Color { Red, Blue };
+union Value { int i; float f; };
+"""
+    root = map_cpp_tree_to_uast(parse_cpp(src))
+    kinds = _kinds(root)
+    assert kinds.count("TypeDecl") == 4
+    assert "Unknown" not in kinds or kinds.count("Unknown") < len(kinds)
+
+
+def test_pure_virtual_method_marks_class_abstract():
+    src = "class Shape { public: virtual double area() const = 0; };"
+    root = map_cpp_tree_to_uast(parse_cpp(src))
+    assert _type_kinds(root) == ["abstractClass"]
+
+
+def test_concrete_class_without_pure_virtual_is_not_abstract():
+    src = "class Point { public: double x; double y; };"
+    root = map_cpp_tree_to_uast(parse_cpp(src))
+    assert _type_kinds(root) == ["class"]
+
+
+def test_subclass_of_abstract_base_is_still_concrete():
+    # Per-declaration classification, like the other language mappers:
+    # Circle overrides the pure-virtual method with a real body, so it has
+    # no pure-virtual of its own.
+    src = """
+class Shape { public: virtual double area() const = 0; };
+struct Circle : public Shape { double area() const override { return 1.0; } };
+"""
+    root = map_cpp_tree_to_uast(parse_cpp(src))
+    assert _type_kinds(root) == ["abstractClass", "struct"]
+
+
+def test_enum_and_union_are_concrete():
+    src = "enum class Color { Red, Blue }; union Value { int i; float f; };"
+    root = map_cpp_tree_to_uast(parse_cpp(src))
+    assert _type_kinds(root) == ["enum", "union"]
+
+
+def test_forward_declaration_is_function_decl_not_var_decl():
+    src = "void forward_decl(int x);"
+    root = map_cpp_tree_to_uast(parse_cpp(src))
+    assert _kinds(root).count("FunctionDecl") == 1
+    assert "VarDecl" not in _kinds(root)
+
+
+def test_global_variable_declaration_is_var_decl():
+    src = "int global_x = 5;"
+    root = map_cpp_tree_to_uast(parse_cpp(src))
+    assert _kinds(root).count("VarDecl") == 1
+    assert "FunctionDecl" not in _kinds(root)
+
+
+def test_data_member_is_var_decl_pure_virtual_signature_is_function_decl():
+    src = "class Shape { public: virtual double area() const = 0; double cached; };"
+    root = map_cpp_tree_to_uast(parse_cpp(src))
+    kinds = _kinds(root)
+    assert kinds.count("FunctionDecl") == 1  # the pure-virtual signature
+    assert kinds.count("VarDecl") == 1  # `double cached;`
+
+
+def test_control_flow_and_expression_kinds_are_recognized():
+    src = """
+void f(int x) {
+    if (x > 0) {
+        for (int i = 0; i < x; i++) {
+            x += i;
+        }
+    }
+    obj.method();
+    arr[0] = 1;
+}
+"""
+    root = map_cpp_tree_to_uast(parse_cpp(src))
+    kinds = _kinds(root)
+    assert "IfStmt" in kinds
+    assert "ForStmt" in kinds
+    assert "AssignExpr" in kinds
+    assert "CallExpr" in kinds
+    assert "MemberExpr" in kinds  # both field_expression and subscript_expression

--- a/topos/graphs/uast/mapper_common.py
+++ b/topos/graphs/uast/mapper_common.py
@@ -76,6 +76,7 @@ def map_tree_sitter_to_uast(
     language: str,
     map_node_kind: Callable[[Node], str],
     file: str | None = None,
+    extract_attributes: Callable[[Node], dict[str, object]] | None = None,
 ) -> UASTNode:
     parser_name, parser_version = parser_identity(language)
 
@@ -155,12 +156,15 @@ def map_tree_sitter_to_uast(
             parser_version=parser_version,
             node_kind=node.type,
         )
+        attributes: dict[str, object] = {"named": node.is_named}
+        if extract_attributes is not None:
+            attributes.update(extract_attributes(node) or {})
         uast_nodes[node.id] = UASTNode(
             kind=map_node_kind(node),
             lang=language,
             span=span,
             native=native,
-            attributes={"named": node.is_named},
+            attributes=attributes,
             children=children,
             id=node_stable_id,
         )

--- a/topos/graphs/uast/mapper_cpp.py
+++ b/topos/graphs/uast/mapper_cpp.py
@@ -5,17 +5,36 @@ from tree_sitter import Node
 from topos.graphs.uast.mapper_common import map_tree_sitter_to_uast
 from topos.graphs.uast.models import UASTNode
 
+# Real tree-sitter-cpp grammar node names (verified against the vendored
+# grammar directly — the previous dict here was copy-pasted from the
+# Python/Rust mappers and used node names tree-sitter-cpp doesn't emit at
+# all, e.g. `class_definition`/`struct_item`, so every C++ type
+# declaration silently fell to `Unknown`; see issue #158).
 _DECLARATION_TYPES = {
-    "function_definition": "FunctionDecl",
-    "class_definition": "TypeDecl",
-    "struct_item": "TypeDecl",
-    "enum_item": "TypeDecl",
-    "impl_item": "TypeDecl",
-    "function_item": "FunctionDecl",
-    "method_definition": "MethodDecl",
-    "lexical_declaration": "VarDecl",
-    "variable_declaration": "VarDecl",
+    "function_definition": "FunctionDecl",  # free functions AND in-class
+    # method *definitions* (with a body) — tree-sitter-cpp doesn't
+    # distinguish the two at this node.
+    "class_specifier": "TypeDecl",
+    "struct_specifier": "TypeDecl",
+    "enum_specifier": "TypeDecl",
+    "union_specifier": "TypeDecl",
 }
+
+# `declaration` (free-standing) and `field_declaration` (inside a class
+# body) are dual-purpose in the grammar: a variable/member declaration
+# (`int x;`) and a declaration-only function/method signature with no
+# body (`void f(int);`, or a pure-virtual `virtual double area() const =
+# 0;`) both use the same wrapper node, distinguished only by whether a
+# `function_declarator` child is present.
+_DECLARATION_ONLY_KINDS = {
+    "declaration": "VarDecl",
+    "field_declaration": "VarDecl",
+}
+
+
+def _has_function_declarator(node: Node) -> bool:
+    return any(child.type == "function_declarator" for child in node.children)
+
 
 _STATEMENT_TYPES = {
     "if_statement": "IfStmt",
@@ -31,21 +50,20 @@ _STATEMENT_TYPES = {
 }
 
 _EXPRESSION_TYPES = {
-    "assignment": "AssignExpr",
-    "augmented_assignment": "AssignExpr",
+    "assignment_expression": "AssignExpr",
     "binary_expression": "BinaryExpr",
-    "boolean_operator": "BinaryExpr",
     "unary_expression": "UnaryExpr",
     "call_expression": "CallExpr",
-    "member_expression": "MemberExpr",
     "field_expression": "MemberExpr",
-    "subscript": "MemberExpr",
+    "subscript_expression": "MemberExpr",
 }
 
 
 def map_node_kind(node: Node) -> str:
     if node.type in _DECLARATION_TYPES:
         return _DECLARATION_TYPES[node.type]
+    if node.type in _DECLARATION_ONLY_KINDS:
+        return "FunctionDecl" if _has_function_declarator(node) else "VarDecl"
     if node.type in _STATEMENT_TYPES:
         return _STATEMENT_TYPES[node.type]
     if node.type in _EXPRESSION_TYPES:
@@ -59,10 +77,55 @@ def map_node_kind(node: Node) -> str:
     return "Unknown"
 
 
+# Martin Abstractness classification (issue #124/#158): a class/struct is
+# abstract iff it declares at least one pure-virtual method
+# (`virtual ... = 0;`) — the C++ idiom for an interface/abstract base
+# class. `enum`/`union` are always concrete.
+_TYPE_KIND = {
+    "class_specifier": "class",
+    "struct_specifier": "struct",
+    "enum_specifier": "enum",
+    "union_specifier": "union",
+}
+
+
+def _is_pure_virtual(field_decl: Node) -> bool:
+    """True for a declaration-only method signature with a `= 0`
+    pure-specifier, e.g. `virtual double area() const = 0;`."""
+    if not _has_function_declarator(field_decl):
+        return False
+    return any(
+        child.type == "number_literal" and child.text == b"0"
+        for child in field_decl.named_children
+    )
+
+
+def _has_pure_virtual_method(type_node: Node) -> bool:
+    for child in type_node.children:
+        if child.type != "field_declaration_list":
+            continue
+        return any(
+            member.type == "field_declaration" and _is_pure_virtual(member)
+            for member in child.named_children
+        )
+    return False
+
+
+def extract_type_attributes(node: Node) -> dict[str, object]:
+    type_kind = _TYPE_KIND.get(node.type)
+    if type_kind is None:
+        return {}
+    is_class_like = node.type in {"class_specifier", "struct_specifier"}
+    if is_class_like and _has_pure_virtual_method(node):
+        return {"typeKind": "abstractClass"}
+    return {"typeKind": type_kind}
+
+
 def map_cpp_tree_to_uast(root: Node, file: str | None = None) -> UASTNode:
     return map_tree_sitter_to_uast(
         root=root,
         language="cpp",
         map_node_kind=map_node_kind,
         file=file,
+        extract_attributes=extract_type_attributes,
     )


### PR DESCRIPTION
## Summary

- `mapper_cpp.py`'s `_DECLARATION_TYPES` was copy-pasted from the Python/Rust mappers and used node names that don't exist in the real `tree-sitter-cpp` grammar (`class_definition`/`struct_item`/`enum_item` instead of the real `class_specifier`/`struct_specifier`/`enum_specifier`). Every C++ class/struct/enum/union silently fell through to `Unknown` in the UAST — verified empirically against the vendored grammar. Two `_EXPRESSION_TYPES` entries (`assignment`, `subscript`) had the same problem; real names are `assignment_expression`/`subscript_expression`.
- Replaced with the verified real grammar node names (`class_specifier`, `struct_specifier`, `enum_specifier`, `union_specifier` → `TypeDecl`).
- `declaration` (free-standing) and `field_declaration` (class members) are dual-purpose in the grammar — a variable/member declaration and a declaration-only function/method signature (forward declarations, pure-virtual methods) share the same wrapper node. Disambiguated by whether a `function_declarator` child is present.
- Added pure-virtual-method detection (`virtual ... = 0;`) so a class/struct containing one classifies as `typeKind=abstractClass` — this makes Martin's Abstractness metric (#124, PR #157) available for C++ as a fast-follow. This PR only fixes the mapper itself; wiring `"cpp"` into `_ABSTRACTNESS_SUPPORTED_LANGUAGES` is a one-line change deferred until `topos/graphs/uast/object.py` lands on `main` via #157 (it doesn't exist there yet).
- Control-flow/statement node names (`if_statement`, `for_statement`, `while_statement`, etc.) were already correct — this is specifically a declaration/type-counting fix, not a CFG/cyclomatic-complexity fix.

Note: this branch independently duplicates the small `extract_attributes` plumbing addition to `mapper_common.py` that PR #157 also makes (both branch off `main`, which doesn't have it yet). Whichever of #157/#158 merges second will hit a trivial, easily-resolved conflict on that one function signature.

Closes #158.

## Test plan

- [x] New `tests/graphs/uast/test_mapper_cpp.py` — class/struct/enum/union now produce `TypeDecl` (not `Unknown`); pure-virtual detection marks a class abstract; concrete classes/subclasses-of-abstract are not marked abstract; enum/union are always concrete; forward declarations classify as `FunctionDecl` while global/local variable declarations classify as `VarDecl`; data members vs. pure-virtual signatures inside a class body are correctly disambiguated; control-flow and expression node kinds (`IfStmt`, `ForStmt`, `AssignExpr`, `CallExpr`, `MemberExpr`) are recognized.
- [x] Full suite: `pytest tests/` — 680 passed, 10 skipped, no regressions (including existing C++-touching tests in `tests/graphs/cpg/test_cpg.py`, `tests/graphs/ast/test_multilang_ast.py`, `tests/graphs/test_graphs.py`).
- [x] `ruff check topos tests` / `ruff format --check topos tests` — clean.
- [x] Manual end-to-end check parsing a representative C++ sample (abstract base class, concrete subclass, enum class, union, free function with branching/loop/member-access/subscript/assignment, forward declaration, global variable) and dumping the full UAST tree to confirm every node classifies correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)