### PR TITLE
fix(security): align Sighthound adapter with real CLI schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@
 Topos evaluates code along three independent pillars:
 
 - **SIMPLE** — Avoids unnecessary complexity (AST entropy & CFG cyclomatic complexity).
-- **COMPOSABLE** — Cleanly decoupled from other modules (MDG Martin instability via GitNexus).
-- **SECURE** — Free of dangerous API reachability and taint paths (CPG analysis).
+- **COMPOSABLE** — Cleanly decoupled from other modules (MDG Martin instability via [GitNexus](https://github.com/abhigyanpatwari/GitNexus)).
+- **SECURE** — Free of dangerous API reachability and taint paths (CPG analysis; optionally powered by [Sighthound](https://github.com/Corgea/Sighthound)).
+
+Topos is the **operator** over those graphs — not another one-off tree-sitter script. Best-in-class analytics (GitNexus for the module graph, Sighthound for SAST) feed a single lattice agents can optimize toward.
 
 ### The Medal Podium
 
@@ -99,6 +101,10 @@ topos evaluate src/ -r --gitnexus-dir .gitnexus
 Install GitNexus once per machine. Run `topos depgraph generate` from each repository you want to score for COMPOSABLE.
 
 > The CLI does **not** auto-detect `.gitnexus/` — pass `--gitnexus-dir` explicitly. Regenerate after imports change (new modules, renames, restructures). *(The `topos mcp` server, by contrast, auto-detects `./.gitnexus`.)*
+
+#### Optional: deepen SECURE with Sighthound
+
+`SECURE` always runs from Topos's CPG probes. Install [Sighthound](https://github.com/Corgea/Sighthound) and put the `sighthound` binary on `PATH` to outsource dangerous-call and taint findings to Corgea's ruleset — same medal, richer SAST signal. No config flag required; Topos detects it automatically.
 
 #### Measure test coverage — structural + semantic
 
@@ -222,7 +228,19 @@ Topos measures code along the three independent quality generators and maps them
 
 - **SIMPLE** — Built from the [abstract syntax tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree) (AST) and [control-flow graph](https://en.wikipedia.org/wiki/Control-flow_graph) (CFG). We calculate cyclomatic complexity of the CFG and entropy of the AST to assess complexity.
 - **COMPOSABLE** — Built from the [module dependency graph](https://en.wikipedia.org/wiki/Module_dependency_graph) (MDG) using [GitNexus](https://github.com/abhigyanpatwari/GitNexus), to capture inter-module dependencies. This is slightly different than the usual [program dependence graph](https://en.wikipedia.org/wiki/Program_dependence_graph) (PDG) which is used to capture intra-function dependencies. We calculate Martin Instability and Fanning metrics for the MDG to assess coupling.
-- **SECURE** — Built from the [code property graph](https://en.wikipedia.org/wiki/Code_property_graph) (CPG). We calculate dangerous-API reachability and taint paths from the CPG to assess security.
+- **SECURE** — Built from the [code property graph](https://en.wikipedia.org/wiki/Code_property_graph) (CPG). When [Sighthound](https://github.com/Corgea/Sighthound) is on `PATH`, Topos outsources dangerous-call and taint findings to its ruleset; otherwise local CPG probes still run. Either way, results land in the same SECURE metrics agents already consume.
+
+#### Operator, not another tree-sitter tool
+
+Plenty of custom analytics are built on [tree-sitter](https://tree-sitter.github.io/tree-sitter/) — ASTs, CFGs, dependency graphs, SAST rules. Topos does not replace those engines. It **operates over them**:
+
+| Pillar | Graph / engine | Specialist we integrate |
+| :--- | :--- | :--- |
+| SIMPLE | AST + CFG | Built-in (tree-sitter → UAST) |
+| COMPOSABLE | Module dependency graph | [GitNexus](https://github.com/abhigyanpatwari/GitNexus) |
+| SECURE | Code property graph / SAST | [Sighthound](https://github.com/Corgea/Sighthound) (optional; local CPG fallback) |
+
+The differentiator is the **lattice + agent loop**: one preference-ranked medal, one set of MCP tools, and a closed refactor cycle — instead of stitching together ad-hoc scripts for every graph.
 
 ```mermaid
 graph BT

--- a/tests/utils/test_sighthound.py
+++ b/tests/utils/test_sighthound.py
@@ -17,6 +17,7 @@ from topos.mcp.security_findings import security_findings
 from topos.utils.sighthound import (
     count_findings,
     finding_callee,
+    finding_source_text,
     is_taint_finding,
     run_sighthound_scan,
 )
@@ -173,6 +174,24 @@ def test_finding_callee():
     assert finding_callee({}) is None
 
 
+def test_finding_source_text_keeps_cross_file_location():
+    # Cross-file taint: origin lives in another file, so location must survive.
+    assert (
+        finding_source_text(MOCK_CROSS_FILE_TAINT)
+        == "input() @ source.py:3 (function: main)"
+    )
+    # Single-file taint keeps type, location, and context too.
+    assert (
+        finding_source_text(MOCK_TAINT_FINDING)
+        == "request.args @ app.py:10 (function: index)"
+    )
+    # Falls back to whichever field is present.
+    assert finding_source_text({"source_info": {"location": "x.py:1"}}) == "x.py:1"
+    assert finding_source_text({"source_info": {"context": "f"}}) == "f"
+    assert finding_source_text({"source_info": {}}) is None
+    assert finding_source_text({}) is None
+
+
 @patch("subprocess.run")
 def test_run_sighthound_scan_file(mock_run, tmp_path):
     mock_response = MagicMock()
@@ -214,6 +233,19 @@ def test_run_sighthound_scan_source_in_memory(mock_run):
 def test_run_sighthound_scan_unwraps_findings_wrapper(mock_run, tmp_path):
     mock_response = MagicMock()
     mock_response.stdout = json.dumps({"findings": [MOCK_SEARCH_FINDING]})
+    mock_response.returncode = 0
+    mock_run.return_value = mock_response
+    target = tmp_path / "x.py"
+    target.write_text("x=1", encoding="utf-8")
+    findings = run_sighthound_scan("x=1", "python", target)
+    assert len(findings) == 1
+    assert findings[0]["function"] == "eval"
+
+
+@patch("subprocess.run")
+def test_run_sighthound_scan_drops_non_dict_entries(mock_run, tmp_path):
+    mock_response = MagicMock()
+    mock_response.stdout = json.dumps([MOCK_SEARCH_FINDING, "bogus", None, 42])
     mock_response.returncode = 0
     mock_run.return_value = mock_response
     target = tmp_path / "x.py"
@@ -271,7 +303,8 @@ def test_security_findings_with_sighthound(mock_scan, mock_which):
     assert f3.line == 42
     assert f3.snippet == "os.system(cmd)"
     assert f3.callee == "os.system"
-    assert f3.source == "request.args (function: index)"
+    # Source text keeps the origin location alongside type and context.
+    assert f3.source == "request.args @ app.py:10 (function: index)"
     assert f3.sink == "os.system"
 
 

--- a/tests/utils/test_sighthound.py
+++ b/tests/utils/test_sighthound.py
@@ -1,3 +1,11 @@
+"""Tests for the Sighthound adapter — fixtures match real CLI JSON.
+
+Real Sighthound findings use vulnerability labels as ``finding_type``
+(e.g. ``"Command Injection"``), not rule mode. Taint findings are identified
+by tags ``taint_analysis`` / ``data_flow`` / ``cross_file``. ``source_info``
+uses ``context`` (not ``snippet``); ``sink_info`` uses ``function_name``.
+"""
+
 from __future__ import annotations
 
 import json
@@ -6,47 +14,163 @@ from unittest.mock import MagicMock, patch
 from topos.graphs.cpg.object import CodePropertyGraph
 from topos.graphs.uast.models import NativeRef, SourceSpan, UASTNode
 from topos.mcp.security_findings import security_findings
-from topos.utils.sighthound import count_findings, run_sighthound_scan
+from topos.utils.sighthound import (
+    count_findings,
+    finding_callee,
+    is_taint_finding,
+    run_sighthound_scan,
+)
+
+# Captured shape from live `sighthound --output-format json` on a vuln fixture.
+# Search-mode findings: rule tags only (no taint_analysis).
+MOCK_SEARCH_FINDING = {
+    "file": "/tmp/topos-dogfood/vuln.py",
+    "line": 5,
+    "column": 5,
+    "end_line": 5,
+    "end_column": 21,
+    "function": "eval",
+    "finding_type": "Code Injection",
+    "snippet": "eval(user_input)",
+    "severity": "Critical",
+    "confidence": "High",
+    "description": "Use of eval()/exec() can lead to arbitrary code execution",
+    "cwe_id": "cwe-95",
+    "source_info": {
+        "source_type": "User Input",
+        "location": "Line 5",
+        "context": "handle",
+    },
+    "sink_info": {
+        "sink_type": "General Sink",
+        "function_name": "eval",
+        "location": "Line 5",
+        "variable": "eval",
+    },
+    "tags": ["code", "injection", "eval"],
+}
+
+MOCK_SEARCH_FINDING_CMD = {
+    "file": "/tmp/topos-dogfood/vuln.py",
+    "line": 7,
+    "column": 5,
+    "end_line": 7,
+    "end_column": 43,
+    "function": "subprocess.run",
+    "finding_type": "Command Injection",
+    "snippet": "subprocess.run(user_input, shell=True)",
+    "severity": "High",
+    "confidence": "Medium",
+    "description": "subprocess invoked with shell=True",
+    "cwe_id": "cwe-78",
+    "source_info": {
+        "source_type": "User Input",
+        "location": "Line 7",
+        "context": "handle",
+    },
+    "sink_info": {
+        "sink_type": "Command Execution",
+        "function_name": "subprocess.run",
+        "location": "Line 7",
+        "variable": "subprocess",
+    },
+    "tags": ["command", "injection", "subprocess"],
+}
+
+# Single-file taint finding tags from scanning_logic.rs.
+MOCK_TAINT_FINDING = {
+    "file": "app.py",
+    "line": 42,
+    "column": 8,
+    "end_line": 42,
+    "end_column": 30,
+    "function": "os.system",
+    "finding_type": "Command Injection",
+    "snippet": "os.system(cmd)",
+    "severity": "High",
+    "confidence": "High",
+    "description": "Tainted data reaches command execution sink",
+    "cwe_id": "cwe-78",
+    "source_info": {
+        "source_type": "request.args",
+        "location": "app.py:10",
+        "context": "function: index",
+    },
+    "sink_info": {
+        "sink_type": "os.system",
+        "function_name": "os.system",
+        "location": "app.py:42",
+        "variable": "cmd",
+    },
+    "tags": ["taint_analysis", "data_flow"],
+}
+
+# Cross-file taint tags from multifile_taint.rs.
+MOCK_CROSS_FILE_TAINT = {
+    "file": "sink.py",
+    "line": 8,
+    "column": 0,
+    "end_line": 8,
+    "end_column": 0,
+    "function": "run",
+    "finding_type": "Command Injection",
+    "snippet": "Sink: os.system",
+    "severity": "High",
+    "confidence": "High",
+    "description": "Verified cross-file taint flow",
+    "source_info": {
+        "source_type": "input()",
+        "location": "source.py:3",
+        "context": "function: main",
+    },
+    "sink_info": {
+        "sink_type": "os.system",
+        "function_name": "run",
+        "location": "sink.py:8",
+        "variable": "cmd",
+    },
+    "tags": ["taint_analysis", "cross_file"],
+}
 
 MOCK_SIGHTHOUND_OUTPUT = [
-    {
-        "file": "main.py",
-        "line": 10,
-        "column": 5,
-        "end_line": 10,
-        "end_column": 15,
-        "function": "eval",
-        "finding_type": "search",
-        "snippet": "eval(user_input)",
-        "severity": "Critical",
-        "confidence": "High",
-        "description": "Use of dangerous function eval",
-    },
-    {
-        "file": "main.py",
-        "line": 15,
-        "column": 8,
-        "end_line": 15,
-        "end_column": 30,
-        "function": "subprocess.run",
-        "finding_type": "taint",
-        "snippet": "subprocess.run(cmd)",
-        "severity": "High",
-        "confidence": "Medium",
-        "description": "Command injection vulnerability",
-        "source_info": {"snippet": "user_input = input()"},
-        "sink_info": {
-            "snippet": "subprocess.run(cmd)",
-            "function_name": "subprocess.run",
-        },
-    },
+    MOCK_SEARCH_FINDING,
+    MOCK_SEARCH_FINDING_CMD,
+    MOCK_TAINT_FINDING,
 ]
 
 
-def test_count_findings():
+def test_is_taint_finding_uses_tags_not_finding_type():
+    assert not is_taint_finding(MOCK_SEARCH_FINDING)
+    assert not is_taint_finding(MOCK_SEARCH_FINDING_CMD)
+    assert is_taint_finding(MOCK_TAINT_FINDING)
+    assert is_taint_finding(MOCK_CROSS_FILE_TAINT)
+    # finding_type alone must not classify search findings as taint
+    assert not is_taint_finding(
+        {"finding_type": "Command Injection", "tags": ["command"]}
+    )
+    # fallback when tags missing
+    assert is_taint_finding({"finding_type": "Taint Flow"})
+    assert not is_taint_finding({"finding_type": "Code Injection"})
+
+
+def test_count_findings_real_schema():
     dangerous, taint = count_findings(MOCK_SIGHTHOUND_OUTPUT)
-    assert dangerous == 1
+    assert dangerous == 2
     assert taint == 1
+    # All-search payload (live vuln.py shape) must not zero out
+    dangerous_only, taint_only = count_findings(
+        [MOCK_SEARCH_FINDING, MOCK_SEARCH_FINDING_CMD]
+    )
+    assert dangerous_only == 2
+    assert taint_only == 0
+    d, t = count_findings([MOCK_CROSS_FILE_TAINT])
+    assert (d, t) == (0, 1)
+
+
+def test_finding_callee():
+    assert finding_callee(MOCK_SEARCH_FINDING) == "eval"
+    assert finding_callee({"sink_info": {"function_name": "exec"}}) == "exec"
+    assert finding_callee({}) is None
 
 
 @patch("subprocess.run")
@@ -60,7 +184,7 @@ def test_run_sighthound_scan_file(mock_run, tmp_path):
     target_file.write_text("print(1)", encoding="utf-8")
 
     findings = run_sighthound_scan("print(1)", "python", target_file)
-    assert len(findings) == 2
+    assert len(findings) == 3
     mock_run.assert_called_once_with(
         ["sighthound", "--output-format", "json", str(target_file)],
         capture_output=True,
@@ -77,15 +201,26 @@ def test_run_sighthound_scan_source_in_memory(mock_run):
     mock_run.return_value = mock_response
 
     findings = run_sighthound_scan("eval(x)", "python")
-    assert len(findings) == 2
-    # Should create a temporary file and clean it up
+    assert len(findings) == 3
     assert mock_run.call_count == 1
-    args, kwargs = mock_run.call_args
+    args, _kwargs = mock_run.call_args
     assert args[0][0] == "sighthound"
     assert args[0][1] == "--output-format"
     assert args[0][2] == "json"
-    # Temp file should have .py suffix
     assert args[0][3].endswith(".py")
+
+
+@patch("subprocess.run")
+def test_run_sighthound_scan_unwraps_findings_wrapper(mock_run, tmp_path):
+    mock_response = MagicMock()
+    mock_response.stdout = json.dumps({"findings": [MOCK_SEARCH_FINDING]})
+    mock_response.returncode = 0
+    mock_run.return_value = mock_response
+    target = tmp_path / "x.py"
+    target.write_text("x=1", encoding="utf-8")
+    findings = run_sighthound_scan("x=1", "python", target)
+    assert len(findings) == 1
+    assert findings[0]["function"] == "eval"
 
 
 @patch("shutil.which")
@@ -100,7 +235,7 @@ def test_cpg_metrics_uses_sighthound_when_present(mock_scan, mock_which):
     cpg = CodePropertyGraph.from_uast(uast, source="print(1)")
 
     metrics = cpg.metrics()
-    assert metrics["cpg.dangerous_calls"] == 1.0
+    assert metrics["cpg.dangerous_calls"] == 2.0
     assert metrics["cpg.taint_flows"] == 1.0
     mock_scan.assert_called_once_with("print(1)", "python", "main.py")
 
@@ -117,20 +252,43 @@ def test_security_findings_with_sighthound(mock_scan, mock_which):
     cpg = CodePropertyGraph.from_uast(uast, source="print(1)")
 
     findings = security_findings(cpg)
-    assert len(findings) == 2
+    assert len(findings) == 3
 
-    # Verify Search-mode finding
     f1 = findings[0]
     assert f1.kind == "dangerous_call"
-    assert f1.line == 10
+    assert f1.line == 5
     assert f1.snippet == "eval(user_input)"
     assert f1.callee == "eval"
+    assert f1.source is None
+    assert f1.sink is None
 
-    # Verify Taint-mode finding
     f2 = findings[1]
-    assert f2.kind == "taint_flow"
-    assert f2.line == 15
-    assert f2.snippet == "subprocess.run(cmd)"
+    assert f2.kind == "dangerous_call"
     assert f2.callee == "subprocess.run"
-    assert f2.source == "user_input = input()"
-    assert f2.sink == "subprocess.run(cmd)"
+
+    f3 = findings[2]
+    assert f3.kind == "taint_flow"
+    assert f3.line == 42
+    assert f3.snippet == "os.system(cmd)"
+    assert f3.callee == "os.system"
+    assert f3.source == "request.args (function: index)"
+    assert f3.sink == "os.system"
+
+
+@patch("shutil.which")
+@patch("topos.utils.sighthound.run_sighthound_scan")
+def test_security_findings_live_search_only_shape(mock_scan, mock_which):
+    """Live vuln.py-style payload: all search findings, non-zero dangerous_calls."""
+    mock_which.return_value = "/usr/local/bin/sighthound"
+    mock_scan.return_value = [MOCK_SEARCH_FINDING, MOCK_SEARCH_FINDING_CMD]
+
+    span = SourceSpan("vuln.py", 0, 10, 1, 0, 1, 10)
+    native = NativeRef("tree-sitter", "0.22", "module")
+    uast = UASTNode("module", "python", span, native)
+    cpg = CodePropertyGraph.from_uast(uast, source="eval(x)")
+
+    assert cpg.metrics()["cpg.dangerous_calls"] == 2.0
+    assert cpg.metrics()["cpg.taint_flows"] == 0.0
+    findings = security_findings(cpg)
+    assert all(f.kind == "dangerous_call" for f in findings)
+    assert {f.callee for f in findings} == {"eval", "subprocess.run"}

--- a/topos/mcp/security_findings.py
+++ b/topos/mcp/security_findings.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import shutil
+from typing import Any
 
 from topos.functors.probes.cpg.danger import (
     _callee_from_text,
@@ -26,85 +27,108 @@ def security_findings(
 
     When *allow* is given, allowlisted patterns are excluded from the
     registry first.  ``allow=None`` preserves canonical behavior.
+
+    If the ``sighthound`` CLI is on ``PATH``, findings come from its ruleset
+    (via :mod:`topos.utils.sighthound`); otherwise local CPG probes are used.
     """
     if cpg is None:
         return []
 
-    # If sighthound is installed on the system, run its ruleset
     if shutil.which("sighthound"):
-        file_path = None
-        for node in cpg.nodes.values():
-            if node.uast and node.uast.span and node.uast.span.file:
-                file_path = node.uast.span.file
-                break
-
-        from topos.utils.sighthound import run_sighthound_scan
-
-        raw_findings = run_sighthound_scan(cpg.source, cpg.language, file_path)
-
-        # Build registry for allow-list matching if supplied
-        registry = (
-            effective_registry(cpg.language, allow) if allow is not None else None
+        return _sighthound_security_findings(
+            cpg, max_findings=max_findings, allow=allow
         )
 
-        findings: list[SecurityFinding] = []
-        for raw in raw_findings:
-            ftype = raw.get("finding_type", "").lower()
-            callee = raw.get("function") or (
-                raw.get("sink_info", {}).get("function_name")
-                if raw.get("sink_info")
-                else None
-            )
-
-            # Allowlist filter: if a registry is effective and a callee is found,
-            # we exclude findings that do not match the allowed pattern (if we want
-            # to filter them).
-            # Wait, in standard topos, effective_registry returns the list of
-            # DANGEROUS APIs. If allow is provided, the allowed APIs are removed
-            # from the dangerous list.
-            # So _matches_registry(callee, registry) is True if the callee is
-            # STILL dangerous. Thus, we only include the finding if it matches
-            # the registry (remains dangerous).
-            if (
-                registry is not None
-                and callee
-                and not _matches_registry(callee, registry)
-            ):
-                continue
-
-            kind = "dangerous_call" if ftype == "search" else "taint_flow"
-
-            source_snippet = (
-                raw.get("source_info", {}).get("snippet")
-                if raw.get("source_info")
-                else None
-            )
-            sink_snippet = (
-                raw.get("sink_info", {}).get("snippet")
-                if raw.get("sink_info")
-                else None
-            )
-
-            findings.append(
-                SecurityFinding(
-                    kind=kind,
-                    line=max(1, raw.get("line", 1)),
-                    snippet=raw.get("snippet", ""),
-                    callee=callee,
-                    source=source_snippet,
-                    sink=sink_snippet,
-                )
-            )
-            if len(findings) >= max_findings:
-                break
-        return findings
-
-    # Fallback to local probes if sighthound is not available
     findings = dangerous_call_findings(cpg, max_findings=max_findings, allow=allow)
     remaining = max(0, max_findings - len(findings))
     if remaining:
-        findings.extend(taint_flow_findings(cpg, max_findings=remaining, allow=allow))
+        findings.extend(
+            taint_flow_findings(cpg, max_findings=remaining, allow=allow)
+        )
     return findings
+
+
+def _sighthound_security_findings(
+    cpg: CodePropertyGraph,
+    *,
+    max_findings: int,
+    allow: set[str] | None,
+) -> list[SecurityFinding]:
+    """Map Sighthound JSON findings into :class:`SecurityFinding` models."""
+    from topos.utils.sighthound import (
+        finding_callee,
+        finding_line,
+        finding_sink_text,
+        finding_snippet,
+        finding_source_text,
+        is_taint_finding,
+        run_sighthound_scan,
+    )
+
+    file_path = None
+    for node in cpg.nodes.values():
+        if node.uast and node.uast.span and node.uast.span.file:
+            file_path = node.uast.span.file
+            break
+
+    raw_findings = run_sighthound_scan(cpg.source, cpg.language, file_path)
+    registry = (
+        effective_registry(cpg.language, allow) if allow is not None else None
+    )
+
+    findings: list[SecurityFinding] = []
+    for raw in raw_findings:
+        if not isinstance(raw, dict):
+            continue
+        mapped = _map_sighthound_finding(
+            raw,
+            registry=registry,
+            finding_callee=finding_callee,
+            finding_line=finding_line,
+            finding_sink_text=finding_sink_text,
+            finding_snippet=finding_snippet,
+            finding_source_text=finding_source_text,
+            is_taint_finding=is_taint_finding,
+        )
+        if mapped is None:
+            continue
+        findings.append(mapped)
+        if len(findings) >= max_findings:
+            break
+    return findings
+
+
+def _map_sighthound_finding(
+    raw: dict[str, Any],
+    *,
+    registry: set[str] | None,
+    finding_callee: Any,
+    finding_line: Any,
+    finding_sink_text: Any,
+    finding_snippet: Any,
+    finding_source_text: Any,
+    is_taint_finding: Any,
+) -> SecurityFinding | None:
+    """Convert one Sighthound finding; return None if allowlisted away."""
+    callee = finding_callee(raw)
+    # When an allow set is active, ``effective_registry`` already dropped
+    # allowlisted callees. Skip findings whose callee is no longer dangerous.
+    if registry is not None and callee and not _matches_registry(callee, registry):
+        return None
+
+    taint = is_taint_finding(raw)
+    kind = "taint_flow" if taint else "dangerous_call"
+    source = finding_source_text(raw) if taint else None
+    sink = finding_sink_text(raw) if taint else None
+
+    return SecurityFinding(
+        kind=kind,
+        line=finding_line(raw),
+        snippet=finding_snippet(raw),
+        callee=callee,
+        source=source,
+        sink=sink,
+    )
 
 
 def dangerous_call_findings(

--- a/topos/mcp/security_findings.py
+++ b/topos/mcp/security_findings.py
@@ -42,9 +42,7 @@ def security_findings(
     findings = dangerous_call_findings(cpg, max_findings=max_findings, allow=allow)
     remaining = max(0, max_findings - len(findings))
     if remaining:
-        findings.extend(
-            taint_flow_findings(cpg, max_findings=remaining, allow=allow)
-        )
+        findings.extend(taint_flow_findings(cpg, max_findings=remaining, allow=allow))
     return findings
 
 
@@ -55,15 +53,7 @@ def _sighthound_security_findings(
     allow: set[str] | None,
 ) -> list[SecurityFinding]:
     """Map Sighthound JSON findings into :class:`SecurityFinding` models."""
-    from topos.utils.sighthound import (
-        finding_callee,
-        finding_line,
-        finding_sink_text,
-        finding_snippet,
-        finding_source_text,
-        is_taint_finding,
-        run_sighthound_scan,
-    )
+    from topos.utils.sighthound import run_sighthound_scan
 
     file_path = None
     for node in cpg.nodes.values():
@@ -72,24 +62,13 @@ def _sighthound_security_findings(
             break
 
     raw_findings = run_sighthound_scan(cpg.source, cpg.language, file_path)
-    registry = (
-        effective_registry(cpg.language, allow) if allow is not None else None
-    )
+    registry = effective_registry(cpg.language, allow) if allow is not None else None
 
     findings: list[SecurityFinding] = []
     for raw in raw_findings:
         if not isinstance(raw, dict):
             continue
-        mapped = _map_sighthound_finding(
-            raw,
-            registry=registry,
-            finding_callee=finding_callee,
-            finding_line=finding_line,
-            finding_sink_text=finding_sink_text,
-            finding_snippet=finding_snippet,
-            finding_source_text=finding_source_text,
-            is_taint_finding=is_taint_finding,
-        )
+        mapped = _map_sighthound_finding(raw, registry=registry)
         if mapped is None:
             continue
         findings.append(mapped)
@@ -102,14 +81,17 @@ def _map_sighthound_finding(
     raw: dict[str, Any],
     *,
     registry: set[str] | None,
-    finding_callee: Any,
-    finding_line: Any,
-    finding_sink_text: Any,
-    finding_snippet: Any,
-    finding_source_text: Any,
-    is_taint_finding: Any,
 ) -> SecurityFinding | None:
     """Convert one Sighthound finding; return None if allowlisted away."""
+    from topos.utils.sighthound import (
+        finding_callee,
+        finding_line,
+        finding_sink_text,
+        finding_snippet,
+        finding_source_text,
+        is_taint_finding,
+    )
+
     callee = finding_callee(raw)
     # When an allow set is active, ``effective_registry`` already dropped
     # allowlisted callees. Skip findings whose callee is no longer dangerous.

--- a/topos/utils/sighthound.py
+++ b/topos/utils/sighthound.py
@@ -1,3 +1,19 @@
+"""Adapter for the Corgea/Sighthound SAST CLI.
+
+Sighthound's JSON schema (see ``Finding`` in Sighthound ``models.rs``):
+
+* ``finding_type`` is a **vulnerability label** (e.g. ``"Command Injection"``),
+  not the rule mode. Rule mode is ``search`` | ``taint`` on the rule, not the
+  finding.
+* Taint findings are tagged with ``taint_analysis`` (plus ``data_flow`` and/or
+  ``cross_file``). Search findings carry rule tags only.
+* ``source_info.context`` / ``sink_info.function_name`` — not ``snippet``.
+
+This module is the single source of truth for invoking the CLI and classifying
+findings into Topos SECURE metrics (``cpg.dangerous_calls`` /
+``cpg.taint_flows``).
+"""
+
 from __future__ import annotations
 
 import contextlib
@@ -7,18 +23,20 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
+# Tags Sighthound itself uses to count search vs taint findings
+# (see vulnerability_scanner.rs / scanning_logic.rs / multifile_taint.rs).
+_TAINT_TAGS = frozenset({"taint_analysis", "data_flow", "cross_file"})
+# Rare fallbacks when tags are missing (legacy / partial payloads).
+_TAINT_FINDING_TYPES = frozenset({"taint", "taint flow"})
+
 
 def run_sighthound_scan(
     source: str, language: str, file_path: str | Path | None = None
 ) -> list[dict[str, Any]]:
-    """
-    Run Sighthound SAST scanner on a source file or an in-memory source string.
-    Returns a list of parsed JSON findings.
-    """
+    """Run Sighthound on a path or in-memory source; return parsed findings."""
     if file_path and Path(file_path).exists():
         return _run_cli(Path(file_path))
 
-    # In-memory source: write to temporary file
     suffix_map = {
         "python": ".py",
         "rust": ".rs",
@@ -41,7 +59,7 @@ def run_sighthound_scan(
 
 
 def _run_cli(target_path: Path) -> list[dict[str, Any]]:
-    """Execute sighthound --output-format json and return parsed findings."""
+    """Execute ``sighthound --output-format json`` and return findings."""
     try:
         result = subprocess.run(
             ["sighthound", "--output-format", "json", str(target_path)],
@@ -49,25 +67,135 @@ def _run_cli(target_path: Path) -> list[dict[str, Any]]:
             text=True,
             check=False,
         )
-        if not result.stdout.strip():
-            return []
-        try:
-            return json.loads(result.stdout)
-        except json.JSONDecodeError:
-            return []
     except FileNotFoundError:
-        # sighthound CLI is not installed / in PATH
         return []
+
+    if not result.stdout.strip():
+        return []
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return []
+    return _normalize_findings_payload(payload)
+
+
+def _normalize_findings_payload(payload: Any) -> list[dict[str, Any]]:
+    """Accept a bare list or a wrapper object with a ``findings`` key."""
+    if isinstance(payload, list):
+        return [f for f in payload if isinstance(f, dict)]
+    if isinstance(payload, dict):
+        findings = payload.get("findings")
+        if isinstance(findings, list):
+            return [f for f in findings if isinstance(f, dict)]
+    return []
+
+
+def finding_tags(finding: dict[str, Any]) -> list[str]:
+    """Return lowercased tags from a finding, if any."""
+    tags = finding.get("tags") or []
+    if not isinstance(tags, list):
+        return []
+    return [t.lower() for t in tags if isinstance(t, str)]
+
+
+def is_taint_finding(finding: dict[str, Any]) -> bool:
+    """True when Sighthound produced this finding via taint analysis.
+
+    Prefer tags (``taint_analysis`` / ``data_flow`` / ``cross_file``), matching
+    Sighthound's own search/taint counters. Fall back to a few literal
+    ``finding_type`` values only when tags are absent.
+    """
+    tags = finding_tags(finding)
+    if tags and any(t in _TAINT_TAGS for t in tags):
+        return True
+    if tags:
+        # Explicit non-taint tags present → search-mode finding.
+        return False
+    ftype = str(finding.get("finding_type") or "").strip().lower()
+    return ftype in _TAINT_FINDING_TYPES
 
 
 def count_findings(findings: list[dict[str, Any]]) -> tuple[int, int]:
-    """Count dangerous calls (search mode) and taint flows (taint mode)."""
+    """Count ``(dangerous_calls, taint_flows)`` for Topos SECURE metrics.
+
+    Search-mode findings → ``cpg.dangerous_calls``.
+    Taint-mode findings → ``cpg.taint_flows``.
+    """
     dangerous_calls = 0
     taint_flows = 0
     for finding in findings:
-        ftype = finding.get("finding_type", "").lower()
-        if ftype == "search":
-            dangerous_calls += 1
-        elif ftype == "taint":
+        if is_taint_finding(finding):
             taint_flows += 1
+        else:
+            dangerous_calls += 1
     return dangerous_calls, taint_flows
+
+
+def finding_callee(finding: dict[str, Any]) -> str | None:
+    """Best-effort callee / sink function name for allowlisting and display."""
+    func = finding.get("function")
+    if isinstance(func, str) and func.strip():
+        return func.strip()
+    sink = finding.get("sink_info")
+    if isinstance(sink, dict):
+        name = sink.get("function_name")
+        if isinstance(name, str) and name.strip():
+            return name.strip()
+    return None
+
+
+def finding_source_text(finding: dict[str, Any]) -> str | None:
+    """Human-readable taint source text from ``source_info`` (not ``snippet``)."""
+    info = finding.get("source_info")
+    if not isinstance(info, dict):
+        return None
+    context = info.get("context")
+    source_type = info.get("source_type")
+    location = info.get("location")
+    parts: list[str] = []
+    if isinstance(source_type, str) and source_type.strip():
+        parts.append(source_type.strip())
+    if isinstance(context, str) and context.strip():
+        parts.append(context.strip())
+    if isinstance(location, str) and location.strip() and not parts:
+        parts.append(location.strip())
+    if not parts:
+        return None
+    if len(parts) == 1:
+        return parts[0]
+    if isinstance(context, str) and context.strip() and isinstance(source_type, str):
+        return f"{source_type.strip()} ({context.strip()})"
+    return " @ ".join(parts)
+
+
+def finding_sink_text(finding: dict[str, Any]) -> str | None:
+    """Human-readable sink text from ``sink_info`` or the finding snippet."""
+    sink = finding.get("sink_info")
+    if isinstance(sink, dict):
+        name = sink.get("function_name")
+        if isinstance(name, str) and name.strip():
+            return name.strip()
+        sink_type = sink.get("sink_type")
+        if isinstance(sink_type, str) and sink_type.strip():
+            return sink_type.strip()
+    snippet = finding.get("snippet")
+    if isinstance(snippet, str) and snippet.strip():
+        return snippet.strip()
+    return None
+
+
+def finding_line(finding: dict[str, Any]) -> int:
+    """1-based line number, clamped for SecurityFinding validation."""
+    try:
+        line = int(finding.get("line") or 1)
+    except (TypeError, ValueError):
+        line = 1
+    return max(1, line)
+
+
+def finding_snippet(finding: dict[str, Any]) -> str:
+    """Top-level code snippet (always present on real Sighthound findings)."""
+    snippet = finding.get("snippet")
+    if isinstance(snippet, str):
+        return snippet
+    return ""

--- a/topos/utils/sighthound.py
+++ b/topos/utils/sighthound.py
@@ -144,28 +144,38 @@ def finding_callee(finding: dict[str, Any]) -> str | None:
     return None
 
 
+def _clean_str(value: Any) -> str | None:
+    """Return a stripped non-empty string, or None."""
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
 def finding_source_text(finding: dict[str, Any]) -> str | None:
-    """Human-readable taint source text from ``source_info`` (not ``snippet``)."""
+    """Human-readable taint source text from ``source_info`` (not ``snippet``).
+
+    Combines ``source_type`` with the origin ``location`` (kept for cross-file
+    flows, where the source lives in another file) and the ``context``.
+    """
     info = finding.get("source_info")
     if not isinstance(info, dict):
         return None
-    context = info.get("context")
-    source_type = info.get("source_type")
-    location = info.get("location")
-    parts: list[str] = []
-    if isinstance(source_type, str) and source_type.strip():
-        parts.append(source_type.strip())
-    if isinstance(context, str) and context.strip():
-        parts.append(context.strip())
-    if isinstance(location, str) and location.strip() and not parts:
-        parts.append(location.strip())
-    if not parts:
+    source_type = _clean_str(info.get("source_type"))
+    location = _clean_str(info.get("location"))
+    context = _clean_str(info.get("context"))
+
+    head = source_type or location or context
+    if head is None:
         return None
-    if len(parts) == 1:
-        return parts[0]
-    if isinstance(context, str) and context.strip() and isinstance(source_type, str):
-        return f"{source_type.strip()} ({context.strip()})"
-    return " @ ".join(parts)
+
+    # Anchor on the source type, then append location and context when they
+    # add information beyond the head.
+    text = head
+    if location and location != head:
+        text = f"{text} @ {location}"
+    if context and context != head:
+        text = f"{text} ({context})"
+    return text
 
 
 def finding_sink_text(finding: dict[str, Any]) -> str | None:


### PR DESCRIPTION
## Summary
- Fix false SECURE when Sighthound is installed: classify findings by Sighthound tags (`taint_analysis` / `data_flow` / `cross_file`), not `finding_type` labels.
- Map MCP/agent `security_findings` from real fields (`function`, `snippet`, `source_info.context`, `sink_info.function_name`).
- Replace schema-wrong unit mocks with live-shaped fixtures so CPG metrics and diagnostics stay aligned with the CLI.
- README: shout out [GitNexus](https://github.com/abhigyanpatwari/GitNexus) and [Sighthound](https://github.com/Corgea/Sighthound); position Topos as the **operator** over specialist tree-sitter analytics into one agent lattice.

## Context
PR #134 outsources SECURE to Corgea/Sighthound. The original adapter treated `finding_type` as search/taint mode. Upstream Sighthound uses vuln labels there (e.g. `"Command Injection"`) and counts taint via tags — so metrics collapsed to `(0, 0)` and vulnerable code looked SECURE.

## Test plan
- [x] `pytest tests/utils/test_sighthound.py` (9 passed)
- [x] Local dogfood with real Sighthound binary on PATH:
  - `vuln.py` → `cpg.dangerous_calls=4`, secure SLOP, 4 `dangerous_call` findings
  - `safe.py` → SIMPLE_SECURE
  - fallback without Sighthound still reports 4 dangerous calls
- [x] MCP path: `classify_file` / `overlay_for_file` and `classify_code_string` / `overlay_for_source` return 4 active findings with correct callees/snippets
- [x] README review: pillars blurb, optional Sighthound install note, operator table under How it works
- [x] CI green on this PR