### PR TITLE
fix: branch-aware .gitnexus store resolution

### DIFF
--- a/tests/functors/probes/mdg/test_pdg_metrics.py
+++ b/tests/functors/probes/mdg/test_pdg_metrics.py
@@ -503,6 +503,134 @@ def test_from_gitnexus_dir_missing_lbug_raises():
         ModuleDependencyGraph.from_gitnexus_dir(tmp, target_file="x.py")
 
 
+# ---------------------------------------------------------------------------
+# from_gitnexus_dir — branch-scoped stores (GitNexus writes
+# .gitnexus/branches/<branch>-<hash>/lbug instead of updating the flat slot
+# once a second branch is analyzed; see topos.utils.gitnexus.resolve_lbug_store)
+# ---------------------------------------------------------------------------
+
+
+def _write_git_head(project_root: Path, branch: str | None) -> None:
+    git_dir = project_root / ".git"
+    git_dir.mkdir(parents=True, exist_ok=True)
+    if branch is None:
+        (git_dir / "HEAD").write_text("deadbeef" * 5, encoding="utf-8")  # detached
+    else:
+        (git_dir / "HEAD").write_text(f"ref: refs/heads/{branch}\n", encoding="utf-8")
+
+
+def _write_meta(store_dir: Path, *, branch: str) -> None:
+    (store_dir / "meta.json").write_text(
+        json.dumps({"branch": branch, "lastCommit": "abc123"}), encoding="utf-8"
+    )
+
+
+def test_from_gitnexus_dir_uses_branch_scoped_store_over_stale_flat():
+    """The literal bug from the report: flat holds main's stale data, a
+    branches/feature-x-* store holds feature-x's data, HEAD is on feature-x
+    -> must load feature-x's data, not main's."""
+    with tempfile.TemporaryDirectory() as tmp:
+        project_root = Path(tmp)
+        gitnexus_dir = project_root / ".gitnexus"
+        _write_git_head(project_root, "feature-x")
+
+        # Flat slot: main's (stale) data.
+        _write_lbug_dir(
+            gitnexus_dir,
+            [
+                {
+                    "id": "File:main.py",
+                    "label": "File",
+                    "properties": {"filePath": "main.py"},
+                }
+            ],
+        )
+        _write_meta(gitnexus_dir, branch="main")
+
+        # branches/feature-x-<hash>/: feature-x's data.
+        branch_dir = gitnexus_dir / "branches" / "feature-x-deadbeef"
+        _write_lbug_dir(
+            branch_dir,
+            [
+                {
+                    "id": "File:feature.py",
+                    "label": "File",
+                    "properties": {"filePath": "feature.py"},
+                }
+            ],
+        )
+        _write_meta(branch_dir, branch="feature-x")
+
+        g = ModuleDependencyGraph.from_gitnexus_dir(
+            gitnexus_dir, target_file="feature.py"
+        )
+
+    assert g.get_node("File:feature.py") is not None
+    assert g.get_node("File:main.py") is None
+
+
+def test_from_gitnexus_dir_branch_not_indexed_raises_branch_mismatch_error():
+    from topos.graphs.mdg.object import LadybugBranchMismatchError
+
+    with tempfile.TemporaryDirectory() as tmp:
+        project_root = Path(tmp)
+        gitnexus_dir = project_root / ".gitnexus"
+        _write_git_head(project_root, "feature-y")
+
+        _write_lbug_dir(
+            gitnexus_dir,
+            [
+                {
+                    "id": "File:main.py",
+                    "label": "File",
+                    "properties": {"filePath": "main.py"},
+                }
+            ],
+        )
+        _write_meta(gitnexus_dir, branch="main")
+
+        with pytest.raises(LadybugBranchMismatchError, match="feature-y"):
+            ModuleDependencyGraph.from_gitnexus_dir(gitnexus_dir, target_file="x.py")
+
+
+def test_from_gitnexus_dir_detached_head_uses_flat_unconditionally():
+    """A detached HEAD has no branch identity to match -- fall back to the
+    flat slot even when other branch-scoped stores exist."""
+    with tempfile.TemporaryDirectory() as tmp:
+        project_root = Path(tmp)
+        gitnexus_dir = project_root / ".gitnexus"
+        _write_git_head(project_root, None)  # detached
+
+        _write_lbug_dir(
+            gitnexus_dir,
+            [
+                {
+                    "id": "File:main.py",
+                    "label": "File",
+                    "properties": {"filePath": "main.py"},
+                }
+            ],
+        )
+        _write_meta(gitnexus_dir, branch="main")
+
+        branch_dir = gitnexus_dir / "branches" / "feature-x-deadbeef"
+        _write_lbug_dir(
+            branch_dir,
+            [
+                {
+                    "id": "File:feature.py",
+                    "label": "File",
+                    "properties": {"filePath": "feature.py"},
+                }
+            ],
+        )
+        _write_meta(branch_dir, branch="feature-x")
+
+        g = ModuleDependencyGraph.from_gitnexus_dir(gitnexus_dir, target_file="main.py")
+
+    assert g.get_node("File:main.py") is not None
+
+
 def test_from_gitnexus_dir_list_format_auto_id():
     """Relationships without an explicit id get an auto-generated id."""
     items = [

--- a/tests/graphs/process/test_process_graph.py
+++ b/tests/graphs/process/test_process_graph.py
@@ -1,5 +1,9 @@
 """Tests for the ProcessGraph representation (issue #86)."""
 
+import json
+import tempfile
+from pathlib import Path
+
 from topos.graphs.mdg.object import GraphNode, GraphRelationship, ModuleDependencyGraph
 from topos.graphs.process.object import ProcessGraph
 
@@ -119,3 +123,62 @@ def test_no_process_nodes_yields_empty_paths():
     graph = ProcessGraph.from_mdg(mdg, "f.py")
     assert graph.paths == []
     assert graph.edges() == []
+
+
+
+def test_from_gitnexus_dir_delegates_to_branch_aware_mdg_resolution():
+    """ProcessGraph.from_gitnexus_dir just wraps
+    ModuleDependencyGraph.from_gitnexus_dir + from_mdg -- confirm the
+    delegation actually resolves a branch-scoped store correctly (not just
+    that it forwards the call), rather than re-deriving the resolver's own
+    unit tests here."""
+    with tempfile.TemporaryDirectory() as tmp:
+        project_root = Path(tmp)
+        gitnexus_dir = project_root / ".gitnexus"
+
+        git_dir = project_root / ".git"
+        git_dir.mkdir()
+        (git_dir / "HEAD").write_text("ref: refs/heads/feature-x\n", encoding="utf-8")
+
+        flat_lbug = gitnexus_dir / "lbug"
+        flat_lbug.mkdir(parents=True)
+        (flat_lbug / "graph.json").write_text(
+            json.dumps(
+                [
+                    {
+                        "id": "File:main.py",
+                        "label": "File",
+                        "properties": {"filePath": "main.py"},
+                    }
+                ]
+            ),
+            encoding="utf-8",
+        )
+        (gitnexus_dir / "meta.json").write_text(
+            json.dumps({"branch": "main"}), encoding="utf-8"
+        )
+
+        branch_dir = gitnexus_dir / "branches" / "feature-x-deadbeef"
+        branch_lbug = branch_dir / "lbug"
+        branch_lbug.mkdir(parents=True)
+        (branch_lbug / "graph.json").write_text(
+            json.dumps(
+                [
+                    {
+                        "id": "File:feature.py",
+                        "label": "File",
+                        "properties": {"filePath": "feature.py"},
+                    }
+                ]
+            ),
+            encoding="utf-8",
+        )
+        (branch_dir / "meta.json").write_text(
+            json.dumps({"branch": "feature-x"}), encoding="utf-8"
+        )
+
+        pg = ProcessGraph.from_gitnexus_dir(gitnexus_dir, target_file="feature.py")
+
+    assert pg._mdg is not None
+    assert pg._mdg.get_node("File:feature.py") is not None
+    assert pg._mdg.get_node("File:main.py") is None

--- a/tests/mcp/test_depgraph.py
+++ b/tests/mcp/test_depgraph.py
@@ -12,6 +12,7 @@ import pytest
 from topos.core.omega import EvaluationValue
 from topos.evaluation.characteristic_morphism import ClassificationResult
 from topos.evaluation.policies.base import Priority
+from topos.mcp.cache import clear_caches, dep_graph_for
 from topos.mcp.evaluation import (
     STALE_GITNEXUS_MARKER,
     DepgraphStatus,
@@ -82,6 +83,14 @@ def test_status_missing_points_to_generate(tmp_path, monkeypatch) -> None:
         # An invalid override must NOT route to generation (a bad path won't be
         # fixed by regenerating); next_tool is None so the agent fixes the path.
         (DepgraphState.INVALID_DIR, ["invalid_gitnexus_dir"], False, None),
+        # A branch with no indexed store (others may be indexed) routes to
+        # generation, same shape as MISSING/STALE.
+        (
+            DepgraphState.BRANCH_NOT_INDEXED,
+            ["branch_not_indexed_gitnexus_dir"],
+            False,
+            "topos_generate_depgraph",
+        ),
     ],
 )
 def test_status_maps_each_state(
@@ -733,3 +742,159 @@ def test_generate_ensure_regenerates_after_in_place_edit(tmp_path, monkeypatch) 
     assert r.ok is True
     assert r.generated is True
     assert r.state_before == DepgraphState.STALE
+
+
+
+def _checkout_branch(root, name: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(root), "checkout", "-b", name],
+        check=True,
+        capture_output=True,
+    )
+
+
+def _rename_branch(root, name: str) -> None:
+    """Deterministically name the current branch, independent of the
+    system's init.defaultBranch config (main vs master vs anything else)."""
+    subprocess.run(
+        ["git", "-C", str(root), "branch", "-m", name],
+        check=True,
+        capture_output=True,
+    )
+
+
+def _write_meta(store_dir: Path, *, branch: str) -> None:
+    store_dir.mkdir(parents=True, exist_ok=True)
+    (store_dir / "meta.json").write_text(
+        json.dumps({"branch": branch, "lastCommit": "abc123"}), encoding="utf-8"
+    )
+
+
+def test_generate_runs_once_when_branch_not_indexed(tmp_path, monkeypatch) -> None:
+    _use_root(tmp_path, monkeypatch)
+    gitnexus = tmp_path / ".gitnexus"
+    calls = []
+
+    def fake_generate(d):
+        calls.append(d)
+        return DepgraphGenerationResult(True, 0, gitnexus, "done")
+
+    def fake_status(_override, _project_root, _target_file):
+        return DepgraphStatus(
+            state=DepgraphState.BRANCH_NOT_INDEXED.value,
+            gitnexus_dir=str(gitnexus),
+            gitnexus_mtime=1.0,
+            git_head_mtime=2.0,
+            detail="no gitnexus store indexed for branch 'feature-x'",
+        )
+
+    monkeypatch.setattr(depgraph_tool, "depgraph_status", fake_status)
+    monkeypatch.setattr(depgraph_tool, "generate_depgraph", fake_generate)
+
+    r = _generate(topos_generate_depgraph(GenerateDepgraphInput()))
+
+    assert calls == [tmp_path]
+    assert r.ok is True
+    assert r.generated is True
+    assert r.state_before == DepgraphState.BRANCH_NOT_INDEXED
+    assert r.agent_contract.next_tool == "topos_evaluate_file"
+
+
+def test_depgraph_status_detects_branch_not_indexed_end_to_end(tmp_path) -> None:
+    """Real depgraph_status() (no monkeypatching of the function itself):
+    flat store belongs to 'main', current branch is 'feature-x', no
+    branches/* store exists for it -> state must be branch_not_indexed, not
+    a generic load_error."""
+    from topos.mcp.evaluation import depgraph_status
+
+    _commit_repo(tmp_path)
+    _checkout_branch(tmp_path, "feature-x")
+    gitnexus = _graph_dir(tmp_path, fingerprint=None)
+    _write_meta(gitnexus, branch="main")
+
+    status = depgraph_status(None, tmp_path, "f.py")
+    assert status.state == "branch_not_indexed"
+    assert "feature-x" in status.detail
+
+
+def test_graph_freshness_uses_resolved_branch_store_not_stale_flat(tmp_path) -> None:
+    """The fingerprint-desync bug: flat slot (main) carries a fingerprint that
+    would read as STALE if consulted; the branches/feature-x store (current
+    branch) carries a fingerprint that matches HEAD. _graph_freshness must
+    resolve to the branch store, not the flat one."""
+    head = _commit_repo(tmp_path)
+    _checkout_branch(tmp_path, "feature-x")
+
+    gitnexus = tmp_path / ".gitnexus"
+    gitnexus.mkdir()
+    flat_lbug = gitnexus / "lbug"
+    flat_lbug.write_text("", encoding="utf-8")
+    _write_meta(gitnexus, branch="main")
+    (gitnexus / GITNEXUS_FINGERPRINT_FILE).write_text(
+        json.dumps({"head_sha": "0" * 40}), encoding="utf-8"  # would read stale
+    )
+
+    branch_dir = gitnexus / "branches" / "feature-x-deadbeef"
+    branch_dir.mkdir(parents=True)
+    (branch_dir / "lbug").write_text("", encoding="utf-8")
+    _write_meta(branch_dir, branch="feature-x")
+    (branch_dir / GITNEXUS_FINGERPRINT_FILE).write_text(
+        json.dumps({"head_sha": head}), encoding="utf-8"  # matches current HEAD
+    )
+
+    is_stale, detail = _graph_freshness(tmp_path, gitnexus)
+    assert is_stale is False
+    assert detail is None
+
+
+def _write_json_lbug(store_dir: Path, *, file_path: str) -> None:
+    lbug = store_dir / "lbug"
+    lbug.mkdir(parents=True, exist_ok=True)
+    (lbug / "graph.json").write_text(
+        json.dumps(
+            [
+                {
+                    "id": f"File:{file_path}",
+                    "label": "File",
+                    "properties": {"filePath": file_path},
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_dep_graph_for_cache_key_includes_branch_not_just_mtime(tmp_path) -> None:
+    """Two branch-scoped stores sharing an identical mtime (coarse filesystem
+    resolution, or a same-second CI run) must not collide in the cache --
+    the branch itself has to be part of the key, not just the mtime."""
+    clear_caches()
+    _commit_repo(tmp_path)
+    _rename_branch(tmp_path, "main")  # deterministic, regardless of system default
+    gitnexus = tmp_path / ".gitnexus"
+
+    main_dir = gitnexus / "branches" / "main-aaa"
+    _write_json_lbug(main_dir, file_path="main.py")
+    _write_meta(main_dir, branch="main")
+
+    feature_dir = gitnexus / "branches" / "feature-x-bbb"
+    _write_json_lbug(feature_dir, file_path="feature.py")
+    _write_meta(feature_dir, branch="feature-x")
+
+    same_time = 12345.0
+    os.utime(main_dir / "lbug", (same_time, same_time))
+    os.utime(feature_dir / "lbug", (same_time, same_time))
+
+    _checkout_branch(tmp_path, "feature-x")
+    on_feature = dep_graph_for(gitnexus, "feature.py")
+    assert on_feature.get_node("File:feature.py") is not None
+    assert on_feature.get_node("File:main.py") is None
+
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "checkout", "main"],
+        check=True,
+        capture_output=True,
+    )
+    on_main = dep_graph_for(gitnexus, "main.py")
+    assert on_main.get_node("File:main.py") is not None
+    assert on_main.get_node("File:feature.py") is None

--- a/tests/utils/test_gitnexus.py
+++ b/tests/utils/test_gitnexus.py
@@ -12,7 +12,9 @@ from topos.utils.gitnexus import (
     DEFAULT_ANALYZE_TIMEOUT_S,
     GITNEXUS_FINGERPRINT_FILE,
     _resolve_timeout,
+    current_git_branch,
     generate_depgraph,
+    resolve_lbug_store,
     source_fingerprint,
 )
 
@@ -192,3 +194,164 @@ def test_generate_skips_unreadable_source_dirs(
     payload = json.loads(marker.read_text(encoding="utf-8"))
     assert payload["source_file_count"] == 1
     assert payload["source_hash"] == source_fingerprint(tmp_path).content_hash
+
+
+
+def _checkout_branch(root: Path, name: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(root), "checkout", "-b", name],
+        check=True,
+        capture_output=True,
+    )
+
+
+def _write_meta(store_dir: Path, *, branch: str, last_commit: str = "abc123") -> None:
+    store_dir.mkdir(parents=True, exist_ok=True)
+    (store_dir / "meta.json").write_text(
+        json.dumps({"branch": branch, "lastCommit": last_commit}), encoding="utf-8"
+    )
+
+
+def _write_flat_store(gitnexus_dir: Path, *, branch: str | None) -> Path:
+    gitnexus_dir.mkdir(parents=True, exist_ok=True)
+    lbug = gitnexus_dir / "lbug"
+    lbug.write_bytes(b"\x00")
+    if branch is not None:
+        _write_meta(gitnexus_dir, branch=branch)
+    return lbug
+
+
+def _write_branch_store(
+    gitnexus_dir: Path, *, branch: str, suffix: str = "deadbeef"
+) -> Path:
+    store_dir = gitnexus_dir / "branches" / f"{branch}-{suffix}"
+    store_dir.mkdir(parents=True, exist_ok=True)
+    lbug = store_dir / "lbug"
+    lbug.write_bytes(b"\x00")
+    _write_meta(store_dir, branch=branch)
+    return lbug
+
+
+# ---------------------------------------------------------------------------
+# current_git_branch
+# ---------------------------------------------------------------------------
+
+
+def test_current_git_branch_reads_symbolic_ref(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    _checkout_branch(tmp_path, "feature-x")
+    assert current_git_branch(tmp_path) == "feature-x"
+
+
+def test_current_git_branch_none_for_detached_head(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    head_sha = subprocess.run(
+        ["git", "-C", str(tmp_path), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "checkout", head_sha],
+        check=True,
+        capture_output=True,
+    )
+    assert current_git_branch(tmp_path) is None
+
+
+def test_current_git_branch_none_without_git_dir(tmp_path: Path) -> None:
+    assert current_git_branch(tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# resolve_lbug_store
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_lbug_store_flat_matches_current_branch(tmp_path: Path) -> None:
+    gitnexus_dir = tmp_path / ".gitnexus"
+    flat = _write_flat_store(gitnexus_dir, branch="main")
+    resolved = resolve_lbug_store(gitnexus_dir, "main")
+    assert resolved.path == flat
+    assert resolved.matched_branch == "main"
+
+
+def test_resolve_lbug_store_prefers_branch_dir_over_wrong_flat(tmp_path: Path) -> None:
+    gitnexus_dir = tmp_path / ".gitnexus"
+    _write_flat_store(gitnexus_dir, branch="main")
+    branch_lbug = _write_branch_store(gitnexus_dir, branch="feature-x")
+    resolved = resolve_lbug_store(gitnexus_dir, "feature-x")
+    assert resolved.path == branch_lbug
+    assert resolved.matched_branch == "feature-x"
+
+
+def test_resolve_lbug_store_no_match_reports_available_branches(tmp_path: Path) -> None:
+    gitnexus_dir = tmp_path / ".gitnexus"
+    _write_flat_store(gitnexus_dir, branch="main")
+    _write_branch_store(gitnexus_dir, branch="feature-x")
+    resolved = resolve_lbug_store(gitnexus_dir, "feature-y")
+    assert resolved.path is None
+    assert resolved.available_branches == ("feature-x", "main")
+
+
+def test_resolve_lbug_store_none_branch_uses_flat_unconditionally(
+    tmp_path: Path,
+) -> None:
+    gitnexus_dir = tmp_path / ".gitnexus"
+    flat = _write_flat_store(gitnexus_dir, branch="main")
+    _write_branch_store(gitnexus_dir, branch="feature-x")
+    resolved = resolve_lbug_store(gitnexus_dir, None)
+    assert resolved.path == flat
+
+
+def test_resolve_lbug_store_legacy_flat_with_no_meta_used_unconditionally(
+    tmp_path: Path,
+) -> None:
+    gitnexus_dir = tmp_path / ".gitnexus"
+    flat = _write_flat_store(gitnexus_dir, branch=None)  # no meta.json at all
+    resolved = resolve_lbug_store(gitnexus_dir, "feature-x")
+    assert resolved.path == flat
+
+
+def test_resolve_lbug_store_missing_gitnexus_dir(tmp_path: Path) -> None:
+    resolved = resolve_lbug_store(tmp_path / ".gitnexus", "main")
+    assert resolved.path is None
+    assert resolved.available_branches == ()
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint colocation (the false-negative regression from the bug report)
+# ---------------------------------------------------------------------------
+
+
+def test_generate_writes_fingerprint_beside_resolved_branch_store(
+    tmp_path: Path,
+) -> None:
+    _init_repo(tmp_path)
+    _checkout_branch(tmp_path, "feature-x")
+    gitnexus_dir = tmp_path / ".gitnexus"
+    # Flat slot already belongs to another branch (main) with its own stale
+    # fingerprint; a branch-scoped store for feature-x already exists (as if
+    # GitNexus had just written it) but has no fingerprint yet.
+    _write_flat_store(gitnexus_dir, branch="main")
+    (gitnexus_dir / GITNEXUS_FINGERPRINT_FILE).write_text(
+        json.dumps({"head_sha": "stale-main-sha"}), encoding="utf-8"
+    )
+    branch_lbug = _write_branch_store(gitnexus_dir, branch="feature-x")
+
+    with (
+        patch("topos.utils.gitnexus.gitnexus_available", return_value=True),
+        patch("subprocess.run", side_effect=_fake_analyze),
+    ):
+        result = generate_depgraph(tmp_path)
+
+    assert result.ok is True
+    branch_fingerprint = branch_lbug.parent / GITNEXUS_FINGERPRINT_FILE
+    assert branch_fingerprint.exists()
+    payload = json.loads(branch_fingerprint.read_text(encoding="utf-8"))
+    assert payload["head_sha"] is not None
+    # The flat slot's fingerprint must be left untouched (still main's stale sha).
+    flat_payload = json.loads(
+        (gitnexus_dir / GITNEXUS_FINGERPRINT_FILE).read_text(encoding="utf-8")
+    )
+    assert flat_payload["head_sha"] == "stale-main-sha"

--- a/topos/graphs/mdg/object.py
+++ b/topos/graphs/mdg/object.py
@@ -71,6 +71,17 @@ class LadybugSchemaMismatchError(RuntimeError):
         self.original = original
 
 
+class LadybugBranchMismatchError(FileNotFoundError):
+    """Raised when ``.gitnexus`` has indexed stores, but none for the current branch.
+
+    Subclasses ``FileNotFoundError`` (same trick ``LadybugSchemaMismatchError``
+    plays on ``RuntimeError``) so every existing ``except FileNotFoundError``
+    elsewhere in the codebase keeps degrading gracefully with no further
+    changes -- this only needs special-casing where a *better* message/state
+    is wanted, not everywhere graceful degradation already happens.
+    """
+
+
 def _is_shadow_replay_error(exc: BaseException) -> bool:
     """Whether *exc* is Ladybug refusing to replay shadow pages read-only.
 
@@ -218,8 +229,26 @@ class ModuleDependencyGraph:
             ImportError: If ``ladybug`` is not installed for binary format.
             LadybugSchemaMismatchError: If the store version exceeds embedded ladybug.
         """
+        from topos.utils.gitnexus import current_git_branch, resolve_lbug_store
+
         base = Path(gitnexus_dir)
-        lbug_path = base / "lbug"
+        branch = current_git_branch(base.parent)
+        resolved = resolve_lbug_store(base, branch)
+        lbug_path = resolved.path
+
+        if lbug_path is None:
+            if resolved.available_branches:
+                raise LadybugBranchMismatchError(
+                    f"No GitNexus store indexed for branch {branch!r} at {base}. "
+                    f"Indexed branches: {', '.join(resolved.available_branches)}. "
+                    "Run 'gitnexus analyze' on this branch (or 'topos depgraph "
+                    "generate') to index it."
+                )
+            raise FileNotFoundError(
+                f"LadybugDB store not found at {base / 'lbug'}. "
+                "Install GitNexus (npm install -g gitnexus) and run "
+                "'gitnexus analyze' in the repository root first."
+            )
 
         if lbug_path.is_file():
             return cls._from_ladybugdb(lbug_path, target_file)

--- a/topos/mcp/cache.py
+++ b/topos/mcp/cache.py
@@ -17,13 +17,18 @@ from functools import lru_cache
 from pathlib import Path
 
 from topos.graphs.mdg.object import ModuleDependencyGraph
+from topos.utils.gitnexus import current_git_branch, resolve_lbug_store
 
 
-def _gitnexus_mtime(gitnexus_dir: Path) -> float:
+def _gitnexus_mtime(gitnexus_dir: Path, current_branch: str | None) -> float:
     """Cheap mtime signal for the gitnexus snapshot, used as a cache key.
 
     Invalidation key component for ``dep_graph_for``: when GitNexus re-runs it
     rewrites the ``lbug`` store, bumping this mtime and busting the cache.
+    ``current_branch`` picks the *right* store to stat (see
+    ``resolve_lbug_store``) — a repo with multiple branch-scoped stores must
+    not report the flat slot's mtime while actually loading a
+    ``branches/*`` store, or vice versa.
 
     Resolution by snapshot format (see ``ModuleDependencyGraph.from_gitnexus_dir``):
     - Binary LadybugDB (``lbug`` is a file, GitNexus >= 1.5): the file's mtime is
@@ -37,11 +42,12 @@ def _gitnexus_mtime(gitnexus_dir: Path) -> float:
       regenerated wholesale (dir mtime bumps) in practice. Full implementation if
       this ever bites: hash every ``lbug/*.json`` file (sha256 of the bytes)
       and fold the digest into the key instead of the dir mtime.
-    - No ``lbug`` yet: fall back to the gitnexus dir's own mtime.
+    - No matching store yet: fall back to the gitnexus dir's own mtime.
     """
-    lbug = gitnexus_dir / "lbug"
+    resolved = resolve_lbug_store(gitnexus_dir, current_branch)
+    lbug = resolved.path
     try:
-        if lbug.exists():
+        if lbug is not None and lbug.exists():
             return lbug.stat().st_mtime
         return gitnexus_dir.stat().st_mtime
     except OSError:
@@ -50,9 +56,19 @@ def _gitnexus_mtime(gitnexus_dir: Path) -> float:
 
 @lru_cache(maxsize=32)
 def _cached_dep_graph(
-    gitnexus_dir_str: str, target_file: str, _mtime_for_key: float
+    gitnexus_dir_str: str,
+    target_file: str,
+    current_branch: str | None,
+    _mtime_for_key: float,
 ) -> ModuleDependencyGraph:
-    """Inner cached loader. ``_mtime_for_key`` is part of the cache key only."""
+    """Inner cached loader. ``_mtime_for_key`` is part of the cache key only.
+
+    ``current_branch`` is also part of the key (not just an input to the
+    mtime computed by the caller): two branch-scoped stores could share an
+    mtime on a coarse-resolution filesystem or a same-second CI run, and
+    without the branch itself in the key that collision would silently
+    serve the wrong cached graph even with a correct mtime source.
+    """
     del _mtime_for_key  # in key for invalidation; not used in body
     return ModuleDependencyGraph.from_gitnexus_dir(gitnexus_dir_str, target_file)
 
@@ -60,8 +76,9 @@ def _cached_dep_graph(
 def dep_graph_for(gitnexus_dir: Path, target_file: str) -> ModuleDependencyGraph:
     """Return a cached ``ModuleDependencyGraph`` for the given gitnexus dir + file."""
     gitnexus_dir = Path(gitnexus_dir).resolve()
-    mtime = _gitnexus_mtime(gitnexus_dir)
-    return _cached_dep_graph(str(gitnexus_dir), target_file, mtime)
+    branch = current_git_branch(gitnexus_dir.parent)
+    mtime = _gitnexus_mtime(gitnexus_dir, branch)
+    return _cached_dep_graph(str(gitnexus_dir), target_file, branch, mtime)
 
 
 def clear_caches() -> None:

--- a/topos/mcp/evaluation.py
+++ b/topos/mcp/evaluation.py
@@ -28,10 +28,19 @@ from topos.evaluation.characteristic_morphism import (
 )
 from topos.evaluation.policies.base import Priority
 from topos.graphs.base import Representation
-from topos.graphs.mdg.object import LadybugSchemaMismatchError, ModuleDependencyGraph
-from topos.utils.gitnexus import GITNEXUS_FINGERPRINT_FILE, source_fingerprint
+from topos.graphs.mdg.object import (
+    LadybugBranchMismatchError,
+    LadybugSchemaMismatchError,
+    ModuleDependencyGraph,
+)
+from topos.utils.gitnexus import (
+    GITNEXUS_FINGERPRINT_FILE,
+    current_git_branch,
+    resolve_lbug_store,
+    source_fingerprint,
+)
 
-from .cache import dep_graph_for
+from .cache import _gitnexus_mtime, dep_graph_for
 
 # Debug-only: which freshness method decided a verdict, and the calibration
 # internals in _newer_source_file. Never rises above DEBUG — this exists so a
@@ -109,10 +118,22 @@ def _is_schema_mismatch(message: str | None) -> bool:
     )
 
 
+BRANCH_NOT_INDEXED_MARKER = "no gitnexus store indexed for branch"
+
+
+def _is_branch_not_indexed(message: str | None) -> bool:
+    """Whether a dep-graph load error is LadybugBranchMismatchError's message."""
+    if not message:
+        return False
+    return BRANCH_NOT_INDEXED_MARKER in message.lower()
+
+
 def _dep_graph_load_warning(gitnexus_dir: Path, dep_graph_loaded: bool) -> list[str]:
     if dep_graph_loaded:
         return []
     load_error = last_dep_graph_error()
+    if _is_branch_not_indexed(load_error):
+        return [f"COMPOSABLE not scored — {load_error}"]
     is_schema_mismatch = _is_schema_mismatch(load_error)
     if is_schema_mismatch:
         return [
@@ -303,7 +324,11 @@ def _graph_freshness(project_root: Path, gitnexus_dir: Path) -> tuple[bool, str 
     Graphs from before the fingerprint marker fall back to comparing the
     graph DB mtime to the latest commit's mtime. Returns ``(is_stale, detail)``.
     """
-    fingerprint = _read_graph_fingerprint(gitnexus_dir)
+    branch = current_git_branch(project_root)
+    resolved = resolve_lbug_store(gitnexus_dir, branch)
+    store_dir = resolved.path.parent if resolved.path is not None else gitnexus_dir
+
+    fingerprint = _read_graph_fingerprint(store_dir)
     if fingerprint is not None and fingerprint.source_hash is not None:
         current = source_fingerprint(project_root)
         is_stale = current.content_hash != fingerprint.source_hash
@@ -328,7 +353,7 @@ def _graph_freshness(project_root: Path, gitnexus_dir: Path) -> tuple[bool, str 
         )
 
     if fingerprint is not None and fingerprint.generated_at is not None:
-        fingerprint_file = gitnexus_dir / GITNEXUS_FINGERPRINT_FILE
+        fingerprint_file = store_dir / GITNEXUS_FINGERPRINT_FILE
         fingerprint_mtime = None
         if fingerprint_file.exists():
             with contextlib.suppress(OSError):
@@ -362,7 +387,7 @@ def _graph_freshness(project_root: Path, gitnexus_dir: Path) -> tuple[bool, str 
 
     # Legacy fallback: no fingerprint marker (or HEAD unresolvable) — compare the
     # graph DB mtime to the latest commit's mtime.
-    graph_mtime = _gitnexus_mtime(gitnexus_dir)
+    graph_mtime = _gitnexus_mtime(gitnexus_dir, branch)
     head_mtime = _git_head_mtime(project_root)
     if graph_mtime <= 0 or head_mtime is None:
         _logger.debug("depgraph freshness: method=legacy_dir_mtime unavailable")
@@ -441,16 +466,6 @@ def _git_head_sha(project_root: Path) -> str | None:
         return _packed_ref_sha(git_dir, ref)
 
 
-def _gitnexus_mtime(gitnexus_dir: Path) -> float:
-    lbug = gitnexus_dir / "lbug"
-    try:
-        if lbug.exists():
-            return lbug.stat().st_mtime
-        return gitnexus_dir.stat().st_mtime
-    except OSError:
-        return 0.0
-
-
 @dataclass(frozen=True)
 class DepgraphStatus:
     """Structured ``.gitnexus`` state for the depgraph status MCP tool."""
@@ -486,7 +501,8 @@ def depgraph_status(
             detail="No .gitnexus directory found; run topos_generate_depgraph.",
         )
 
-    graph_mtime = _gitnexus_mtime(gitnexus_dir)
+    branch = current_git_branch(project_root)
+    graph_mtime = _gitnexus_mtime(gitnexus_dir, branch)
     head_mtime = _git_head_mtime(project_root)
     dir_str = str(gitnexus_dir)
 
@@ -495,7 +511,12 @@ def depgraph_status(
         dep_graph_for(gitnexus_dir, target_file)
     except Exception as exc:  # noqa: BLE001 — surface any load failure as state
         msg = str(exc)
-        state = "schema_mismatch" if _is_schema_mismatch(msg) else "load_error"
+        if isinstance(exc, LadybugBranchMismatchError):
+            state = "branch_not_indexed"
+        elif _is_schema_mismatch(msg):
+            state = "schema_mismatch"
+        else:
+            state = "load_error"
         return DepgraphStatus(state, dir_str, graph_mtime, head_mtime, detail=msg)
 
     stale, detail = _graph_freshness(project_root, gitnexus_dir)

--- a/topos/mcp/formatting.py
+++ b/topos/mcp/formatting.py
@@ -21,7 +21,11 @@ from topos.evaluation.policies.gates import (
 from topos.evaluation.preferences import UserPreferences
 from topos.evaluation.suggestions import suggest_refactors
 
-from .evaluation import INVALID_GITNEXUS_MARKERS, STALE_GITNEXUS_MARKER
+from .evaluation import (
+    BRANCH_NOT_INDEXED_MARKER,
+    INVALID_GITNEXUS_MARKERS,
+    STALE_GITNEXUS_MARKER,
+)
 from .schemas import (
     AcknowledgedRisk,
     AgentContract,
@@ -85,15 +89,21 @@ def composable_contract_signals(
     invalid_override = any(
         marker in w for w in messages for marker in INVALID_GITNEXUS_MARKERS
     )
+    branch_not_indexed = any(
+        BRANCH_NOT_INDEXED_MARKER in w.lower() for w in messages
+    )
     stale_graph = any(STALE_GITNEXUS_MARKER in w for w in messages)
 
     if not coupling_available:
         if invalid_override:
             blocked_by.append("invalid_gitnexus_dir")
             risk_flags.append("invalid_gitnexus_dir")
+        elif branch_not_indexed:
+            blocked_by.append("branch_not_indexed_gitnexus_dir")
+            risk_flags.append("branch_not_indexed_gitnexus_dir")
         elif include_missing:
             blocked_by.append("missing_gitnexus_dir")
-        if invalid_override or include_missing:
+        if invalid_override or branch_not_indexed or include_missing:
             risk_flags.append("composable_unavailable")
 
     if stale_graph:
@@ -108,6 +118,13 @@ def composable_contract_signals(
                 "fix gitnexus_dir — it must be an existing directory inside "
                 "the file root"
             ),
+        )
+    if "branch_not_indexed_gitnexus_dir" in blocked_by:
+        return ComposableContractSignals(
+            blocked_by=blocked_by,
+            risk_flags=risk_flags,
+            next_tool="topos_generate_depgraph",
+            next_action="run topos_generate_depgraph to index the current branch",
         )
     if "stale_gitnexus_dir" in blocked_by:
         return ComposableContractSignals(

--- a/topos/mcp/schemas.py
+++ b/topos/mcp/schemas.py
@@ -980,6 +980,7 @@ class DepgraphState(StrEnum):
     LOAD_ERROR = "load_error"
     SCHEMA_MISMATCH = "schema_mismatch"
     INVALID_DIR = "invalid_dir"
+    BRANCH_NOT_INDEXED = "branch_not_indexed"
 
 
 class DepgraphStatusInput(_StrictModel):

--- a/topos/mcp/tools/depgraph.py
+++ b/topos/mcp/tools/depgraph.py
@@ -2,7 +2,7 @@
 
 COMPOSABLE depends on a ``.gitnexus`` index. ``topos_depgraph_status`` lets an
 agent discover graph state (missing / present / stale / load_error /
-schema_mismatch / invalid_dir) without shelling out, and
+schema_mismatch / invalid_dir / branch_not_indexed) without shelling out, and
 ``topos_generate_depgraph`` performs
 the side-effecting regeneration behind an approval-gated annotation.
 """
@@ -79,6 +79,13 @@ _STATE_GUIDANCE: dict[DepgraphState, tuple[str, str | None, str | None]] = {
         "exist); fix the path, then retry. Generating won't help.",
         None,
         "invalid_gitnexus_dir",
+    ),
+    DepgraphState.BRANCH_NOT_INDEXED: (
+        "No GitNexus store is indexed for the currently checked-out branch "
+        "(other branches may be indexed). Run topos_generate_depgraph to "
+        "index this branch.",
+        "topos_generate_depgraph",
+        "branch_not_indexed_gitnexus_dir",
     ),
     DepgraphState.PRESENT: (
         "COMPOSABLE is scorable; proceed with topos_evaluate_file.",

--- a/topos/utils/gitnexus.py
+++ b/topos/utils/gitnexus.py
@@ -26,6 +26,15 @@ _INSTALL_HINT = "GitNexus not found. Install it with: npm install -g gitnexus"
 # freshness is not decided by fragile filesystem clocks.
 GITNEXUS_FINGERPRINT_FILE = ".topos-fingerprint.json"
 
+# GitNexus-owned files/dirs (not Topos-authored, unlike the fingerprint above).
+# GitNexus writes the first-ever `gitnexus analyze` for a repo to the flat
+# slot (`.gitnexus/lbug` + `.gitnexus/meta.json`). Re-running `analyze` on a
+# *different* branch than the one recorded in the flat `meta.json` does not
+# update the flat slot -- it creates `.gitnexus/branches/<branch>-<hash>/lbug`
+# instead, each with its own `meta.json`.
+GITNEXUS_META_FILE = "meta.json"
+GITNEXUS_BRANCHES_DIR = "branches"
+
 # ``gitnexus analyze`` can legitimately run for minutes on a large repo, so the
 # default ceiling is deliberately generous. Operators can override it via the
 # ``TOPOS_DEPGRAPH_TIMEOUT`` env var (seconds); set it to 0 to disable entirely.
@@ -55,6 +64,121 @@ def _resolve_timeout(timeout: float | None) -> float | None:
 def gitnexus_available() -> bool:
     """Whether the ``gitnexus`` CLI is on PATH."""
     return shutil.which(GITNEXUS_CMD) is not None
+
+
+@dataclass(frozen=True)
+class LbugStoreMeta:
+    """The subset of GitNexus's own ``meta.json`` Topos cares about."""
+
+    branch: str | None
+    last_commit: str | None
+
+
+def _read_store_meta(store_dir: Path) -> LbugStoreMeta | None:
+    """Best-effort parse of GitNexus's ``meta.json`` next to a store.
+
+    Returns ``None`` on any read/parse error or a missing ``"branch"`` key --
+    callers treat that identically to "no metadata, can't branch-match."
+    """
+    try:
+        raw = json.loads((store_dir / GITNEXUS_META_FILE).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    branch = raw.get("branch")
+    if not isinstance(branch, str):
+        return None
+    last_commit = raw.get("lastCommit")
+    return LbugStoreMeta(
+        branch=branch,
+        last_commit=last_commit if isinstance(last_commit, str) else None,
+    )
+
+
+def current_git_branch(project_root: Path) -> str | None:
+    """Current branch name, parsed from ``.git/HEAD`` without shelling out.
+
+    Mirrors ``topos.mcp.evaluation._git_head_sha``'s no-subprocess approach
+    exactly, since this is called on every dependency-graph read, not just at
+    generate time. Returns ``None`` for a non-git dir, a detached HEAD (HEAD
+    holds a raw SHA, not a ``ref:`` line), or a ref outside ``refs/heads/``
+    (e.g. a tag checkout) -- all of which mean "no branch identity to match
+    against," and callers fall back to the flat store unconditionally.
+    """
+    git_dir = project_root / ".git"
+    try:
+        head_text = (git_dir / "HEAD").read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    if not head_text.startswith("ref: "):
+        return None  # detached HEAD: contents are a SHA, not a branch name
+    ref = head_text.removeprefix("ref: ").strip()
+    prefix = "refs/heads/"
+    if not ref.startswith(prefix):
+        return None
+    return ref.removeprefix(prefix) or None
+
+
+@dataclass(frozen=True)
+class ResolvedLbugStore:
+    """The ``lbug`` store to load for a given branch, or a "no match" report."""
+
+    path: Path | None
+    matched_branch: str | None
+    available_branches: tuple[str, ...] = ()
+
+
+def resolve_lbug_store(
+    gitnexus_dir: Path, current_branch: str | None
+) -> ResolvedLbugStore:
+    """Pick the ``lbug`` store under ``gitnexus_dir`` matching *current_branch*.
+
+    1. ``current_branch`` is ``None`` (no git / detached HEAD), or the flat
+       store exists with no ``meta.json`` (a legacy, pre-branch-aware store)
+       -> the flat slot unconditionally. This is what keeps the change fully
+       backward compatible with every store GitNexus wrote before it started
+       branch-scoping, and with detached-HEAD checkouts, which have no branch
+       identity to match against.
+    2. The flat store's ``meta.json`` records ``current_branch`` -> flat slot.
+    3. Otherwise scan ``branches/*/meta.json`` for one recording
+       ``current_branch`` (matched on the ``meta.json`` content, never on the
+       opaque ``<hash>`` suffix GitNexus appends to the directory name -- we
+       don't control how that hash is derived, and a branch name containing
+       ``/`` may not round-trip through a directory-name-safe encoding).
+    4. No match anywhere -> ``path=None``, ``available_branches`` populated
+       (sorted) so the caller can build an actionable error message.
+    """
+    flat_lbug = gitnexus_dir / "lbug"
+    flat_meta = _read_store_meta(gitnexus_dir)
+
+    if current_branch is None or (flat_lbug.exists() and flat_meta is None):
+        return ResolvedLbugStore(
+            path=flat_lbug if flat_lbug.exists() else None,
+            matched_branch=flat_meta.branch if flat_meta else None,
+        )
+
+    if flat_meta is not None and flat_meta.branch == current_branch:
+        return ResolvedLbugStore(path=flat_lbug, matched_branch=current_branch)
+
+    available: list[str] = [flat_meta.branch] if flat_meta is not None else []
+    branches_dir = gitnexus_dir / GITNEXUS_BRANCHES_DIR
+    if branches_dir.is_dir():
+        for candidate in sorted(branches_dir.iterdir()):
+            meta = _read_store_meta(candidate)
+            if meta is None:
+                continue
+            available.append(meta.branch)
+            if meta.branch == current_branch:
+                lbug = candidate / "lbug"
+                if lbug.exists():
+                    return ResolvedLbugStore(
+                        path=lbug, matched_branch=current_branch
+                    )
+
+    return ResolvedLbugStore(
+        path=None,
+        matched_branch=None,
+        available_branches=tuple(sorted({b for b in available if b})),
+    )
 
 
 @dataclass(frozen=True)
@@ -167,9 +291,14 @@ def generate_depgraph(
         )
 
     gitnexus_path = target_dir / ".gitnexus"
+    branch = current_git_branch(target_dir)
+    resolved = resolve_lbug_store(gitnexus_path, branch)
+    fingerprint_dir = (
+        resolved.path.parent if resolved.path is not None else gitnexus_path
+    )
     _write_fingerprint(
         target_dir,
-        gitnexus_path,
+        fingerprint_dir,
         start_time=start_time,
         source_snapshot=source_snapshot,
     )


### PR DESCRIPTION
## Summary

Found while smoke-testing PR #163 (v0.3.11 consolidation): GitNexus writes the first-ever `gitnexus analyze` for a repo to the flat `.gitnexus/lbug` slot. Re-running `analyze` on a *different* branch does **not** update the flat slot — it creates `.gitnexus/branches/<branch>-<hash>/lbug` instead, leaving the flat slot pinned to whichever branch was analyzed first (confirmed live with GitNexus v1.6.10-rc.21).

Topos had zero awareness of this. `ModuleDependencyGraph.from_gitnexus_dir` — the single choke point every CLI command and MCP tool routes through — hardcoded `gitnexus_dir / "lbug"`, with two more independent copies of the same assumption in `mcp/cache.py`'s and `mcp/evaluation.py`'s `_gitnexus_mtime`.

**Worse than plain staleness**: `generate_depgraph()` always overwrote Topos's own `.topos-fingerprint.json` at the flat slot regardless of where GitNexus actually wrote the store. So after switching branches and regenerating, the fingerprint would say "fresh, matches this branch's HEAD" while `from_gitnexus_dir` kept silently loading the *other* branch's stale graph — a false negative that actively suppressed the staleness warning that would otherwise have fired, not just a missed one.

## Fix

- **`topos/utils/gitnexus.py`**: new `current_git_branch()` (parses `.git/HEAD` directly, no subprocess — mirrors `evaluation.py`'s existing `_git_head_sha`) and `resolve_lbug_store()` (matches GitNexus's own `meta.json` `"branch"` field against the flat slot and every `branches/*/` candidate). `generate_depgraph()` now writes the fingerprint beside whichever store it actually resolves to, closing the false-negative above.
- **`topos/graphs/mdg/object.py`**: `from_gitnexus_dir` routes through the resolver; new `LadybugBranchMismatchError` (subclasses `FileNotFoundError`, so every existing `except FileNotFoundError` elsewhere degrades gracefully with no other changes needed) when the current branch isn't indexed but others are.
- **`topos/mcp/cache.py`**: `_gitnexus_mtime` and the `dep_graph_for` LRU cache key are both branch-aware now — two branch stores could otherwise share an mtime (coarse filesystem resolution, same-second CI run) and collide in the cache even with a correct mtime source.
- **`topos/mcp/evaluation.py`**: deleted the byte-for-byte duplicate `_gitnexus_mtime`; `_graph_freshness` resolves the branch-correct store once and reads/writes its fingerprint there instead of always the flat slot.
- **`topos/mcp/schemas.py`, `mcp/tools/depgraph.py`, `mcp/formatting.py`**: new `DepgraphState.BRANCH_NOT_INDEXED` state with guidance routing to `topos_generate_depgraph`, mirroring `MISSING`/`STALE`.

100% backward compatible: any store without GitNexus's newer branch-scoped `meta.json`/`branches/` layout (the flat-only case every existing test and every pre-branch-aware GitNexus store uses) resolves to the flat slot unconditionally, byte-identical to today.

## Validation

- New/extended tests: `tests/utils/test_gitnexus.py`, `tests/functors/probes/mdg/test_pdg_metrics.py` (the literal regression case: flat holds a stale branch's data, a `branches/*` store holds the current branch's data, must load the latter), `tests/mcp/test_depgraph.py` (cache-key collision, the fingerprint-desync false-negative, the new state), `tests/graphs/process/test_process_graph.py`.
- Full suite: `798 passed, 11 skipped` (up from `780`/`11` baseline — 18 net new tests). `ruff check` clean.
- **Manual end-to-end** against a live repro repo with two branches, each independently analyzed by real GitNexus: before this fix, inspecting a file while on `feature-x` silently returned `main`'s stale dependency data (`coupling=1.0`, `instability=1.0`, missing a cross-file import only present on `feature-x`); after the fix it correctly resolves `feature-x`'s own store (`coupling=2.0`, `instability=0.5`), and checking out `main` again correctly resolves back to the flat slot (`coupling=1.0`, `instability=1.0`).

Design plan (build vs. buy on issue #138, and why this stays scoped to the resolution fix) was reviewed and approved before implementation.
