### PR TITLE
fix(vscode): avoid files for failed downloads

### DIFF
--- a/extensions/vscode/src/runtime.ts
+++ b/extensions/vscode/src/runtime.ts
@@ -160,11 +160,13 @@ export function downloadFile(
     redirectsRemaining: number = MAX_REDIRECTS
 ): Promise<void> {
     return new Promise((resolve, reject) => {
-        const file = fs.createWriteStream(destPath);
+        let file: fs.WriteStream | undefined;
 
         const cleanup = () => {
-            file.close();
-            fs.unlink(destPath, () => {});
+            if (file) {
+                file.close();
+                fs.unlink(destPath, () => {});
+            }
         };
 
         const request = getImpl(targetUrl, (response) => {
@@ -189,6 +191,8 @@ export function downloadFile(
                 return;
             }
 
+            const destinationFile = fs.createWriteStream(destPath);
+            file = destinationFile;
             const totalBytes = parseInt(response.headers['content-length'] ?? '0', 10);
             let downloadedBytes = 0;
 
@@ -199,14 +203,14 @@ export function downloadFile(
                 }
             });
 
-            response.pipe(file);
+            response.pipe(destinationFile);
 
-            file.on('finish', () => {
-                file.close();
+            destinationFile.on('finish', () => {
+                destinationFile.close();
                 resolve();
             });
 
-            file.on('error', (err) => {
+            destinationFile.on('error', (err) => {
                 cleanup();
                 reject(err);
             });


### PR DESCRIPTION
> [!IMPORTANT]
> **TL;DR:** fix git action failure

## Summary
- defer creation of the download destination stream until the response is confirmed as HTTP 200
- prevent redirects and non-200 responses from creating an empty destination file
- retain cleanup for failures that occur after a successful response starts writing

## Verification
- pnpm run test:unit (24 passed)
- pnpm run check-types
- pnpm run lint
- git diff --check

The pnpm checks ran in a temporary verification copy. The repository continues to use its existing package-lock setup; no pnpm lockfile or workspace configuration is included in this PR.

Closes #173