### PR TITLE
fix(secure): bridge DDG statement/sub-expression granularity mismatch in taint_flow_paths

### DIFF
--- a/tests/functors/probes/cpg/test_taint.py
+++ b/tests/functors/probes/cpg/test_taint.py
@@ -1,0 +1,67 @@
+"""
+Regression tests for ``taint_flow_paths`` (issue #154).
+
+DDG edges connect whole *statement* nodes (see
+``ProgramDependenceGraph._compute_data_dependence``), while source/sink
+detection matches individual *sub-expression* nodes (a bare
+``Identifier``/``MemberExpr`` for sources, a ``CallExpr`` for sinks). These
+two id spaces essentially never intersect directly, so ``taint_flow_paths``
+used to return 0 even for the textbook direct-flow case. It now bridges the
+gap by containment: a source/sink is "connected" if it is a descendant of
+(or equal to) a DDG-participating statement.
+"""
+
+from __future__ import annotations
+
+from topos.core.morphism import ProgramMorphism
+from topos.functors.probes.cpg.taint import taint_flow_paths
+from topos.graphs.cpg.object import CodePropertyGraph
+
+
+def _cpg(source: str, language: str = "python") -> CodePropertyGraph:
+    morphism = ProgramMorphism(source=source, language=language)
+    cpg = morphism.build_cpg()
+    assert cpg is not None
+    return cpg
+
+
+def test_taint_flow_paths_direct_python_source_to_sink():
+    """Issue #154's exact repro: `x = input(); eval(x)` must count >= 1."""
+    cpg = _cpg("def f():\n    x = input()\n    eval(x)\n")
+    assert taint_flow_paths(cpg) >= 1
+
+
+def test_taint_flow_paths_direct_go_source_to_sink():
+    """Same granularity-bridging behavior for a non-Python language."""
+    source = (
+        "package main\n\n"
+        "import (\n"
+        '\t"os"\n'
+        '\t"os/exec"\n'
+        ")\n\n"
+        "func run() {\n"
+        "\tvar v string\n"
+        '\tv = os.Getenv("X")\n'
+        '\texec.Command("sh", "-c", v)\n'
+        "}\n"
+    )
+    cpg = _cpg(source, language="go")
+    assert taint_flow_paths(cpg) >= 1
+
+
+def test_taint_flow_paths_no_flow_when_source_and_sink_unrelated():
+    """A source and a sink with no data-dependence between them stay at 0."""
+    cpg = _cpg("def f():\n    x = input()\n    y = 1\n    eval(y)\n")
+    assert taint_flow_paths(cpg) == 0
+
+
+def test_taint_flow_paths_clean_code_has_no_flows():
+    cpg = _cpg("def f(a, b):\n    return a + b\n")
+    assert taint_flow_paths(cpg) == 0
+
+
+def test_taint_flow_paths_respects_allowlist():
+    """An allowlisted sink pattern is excluded even when a real flow exists."""
+    cpg = _cpg("def f():\n    x = input()\n    eval(x)\n")
+    assert taint_flow_paths(cpg) >= 1
+    assert taint_flow_paths(cpg, allow={"eval"}) == 0

--- a/tests/graphs/pdg/test_pdg_program_dependence.py
+++ b/tests/graphs/pdg/test_pdg_program_dependence.py
@@ -43,3 +43,39 @@ def test_pdg_emits_control_dependence_for_if_statement():
 def test_pdg_density_is_nonnegative():
     pdg = _pdg("x = 1\ny = x + 2\nz = y * 3\n")
     assert pdg.metrics()["pdg.density"] >= 0.0
+
+
+def test_pdg_emits_data_dependence_across_statements():
+    """A variable defined in one statement and used in a later one must
+    produce a DATA dependence edge.
+
+    Regression guard: ``_identifier_name`` used to fall back to each
+    identifier occurrence's own node id (unique per byte span) whenever no
+    ``name`` attribute was present — which is always, since no UAST mapper
+    sets one. Two distinct occurrences of the same variable (e.g. the def
+    in ``x = 1`` and the use in ``y = x + 2``) therefore never shared a key,
+    so ``_compute_data_dependence`` could never link them and
+    ``pdg.data_deps`` was always 0 for real code. Threading ``source``
+    through ``ProgramDependenceGraph.from_uast`` lets identifier names be
+    recovered from the actual token text, fixing this.
+    """
+    pdg = _pdg("x = 1\ny = x + 2\n")
+    data_edges = [e for e in pdg.edges if e.kind is DependenceKind.DATA]
+    assert len(data_edges) >= 1
+    assert any(e.var == "x" for e in data_edges)
+    assert pdg.metrics()["pdg.data_deps"] >= 1.0
+
+
+def test_pdg_data_dependence_without_source_falls_back_gracefully():
+    """Building a PDG directly from a UAST with no source text must not
+    crash, and simply yields no data-dependence edges (the pre-fix
+    behavior) rather than spuriously conflating identifiers."""
+    from topos.graphs.uast.mapper_python import map_python_tree_to_uast
+    from topos.utils.tree_sitter import PythonParser
+
+    root_node = PythonParser().parse("x = 1\ny = x + 2\n")
+    uast_root = map_python_tree_to_uast(root_node)
+
+    pdg = ProgramDependenceGraph.from_uast(uast_root)
+    data_edges = [e for e in pdg.edges if e.kind is DependenceKind.DATA]
+    assert data_edges == []

--- a/topos/core/morphism.py
+++ b/topos/core/morphism.py
@@ -161,7 +161,9 @@ class ProgramMorphism:
             return None
         from topos.graphs.pdg.object import ProgramDependenceGraph
 
-        self._pdg = ProgramDependenceGraph.from_uast(self.ast.uast_root)
+        self._pdg = ProgramDependenceGraph.from_uast(
+            self.ast.uast_root, source=self.source
+        )
         return self._pdg
 
     def build_cpg(self) -> CodePropertyGraph | None:

--- a/topos/functors/probes/cpg/taint.py
+++ b/topos/functors/probes/cpg/taint.py
@@ -74,6 +74,17 @@ def taint_flow_paths(cpg: CodePropertyGraph, allow: set[str] | None = None) -> i
     A DDG path here is a chain of CPG nodes connected by DDG edges; we
     count distinct ``(source_node, sink_node)`` pairs that are reachable.
 
+    DDG edges connect whole *statement* nodes (see
+    ``ProgramDependenceGraph._compute_data_dependence``), while sources and
+    sinks are detected at the finer *sub-expression* granularity (a bare
+    ``Identifier``/``MemberExpr`` for sources, a ``CallExpr`` for sinks).
+    These two id spaces essentially never intersect directly, so before
+    running BFS we bridge the gap by containment: each source/sink is
+    mapped to the smallest DDG-participating statement whose byte span
+    contains it (falling back to itself when it already *is* a
+    DDG-participating statement, keeping the flat/simple case working
+    unchanged).
+
     When *allow* is given, allowlisted sink patterns are excluded; the
     default ``allow=None`` preserves the canonical metrics behavior.
     """
@@ -86,10 +97,13 @@ def taint_flow_paths(cpg: CodePropertyGraph, allow: set[str] | None = None) -> i
     from topos.graphs.cpg.models import CPGEdgeKind
 
     forward: dict[str, list[str]] = {}
+    ddg_stmt_ids: set[str] = set()
     for edge in cpg.edges:
         if edge.kind is not CPGEdgeKind.DDG:
             continue
         forward.setdefault(edge.source, []).append(edge.target)
+        ddg_stmt_ids.add(edge.source)
+        ddg_stmt_ids.add(edge.target)
 
     if not forward:
         return 0
@@ -111,11 +125,78 @@ def taint_flow_paths(cpg: CodePropertyGraph, allow: set[str] | None = None) -> i
     if not sources or not sinks:
         return 0
 
+    # {ddg_participating_stmt_id: (start_byte, end_byte)} — built once up
+    # front so resolving each source/sink's enclosing statement is a single
+    # pass over this (typically small) set, not a scan of every CPG node.
+    ddg_spans: dict[str, tuple[int, int]] = {}
+    for stmt_id in ddg_stmt_ids:
+        stmt_node = cpg.nodes.get(stmt_id)
+        if stmt_node is not None:
+            ddg_spans[stmt_id] = (
+                stmt_node.uast.span.start_byte,
+                stmt_node.uast.span.end_byte,
+            )
+
+    effective_sources = _resolve_effective_ids(sources, cpg, ddg_spans)
+    effective_sinks = _resolve_effective_ids(sinks, cpg, ddg_spans)
+
+    if not effective_sources or not effective_sinks:
+        return 0
+
     total = 0
+    reachable_cache: dict[str, set[str]] = {}
     for src in sources:
-        reachable = _bfs_reachable(forward, src)
-        total += sum(1 for s in sinks if s in reachable)
+        eff_src = effective_sources.get(src)
+        if eff_src is None:
+            continue
+        reachable = reachable_cache.get(eff_src)
+        if reachable is None:
+            reachable = _bfs_reachable(forward, eff_src)
+            reachable_cache[eff_src] = reachable
+        for sink in sinks:
+            eff_sink = effective_sinks.get(sink)
+            if eff_sink is not None and eff_sink in reachable:
+                total += 1
     return total
+
+
+def _resolve_effective_ids(
+    candidate_ids: list[str] | set[str],
+    cpg: CodePropertyGraph,
+    ddg_spans: dict[str, tuple[int, int]],
+) -> dict[str, str]:
+    """
+    Map each source/sink node id to its "effective" DDG-graph entry point.
+
+    A candidate that already equals a DDG-participating statement id maps
+    to itself (the flat/simple case that already worked before this fix).
+    Otherwise we find the smallest DDG-participating statement span that
+    contains the candidate's span — its nearest enclosing statement — since
+    that's the node the DDG adjacency actually knows how to traverse from.
+    Ties (equal-width enclosing spans) keep the first one encountered;
+    candidates with no enclosing DDG statement (e.g. dead code sliced out
+    of the CFG) are simply omitted from the result.
+    """
+    resolved: dict[str, str] = {}
+    for nid in candidate_ids:
+        if nid in ddg_spans:
+            resolved[nid] = nid
+            continue
+        node = cpg.nodes.get(nid)
+        if node is None:
+            continue
+        start, end = node.uast.span.start_byte, node.uast.span.end_byte
+        best_id: str | None = None
+        best_width: int | None = None
+        for stmt_id, (s_start, s_end) in ddg_spans.items():
+            if s_start <= start and end <= s_end:
+                width = s_end - s_start
+                if best_width is None or width < best_width:
+                    best_width = width
+                    best_id = stmt_id
+        if best_id is not None:
+            resolved[nid] = best_id
+    return resolved
 
 
 def _bfs_reachable(adj: dict[str, list[str]], start: str) -> set[str]:

--- a/topos/graphs/cpg/builder.py
+++ b/topos/graphs/cpg/builder.py
@@ -31,15 +31,20 @@ def build_cpg(
     uast_root: UASTNode,
     cfg: ControlFlowGraph | None = None,
     pdg: ProgramDependenceGraph | None = None,
+    source: str = "",
 ) -> tuple[dict[str, CPGNode], list[CPGEdge]]:
     """Return ``(nodes, edges)`` for the CPG.
 
     Reuses pre-built CFG / PDG when supplied; otherwise builds them.
+    ``source`` (when given) is forwarded to a freshly-built PDG so its
+    data-dependence pass can recover real identifier text instead of
+    falling back to per-occurrence node ids (see
+    ``topos.graphs.pdg.object._identifier_name``).
     """
     if cfg is None:
         cfg = ControlFlowGraph.from_uast(uast_root)
     if pdg is None:
-        pdg = ProgramDependenceGraph.from_uast(uast_root)
+        pdg = ProgramDependenceGraph.from_uast(uast_root, source=source)
 
     nodes: dict[str, CPGNode] = {}
     _collect_nodes(uast_root, nodes)

--- a/topos/graphs/cpg/object.py
+++ b/topos/graphs/cpg/object.py
@@ -39,7 +39,7 @@ class CodePropertyGraph:
 
     @classmethod
     def from_uast(cls, uast_root: UASTNode, source: str = "") -> CodePropertyGraph:
-        nodes, edges = build_cpg(uast_root)
+        nodes, edges = build_cpg(uast_root, source=source)
         return cls(nodes=nodes, edges=edges, language=uast_root.lang, source=source)
 
     def node_text(self, node: CPGNode) -> str:

--- a/topos/graphs/pdg/object.py
+++ b/topos/graphs/pdg/object.py
@@ -75,15 +75,21 @@ class ProgramDependenceGraph:
         return "composable"
 
     @classmethod
-    def from_uast(cls, uast_root: UASTNode) -> ProgramDependenceGraph:
-        """Construct DDG ∪ CDG using a freshly-built CFG."""
+    def from_uast(cls, uast_root: UASTNode, source: str = "") -> ProgramDependenceGraph:
+        """Construct DDG ∪ CDG using a freshly-built CFG.
+
+        ``source`` is optional and defaults to ``""`` for backward
+        compatibility; when supplied it lets data-dependence recover real
+        identifier text (see ``_identifier_name``) instead of falling back
+        to each occurrence's own node id.
+        """
         cfg = ControlFlowGraph.from_uast(uast_root)
         statements: list[UASTNode] = []
         for block in cfg.blocks.values():
             statements.extend(block.statements)
 
         edges: list[DependenceEdge] = []
-        edges.extend(_compute_data_dependence(statements))
+        edges.extend(_compute_data_dependence(statements, source))
         edges.extend(_compute_control_dependence(cfg))
 
         return cls(statements=statements, edges=edges, cfg=cfg)
@@ -110,6 +116,7 @@ class ProgramDependenceGraph:
 
 def _compute_data_dependence(
     statements: list[UASTNode],
+    source: str = "",
 ) -> list[DependenceEdge]:
     """
     Approximate reaching-definitions data dependence.
@@ -127,7 +134,7 @@ def _compute_data_dependence(
     last_def: dict[str, str] = {}
 
     for stmt in statements:
-        defs, uses = _defs_and_uses(stmt)
+        defs, uses = _defs_and_uses(stmt, source)
         for var in uses:
             if var in last_def and last_def[var] != stmt.id:
                 edges.append(
@@ -182,7 +189,7 @@ def _compute_control_dependence(cfg: ControlFlowGraph) -> list[DependenceEdge]:
     return edges
 
 
-def _defs_and_uses(stmt: UASTNode) -> tuple[set[str], set[str]]:
+def _defs_and_uses(stmt: UASTNode, source: str = "") -> tuple[set[str], set[str]]:
     """Return ``(defs, uses)`` — variable names defined / used by ``stmt``."""
     defs: set[str] = set()
     uses: set[str] = set()
@@ -196,7 +203,7 @@ def _defs_and_uses(stmt: UASTNode) -> tuple[set[str], set[str]]:
                     walk(c, False)
             return
         if node.kind == "Identifier":
-            name = _identifier_name(node)
+            name = _identifier_name(node, source)
             if name:
                 (defs if in_lhs else uses).add(name)
             return
@@ -207,13 +214,36 @@ def _defs_and_uses(stmt: UASTNode) -> tuple[set[str], set[str]]:
     return defs, uses
 
 
-def _identifier_name(node: UASTNode) -> str:
+def _identifier_name(node: UASTNode, source: str = "") -> str:
     """Best-effort recovery of an identifier's textual name.
 
-    The UAST mappers don't currently carry token text; fall back to the
-    node id so identifiers at distinct spans aren't conflated.
+    The UAST mappers don't carry token text as an attribute, so when
+    ``source`` is available we slice the node's own byte span to recover
+    the real variable name (e.g. ``"x"``) — this is what lets two distinct
+    occurrences of the same variable be recognized as the same dependence
+    key. Without ``source`` we fall back to the node's own id, which is
+    unique per span; that keeps identifiers at distinct spans from being
+    spuriously conflated, at the cost of never matching a reused variable
+    across statements.
     """
     name_attr = node.attributes.get("name")
-    if isinstance(name_attr, str):
+    if isinstance(name_attr, str) and name_attr:
         return name_attr
+    if source:
+        text = _node_text(node, source)
+        if text:
+            return text
     return node.id or ""
+
+
+def _node_text(node: UASTNode, source: str) -> str:
+    """Slice ``source`` by ``node``'s byte span (best-effort)."""
+    span = node.span
+    encoded = source.encode("utf-8")
+    if span.start_byte < 0 or span.end_byte > len(encoded):
+        return ""
+    return (
+        encoded[span.start_byte : span.end_byte]
+        .decode("utf-8", errors="replace")
+        .strip()
+    )


### PR DESCRIPTION
## Summary

Fixes #154 — `taint_flow_paths` built DDG adjacency from `topos/graphs/pdg/object.py`'s statement-level `DependenceEdge`s, but detected sources/sinks at sub-expression granularity (a bare `Identifier`/`MemberExpr` for sources, a `CallExpr` for sinks). These two id spaces essentially never intersected, so even the issue's textbook case:

```python
def f():
    x = input()
    eval(x)
```

returned `0` taint flows instead of `1`.

- `taint_flow_paths` (`topos/functors/probes/cpg/taint.py`) now bridges the gap by **containment**: each detected source/sink resolves to the smallest DDG-participating statement whose byte span contains it (falling back to itself when it already *is* a DDG-participating statement, so previously-working flat cases are unchanged). This is a single up-front pass building `{ddg_stmt_id: span}`, then one pass per source/sink to find its nearest enclosing statement — not an O(nodes × ddg_endpoints) scan.
- Per the issue's own guidance, this stays scoped to the taint probe: `_compute_data_dependence`, `DependenceEdge`, and the statement-granularity DDG model in `topos/graphs/pdg/object.py` are untouched. No PDG redesign.

### A necessary prerequisite bug found while reproducing end-to-end

Reproducing the issue's exact snippet initially still returned `0` even with the containment fix, because **no `DATA` dependence edge was ever produced at all** for `x = input(); eval(x)` — a separate, deeper bug from the one described in the issue. `_identifier_name` (`topos/graphs/pdg/object.py`) fell back to each `Identifier` occurrence's own node id whenever no `"name"` attribute was present — which is always, since no UAST mapper populates one. Since a node's id is a hash of `(lang, kind, start_byte, end_byte, parent_id)`, the two distinct occurrences of `x` (the def in `x = input()` and the use in `eval(x)`) never shared a key, so `_compute_data_dependence`'s `last_def` bookkeeping could never link them. This affected every language, not just Python (confirmed with `x = 1\ny = x + 2\n` producing 0 `pdg.data_deps` before this fix).

Since the granularity-bridging fix has nothing to bridge without a real DDG edge to begin with, I threaded an optional `source: str = ""` parameter through `ProgramDependenceGraph.from_uast` (and its two call sites: `topos/graphs/cpg/builder.py::build_cpg` and `topos/core/morphism.py::build_pdg`), so `_identifier_name` can recover real token text via span-slicing (mirroring the existing `CodePropertyGraph.node_text` pattern) instead of relying on the id fallback. When no source is given, behavior is unchanged (verified with a dedicated regression test). This is a minimal, additive change — no changes to `_compute_data_dependence`'s statement-walking algorithm, `DependenceEdge`, or the overall DDG/CDG model.

## Test plan

- [x] New `tests/functors/probes/cpg/test_taint.py`:
  - `test_taint_flow_paths_direct_python_source_to_sink` — issue #154's exact repro, end-to-end (parse → UAST → CFG → PDG → CPG → `taint_flow_paths` >= 1).
  - `test_taint_flow_paths_direct_go_source_to_sink` — same granularity fix for a non-Python language (`os.Getenv` → `exec.Command`).
  - `test_taint_flow_paths_no_flow_when_source_and_sink_unrelated` — a source and sink with no real data dependence between them still count 0.
  - `test_taint_flow_paths_clean_code_has_no_flows`
  - `test_taint_flow_paths_respects_allowlist`
- [x] New tests in `tests/graphs/pdg/test_pdg_program_dependence.py`:
  - `test_pdg_emits_data_dependence_across_statements` — guards the identifier-name prerequisite fix.
  - `test_pdg_data_dependence_without_source_falls_back_gracefully` — confirms the no-`source` path is unchanged (no data-dependence edges, no crash) for direct `ProgramDependenceGraph.from_uast` callers that don't pass source.
- [x] Existing security/CPG/PDG tests unaffected — checked `tests/graphs/cpg/test_cpg.py`, `tests/graphs/pdg/test_pdg_program_dependence.py`, `tests/evaluation/test_suppression.py`, `tests/mcp/test_evaluate.py`, `tests/evaluation/test_gate_parity.py` for any hardcoded exact `cpg.taint_flows`/`pdg.data_deps` counts derived from real code (none found — all such assertions build `ClassificationResult`/scoring inputs manually, or only check dangerous-call counts which this change doesn't touch).
- [x] Full `pytest`: 678 passed, 10 skipped.
- [x] `ruff check` and `ruff format --check`: clean.
- [x] Confirmed no Rust duplicate: `crates/topos-core/src/functors/probes/cpg/taint.rs` mentioned in the issue does not exist on `main` (it's from an unrelated draft migration branch) — nothing to touch there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
