### PR TITLE
fix: make ast.max_function_complexity language-neutral

### DIFF
--- a/tests/functors/probes/ast/test_function_complexity_entries.py
+++ b/tests/functors/probes/ast/test_function_complexity_entries.py
@@ -2,10 +2,16 @@
 
 Covers nested functions / closures, methods, and module-level code so the
 ``ast.max_function_complexity`` gate can always be mapped back to a span.
+
+``_entries`` builds the ``ProgramObject`` via ``ProgramMorphism`` (rather
+than constructing it directly), so these tests exercise the real production
+code path -- ``uast_root`` populated -- which is what actually drives
+``ast.max_function_complexity`` for real callers (see issue #153).
 """
 
 from __future__ import annotations
 
+from topos.core.morphism import ProgramMorphism
 from topos.core.object import ProgramObject
 from topos.functors.probes.ast.complexity import (
     calculate_function_complexity_entries,
@@ -15,7 +21,7 @@ from topos.utils.tree_sitter import parse_python
 
 
 def _entries(code: str):
-    obj = ProgramObject(root=parse_python(code), source=code, language="python")
+    obj = ProgramMorphism(source=code, language="python").ast
     return {e.qualified_name: e for e in calculate_function_complexity_entries(obj)}
 
 
@@ -70,7 +76,7 @@ def test_nested_closure_is_dotted_and_outer_includes_nested() -> None:
 
 def test_module_level_only_has_no_function_entries() -> None:
     code = "x = 1\nif x:\n    y = 2\nelse:\n    y = 3\n"
-    obj = ProgramObject(root=parse_python(code), source=code, language="python")
+    obj = ProgramMorphism(source=code, language="python").ast
     assert calculate_function_complexity_entries(obj) == []
 
 
@@ -78,6 +84,28 @@ def test_max_entry_matches_gate_metric() -> None:
     code = "def big(x):\n" + "".join(
         f"    if x == {i}:\n        return {i}\n" for i in range(12)
     )
-    obj = ProgramObject(root=parse_python(code), source=code, language="python")
+    obj = ProgramMorphism(source=code, language="python").ast
     entries = calculate_function_complexity_entries(obj)
     assert max(e.complexity for e in entries) == calculate_max_function_complexity(obj)
+
+
+# ---------------------------------------------------------------------------
+# Legacy fallback: a ProgramObject constructed directly (uast_root=None).
+# ---------------------------------------------------------------------------
+#
+# Real callers always go through ProgramMorphism / parse_source, which
+# populate uast_root for every supported language -- but complexity.py keeps
+# a defensive, Python-only native tree-sitter fallback for ProgramObjects
+# built without one. This guards that fallback from silently rotting.
+
+
+def test_fallback_path_used_when_uast_root_is_none() -> None:
+    code = "def foo(x):\n    if x:\n        return 1\n    return 0\n"
+    obj = ProgramObject(root=parse_python(code), source=code, language="python")
+    assert obj.uast_root is None
+
+    entries = {e.qualified_name: e for e in calculate_function_complexity_entries(obj)}
+    foo = entries["foo"]
+    assert foo.kind == "function"
+    assert foo.complexity == 2  # one `if`
+    assert calculate_max_function_complexity(obj) == 2

--- a/tests/functors/probes/ast/test_function_complexity_multilang.py
+++ b/tests/functors/probes/ast/test_function_complexity_multilang.py
@@ -1,0 +1,240 @@
+"""Regression tests for issue #153.
+
+``calculate_function_complexities``/``calculate_function_complexity_entries``
+used to find function nodes via Python-specific tree-sitter native node type
+strings (``function_definition``/``async_function_definition``). For every
+other language that query matched zero nodes, so
+``calculate_max_function_complexity`` silently returned ``0`` -- always
+within the ``<= 10.0`` SIMPLE gate, a vacuous pass rather than a real
+evaluation.
+
+These tests reproduce the bug for each language with an existing UAST
+mapper (Rust, Go, JavaScript, TypeScript): a genuinely branchy function that
+must NOT score complexity 1 (or, pre-fix, complexity 0 via
+``calculate_max_function_complexity``).
+"""
+
+from __future__ import annotations
+
+import pytest
+from topos.core.morphism import ProgramMorphism
+from topos.functors.probes.ast.complexity import (
+    calculate_function_complexity_entries,
+    calculate_max_function_complexity,
+)
+from topos.graphs.ast.object import ASTRepresentation
+
+# A function with two `if`s, a `for` containing a nested `if`, and either a
+# `match`/`switch` or a trailing `while` (decision-node coverage differs
+# slightly per language's UAST mapper -- see complexity.py) -- six decision
+# nodes total, so complexity should be 6, never 0 or 1.
+_BRANCHY_SOURCES: dict[str, tuple[str, int]] = {
+    "rust": (
+        "fn classify(x: i32) -> i32 {\n"
+        "    if x < 0 {\n"
+        "        return -1;\n"
+        "    }\n"
+        "    if x == 0 {\n"
+        "        return 0;\n"
+        "    }\n"
+        "    for i in 0..x {\n"
+        "        if i % 2 == 0 {\n"
+        "            continue;\n"
+        "        }\n"
+        "    }\n"
+        "    match x {\n"
+        "        1 => 1,\n"
+        "        2 => 2,\n"
+        "        _ => 3,\n"
+        "    }\n"
+        "}\n",
+        6,
+    ),
+    "go": (
+        "package main\n\n"
+        "func classify(x int) int {\n"
+        "\tif x < 0 {\n"
+        "\t\treturn -1\n"
+        "\t}\n"
+        "\tif x == 0 {\n"
+        "\t\treturn 0\n"
+        "\t}\n"
+        "\tfor i := 0; i < x; i++ {\n"
+        "\t\tif i%2 == 0 {\n"
+        "\t\t\tcontinue\n"
+        "\t\t}\n"
+        "\t}\n"
+        "\tswitch x {\n"
+        "\tcase 1:\n"
+        "\t\treturn 1\n"
+        "\tcase 2:\n"
+        "\t\treturn 2\n"
+        "\tdefault:\n"
+        "\t\treturn 3\n"
+        "\t}\n"
+        "\treturn 4\n"
+        "}\n",
+        6,
+    ),
+    "javascript": (
+        "function classify(x) {\n"
+        "  if (x < 0) {\n"
+        "    return -1;\n"
+        "  }\n"
+        "  if (x === 0) {\n"
+        "    return 0;\n"
+        "  }\n"
+        "  for (let i = 0; i < x; i++) {\n"
+        "    if (i % 2 === 0) {\n"
+        "      continue;\n"
+        "    }\n"
+        "  }\n"
+        "  while (x > 100) {\n"
+        "    x -= 1;\n"
+        "  }\n"
+        "  return x;\n"
+        "}\n",
+        6,
+    ),
+    "typescript": (
+        "function classify(x: number): number {\n"
+        "  if (x < 0) {\n"
+        "    return -1;\n"
+        "  }\n"
+        "  if (x === 0) {\n"
+        "    return 0;\n"
+        "  }\n"
+        "  for (let i = 0; i < x; i++) {\n"
+        "    if (i % 2 === 0) {\n"
+        "      continue;\n"
+        "    }\n"
+        "  }\n"
+        "  while (x > 100) {\n"
+        "    x -= 1;\n"
+        "  }\n"
+        "  return x;\n"
+        "}\n",
+        6,
+    ),
+}
+
+
+@pytest.mark.parametrize("language", sorted(_BRANCHY_SOURCES))
+def test_branchy_function_is_not_vacuously_zero_or_one(language: str) -> None:
+    source, expected_complexity = _BRANCHY_SOURCES[language]
+    ast = ProgramMorphism(source=source, language=language).ast
+    assert ast.uast_root is not None  # sanity: exercising the real UAST path
+
+    entries = calculate_function_complexity_entries(ast)
+    assert len(entries) == 1
+    assert entries[0].name == "classify"
+    assert entries[0].complexity == expected_complexity
+    assert entries[0].complexity > 1
+
+    max_complexity = calculate_max_function_complexity(ast)
+    assert max_complexity == expected_complexity
+    assert max_complexity > 1
+
+
+@pytest.mark.parametrize("language", sorted(_BRANCHY_SOURCES))
+def test_ast_representation_metric_is_not_vacuously_zero(language: str) -> None:
+    """End-to-end: the exact gate metric consumed by the SIMPLE evaluator."""
+    source, expected_complexity = _BRANCHY_SOURCES[language]
+    morphism = ProgramMorphism(source=source, language=language)
+    representation = ASTRepresentation(program_object=morphism.ast, source=source)
+    metrics = representation.metrics()
+    assert metrics["ast.max_function_complexity"] == float(expected_complexity)
+
+
+_METHOD_SOURCES: dict[str, str] = {
+    "rust": (
+        "struct Foo;\n\n"
+        "impl Foo {\n"
+        "    fn bar(&self, x: i32) -> i32 {\n"
+        "        if x > 0 {\n"
+        "            return 1;\n"
+        "        }\n"
+        "        return 0;\n"
+        "    }\n"
+        "}\n"
+    ),
+    "go": (
+        "package main\n\n"
+        "type Foo struct{}\n\n"
+        "func (f Foo) Bar(x int) int {\n"
+        "\tif x > 0 {\n"
+        "\t\treturn 1\n"
+        "\t}\n"
+        "\treturn 0\n"
+        "}\n"
+    ),
+    "javascript": (
+        "class Foo {\n"
+        "  bar(x) {\n"
+        "    if (x > 0) {\n"
+        "      return 1;\n"
+        "    }\n"
+        "    return 0;\n"
+        "  }\n"
+        "}\n"
+    ),
+    "typescript": (
+        "class Foo {\n"
+        "  bar(x: number): number {\n"
+        "    if (x > 0) {\n"
+        "      return 1;\n"
+        "    }\n"
+        "    return 0;\n"
+        "  }\n"
+        "}\n"
+    ),
+}
+
+
+@pytest.mark.parametrize("language", sorted(_METHOD_SOURCES))
+def test_method_classified_across_languages(language: str) -> None:
+    source = _METHOD_SOURCES[language]
+    ast = ProgramMorphism(source=source, language=language).ast
+    entries = calculate_function_complexity_entries(ast)
+    assert len(entries) == 1
+    entry = entries[0]
+    expected_name = "Bar" if language == "go" else "bar"
+    assert entry.name == expected_name
+    assert entry.kind == "method"
+    assert entry.complexity == 2  # one `if`
+
+
+_ASYNC_SOURCES: dict[str, str] = {
+    "rust": "async fn bar() -> i32 {\n    return 1;\n}\n",
+    "javascript": "async function bar() {\n  return 1;\n}\n",
+    "typescript": "async function bar(): Promise<number> {\n  return 1;\n}\n",
+}
+
+
+@pytest.mark.parametrize("language", sorted(_ASYNC_SOURCES))
+def test_async_function_classified_across_languages(language: str) -> None:
+    source = _ASYNC_SOURCES[language]
+    ast = ProgramMorphism(source=source, language=language).ast
+    entries = calculate_function_complexity_entries(ast)
+    assert len(entries) == 1
+    assert entries[0].name == "bar"
+    assert entries[0].kind == "async_function"
+
+
+def test_nested_closure_classified_for_javascript() -> None:
+    source = (
+        "function outer(x) {\n"
+        "  function inner(y) {\n"
+        "    if (y) {\n"
+        "      return 1;\n"
+        "    }\n"
+        "    return 0;\n"
+        "  }\n"
+        "  return inner(x);\n"
+        "}\n"
+    )
+    ast = ProgramMorphism(source=source, language="javascript").ast
+    entries = {e.qualified_name: e for e in calculate_function_complexity_entries(ast)}
+    assert entries["outer"].kind == "function"
+    assert entries["outer.inner"].kind == "closure"
+    assert entries["outer.inner"].complexity == 2

--- a/topos/functors/probes/ast/complexity.py
+++ b/topos/functors/probes/ast/complexity.py
@@ -5,13 +5,33 @@ Per-Function Complexity Analysis
 Provides a function-level breakdown of complexity using the AST.
 This is separate from the CFG-based module-level cyclomatic complexity used
 in the main program evaluation (SIMPLE generator).
+
+Every ``ProgramObject`` produced by a real parse (``ProgramMorphism`` /
+``parse_source``) carries a populated, language-neutral ``uast_root``
+(see ``topos.graphs.ast.providers.tree_sitter_provider``), so the primary
+implementation below walks that UAST directly to find ``FunctionDecl`` /
+``MethodDecl`` nodes -- this works uniformly across every language with a
+UAST mapper (Python, Rust, Go, JavaScript, TypeScript, C++), unlike the
+previous approach of re-querying Python-specific tree-sitter native node
+type strings (``function_definition``/``async_function_definition``),
+which silently found zero functions for every other language.
+
+A ``uast_root``-less native tree-sitter fallback is retained for callers
+that construct a ``ProgramObject`` directly without populating
+``uast_root`` (e.g. lightweight test fixtures); it remains Python-only,
+same as before this fix.
 """
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from topos.core.object import ProgramObject
+
+if TYPE_CHECKING:
+    from topos.graphs.uast.models import UASTNode
 
 _FUNCTION_NODE_TYPES = ("function_definition", "async_function_definition")
 _SCOPE_NODE_TYPES = (*_FUNCTION_NODE_TYPES, "class_definition")
@@ -46,6 +66,35 @@ DECISION_UAST_KINDS = frozenset(
     }
 )
 
+# UAST kinds that every language mapper agrees denote a callable.
+_FUNCTION_UAST_KINDS = frozenset({"FunctionDecl", "MethodDecl"})
+
+# UAST kinds that introduce a new "scope" for qualified-name/kind purposes
+# (mirrors ``_SCOPE_NODE_TYPES`` for the native tree-sitter fallback).
+_SCOPE_UAST_KINDS = frozenset({*_FUNCTION_UAST_KINDS, "TypeDecl"})
+
+# tree-sitter grammars use different native node kinds for a declaration's
+# name token depending on syntactic position (e.g. tree-sitter-javascript
+# emits ``property_identifier`` for a class method's name, not
+# ``identifier``; tree-sitter-go emits ``field_identifier``/
+# ``type_identifier`` elsewhere). ``UASTNode`` has no stored ``name``
+# attribute, so recovering it means scanning a declaration's own children
+# for one of these native kinds and slicing the corresponding byte span out
+# of the source -- the *native* provenance kind is matched here rather than
+# the normalized UAST ``kind``, since none of the mappers classify these
+# tokens as ``"Identifier"`` today.
+_NAME_NATIVE_KINDS = frozenset(
+    {
+        "identifier",
+        "property_identifier",
+        "field_identifier",
+        "type_identifier",
+        "package_identifier",
+    }
+)
+
+_ASYNC_PREFIX_RE = re.compile(rb"\Aasync\b")
+
 
 def _calculate_node_complexity(ast: ProgramObject) -> int:
     """Internal helper to calculate complexity of a specific node/sub-tree."""
@@ -63,7 +112,7 @@ def _calculate_node_complexity(ast: ProgramObject) -> int:
     return decision_count + 1
 
 
-def _calculate_cyclomatic_complexity_uast(root) -> int:
+def _calculate_cyclomatic_complexity_uast(root: UASTNode) -> int:
     decision_count = 0
 
     def walk(node) -> None:
@@ -98,6 +147,113 @@ def _extract_function_name(node, source_bytes: bytes) -> str | None:
     return None
 
 
+# ---------------------------------------------------------------------------
+# UAST-driven (language-neutral) implementation
+# ---------------------------------------------------------------------------
+
+
+def _extract_uast_name(node: UASTNode, source_bytes: bytes) -> str | None:
+    """Best-effort identifier extraction for a UAST declaration node.
+
+    Returns ``None`` for callables with no bound identifier of their own
+    (e.g. a JS/TS arrow function assigned via ``const f = (x) => {...}``,
+    where the name lives on the enclosing ``variable_declarator``, not the
+    ``FunctionDecl`` node itself) -- these are skipped by callers, matching
+    the pre-existing behavior of never picking up anonymous callables
+    (Python lambdas were never matched by the native node-type query
+    either).
+    """
+    for child in node.children:
+        if child.native.node_kind in _NAME_NATIVE_KINDS:
+            return source_bytes[child.span.start_byte : child.span.end_byte].decode(
+                "utf-8", errors="replace"
+            )
+    return None
+
+
+def _is_async_uast(node: UASTNode, source_bytes: bytes) -> bool:
+    """Detect a leading ``async`` modifier on a UAST declaration node.
+
+    tree-sitter models ``async`` as an unnamed leading token, so it is
+    filtered out of the UAST tree entirely (only *named* children survive
+    mapping) -- but it remains part of the declaration node's own byte span,
+    so a text sniff at the start of that span recovers it uniformly across
+    Python (``async def``), JS/TS (``async function`` / ``async () =>`` /
+    ``async foo()``), and Rust (``async fn``). Go has no ``async`` keyword.
+    """
+    start = node.span.start_byte
+    return bool(_ASYNC_PREFIX_RE.match(source_bytes[start : start + 6]))
+
+
+def _classify_uast_kind(
+    own_kind: str, scope_chain: list[tuple[str, str]], is_async: bool
+) -> str:
+    if own_kind == "MethodDecl":
+        return "method"
+    if scope_chain:
+        enclosing_kind = scope_chain[-1][0]
+        if enclosing_kind == "TypeDecl":
+            return "method"
+        if enclosing_kind in _FUNCTION_UAST_KINDS:
+            return "closure"
+    return "async_function" if is_async else "function"
+
+
+@dataclass(frozen=True)
+class _UastFunctionEntry:
+    node: UASTNode
+    name: str
+    qualified_name: str
+    kind: str
+
+
+def _iter_uast_function_entries(
+    root: UASTNode, source_bytes: bytes
+) -> list[_UastFunctionEntry]:
+    """Top-down walk of the UAST collecting every named callable, in
+    document order, with its dotted qualified name and method/closure/
+    function/async_function classification.
+
+    ``UASTNode`` has no parent pointer, so the enclosing-scope chain is
+    threaded down explicitly as the recursion descends (mirroring the
+    native fallback's upward ``.parent`` walk, just inverted).
+    """
+    entries: list[_UastFunctionEntry] = []
+
+    def walk(node: UASTNode, scope_chain: list[tuple[str, str]]) -> None:
+        kind = getattr(node, "kind", "")
+        next_scope_chain = scope_chain
+
+        if kind in _FUNCTION_UAST_KINDS:
+            name = _extract_uast_name(node, source_bytes)
+            if name is not None:
+                qualified = ".".join([n for _, n in scope_chain] + [name])
+                is_async = _is_async_uast(node, source_bytes)
+                entries.append(
+                    _UastFunctionEntry(
+                        node=node,
+                        name=name,
+                        qualified_name=qualified,
+                        kind=_classify_uast_kind(kind, scope_chain, is_async),
+                    )
+                )
+            next_scope_chain = [*scope_chain, (kind, name or "<anon>")]
+        elif kind in _SCOPE_UAST_KINDS:  # TypeDecl
+            name = _extract_uast_name(node, source_bytes)
+            next_scope_chain = [*scope_chain, (kind, name or "<anon>")]
+
+        for child in getattr(node, "children", []):
+            walk(child, next_scope_chain)
+
+    walk(root, [])
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
 def calculate_function_complexities(ast: ProgramObject) -> dict[str, int]:
     """
     Calculate cyclomatic complexity for each function in the AST.
@@ -108,6 +264,17 @@ def calculate_function_complexities(ast: ProgramObject) -> dict[str, int]:
     Returns:
         A dictionary mapping function names to their complexity scores.
     """
+    if ast.uast_root is not None:
+        source_bytes = ast.source.encode("utf-8")
+        return {
+            entry.name: _calculate_cyclomatic_complexity_uast(entry.node)
+            for entry in _iter_uast_function_entries(ast.uast_root, source_bytes)
+        }
+
+    # Legacy fallback for ProgramObjects constructed without a uast_root.
+    # Python-only, same as before this fix; unreachable for any ProgramObject
+    # produced by ProgramMorphism / parse_source, which always populate
+    # uast_root for every supported language.
     complexities: dict[str, int] = {}
     source_bytes = ast.source.encode("utf-8")
 
@@ -194,6 +361,22 @@ def calculate_function_complexity_entries(
     retains every callable (including same-named ones) plus its span, dotted
     qualified name, and scope kind.
     """
+    if ast.uast_root is not None:
+        source_bytes = ast.source.encode("utf-8")
+        return [
+            FunctionComplexity(
+                name=entry.name,
+                qualified_name=entry.qualified_name,
+                kind=entry.kind,
+                start_line=entry.node.span.start_line,
+                end_line=entry.node.span.end_line,
+                complexity=_calculate_cyclomatic_complexity_uast(entry.node),
+            )
+            for entry in _iter_uast_function_entries(ast.uast_root, source_bytes)
+        ]
+
+    # Legacy fallback for ProgramObjects constructed without a uast_root.
+    # Python-only, same as before this fix; see calculate_function_complexities.
     source_bytes = ast.source.encode("utf-8")
     entries: list[FunctionComplexity] = []
 


### PR DESCRIPTION
## Summary
- `calculate_function_complexities`/`calculate_function_complexity_entries` in `topos/functors/probes/ast/complexity.py` found function nodes via Python-specific tree-sitter native node type strings (`function_definition`/`async_function_definition`), so Rust (`function_item`), Go (`function_declaration`), and JS/TS (`function_declaration`/`arrow_function`/etc.) matched **zero** nodes — `calculate_max_function_complexity` silently returned `0`, always within the `<= 10.0` SIMPLE gate. A vacuous pass, not a real evaluation.
- The per-function code also rebuilt a fresh `ProgramObject(root=node, source=ast.source, language=ast.language)` without `uast_root=...`, so the already-correct, language-neutral `_calculate_cyclomatic_complexity_uast` path (walking `IfStmt`/`ForStmt`/`WhileStmt`/`MatchStmt`/`TryStmt`) was dead code for every language, including Python.
- Fix: both functions now walk the file's already-built UAST directly for `FunctionDecl`/`MethodDecl` nodes whenever `ast.uast_root` is populated — which it always is for any `ProgramObject` built via `ProgramMorphism`/`parse_source` (the real production path for every supported language). No native-node re-querying, no per-function `ProgramObject` reconstruction.
  - Name extraction: `UASTNode` has no stored `name` attribute, so a function's identifier is recovered by scanning its own children for a name-shaped *native* token kind (`identifier`, `property_identifier`, `field_identifier`, `type_identifier`, `package_identifier` — tree-sitter-javascript, for instance, names a method's identifier `property_identifier`, not `identifier`, so this had to be checked per-mapper rather than assumed).
  - `async` detection: tree-sitter models `async` as an unnamed leading token, which is filtered out of the UAST entirely — but it's still part of the declaration node's own byte span, so a text sniff at the start of that span recovers it uniformly (Python `async def`, JS/TS `async function`/`async () =>`/`async foo()`, Rust `async fn`).
  - Scope chain (for `qualified_name`/`method`/`closure` classification) is now a top-down recursive walk carrying an ancestor stack, since `UASTNode` has no parent pointer (unlike tree-sitter's `.parent`).
  - Anonymous callables with no bound identifier of their own (e.g. a JS arrow function assigned via `const f = (x) => {...}`, where the name lives on the enclosing `variable_declarator`) are skipped — matching the pre-existing behavior of never picking up unnamed callables (Python lambdas were never matched either).
- A Python-only native tree-sitter fallback is kept, used only when `ast.uast_root is None` (i.e. a `ProgramObject` constructed directly rather than via `ProgramMorphism`/`parse_source`) — real callers never hit it, but it's guarded by its own regression test rather than left as untested dead code.

## Test plan
- [x] `tests/functors/probes/ast/test_function_complexity_entries.py`: updated to build the `ProgramObject` via `ProgramMorphism` (exercising the real, now-fixed production path) instead of constructing it directly; all prior Python assertions (kind, span, nesting, gate-metric parity) still hold unchanged. Added a dedicated test for the `uast_root=None` legacy fallback path.
- [x] New `tests/functors/probes/ast/test_function_complexity_multilang.py`: reproduces the reported bug for Rust, Go, JavaScript, and TypeScript — a branchy function (`if`/`if`/`for`+nested `if`/`match`-or-`while`) that must score complexity `6`, not the prior vacuous `0`/`1`; also covers method/closure/async_function kind classification across all four languages, plus an end-to-end check through `ASTRepresentation.metrics()["ast.max_function_complexity"]` (the exact gate metric).
- [x] Full `pytest` (688 passed, 10 skipped) and `ruff check` / `ruff format --check` clean.
- [x] No Rust (`src/`/`crates/`) changes needed — this is a Python-side fix; the Rust port referenced in the issue is a separate from-scratch implementation.

Fixes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)