### PR TITLE
fix(security): keep allowlisted `SECURE` surfaces consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Sighthound/Corgea SECURE Outsourcing:** Deprecates Python-based pattern matching and BFS taint-path tracing on the Code Property Graph (CPG) by outsourcing security analysis directly to Corgea/Sighthound when available on system `PATH`. When `sighthound` is present, Topos invokes it to parse JSON-formatted findings and maps them into standard `cpg.dangerous_calls` and `cpg.taint_flows`. If `sighthound` is absent, Topos gracefully falls back to local CPG danger and taint probes.
 
+### Fixed
+
+- **Consistent allowlisting for Sighthound SECURE metrics:** Standardized `cpg.security_metrics` to filter Sighthound findings and local CPG probes through the same active engine, resolving discrepancies where Sighthound-only findings stayed active while `secure_adjusted` passed. Sighthound taint findings now correctly resolve to the actionable sink operation (`sink_type`) instead of the containing function name, ensuring consistent suffix-aware allowlist mapping. (Closes #168)
+
 ## [0.3.11] - 2026-07-13
 
 ### Changed

--- a/tests/evaluation/test_suppression.py
+++ b/tests/evaluation/test_suppression.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
 from topos.config import AllowEntry, ToposConfig, load_topos_config, merge_cli_allows
 from topos.core.morphism import ProgramMorphism
@@ -34,6 +35,40 @@ def test_allowlist_flips_secure_and_caps_grade() -> None:
     assert verdict.acknowledged[0][0].callee == "eval"
     # SECURE is only acknowledged, never a clean pass — no top grade.
     assert verdict.adjusted_element != EvaluationValue.IDEAL
+
+
+def test_sighthound_adjustment_keeps_non_allowlisted_finding_active() -> None:
+    raw_findings = [
+        {
+            "function": "eval",
+            "finding_type": "Code Injection",
+            "line": 1,
+            "snippet": "eval(x)",
+            "tags": ["injection"],
+        },
+        {
+            "function": "database.query",
+            "finding_type": "SQL Injection",
+            "line": 2,
+            "snippet": "database.query(x)",
+            "tags": ["sql"],
+        },
+    ]
+    with (
+        patch("shutil.which", return_value="/usr/local/bin/sighthound"),
+        patch(
+            "topos.utils.sighthound.run_sighthound_scan",
+            return_value=raw_findings,
+        ),
+    ):
+        result, cpg, findings = _setup("eval(x)\ndatabase.query(x)\n")
+        config = ToposConfig(allow=[AllowEntry(pattern="eval", reason="trusted")])
+
+        verdict = apply_allowlist(result, findings, config, file_path="f.py", cpg=cpg)
+
+    assert verdict.adjusted_secure_pass is False
+    assert [finding.callee for finding in verdict.active_findings] == ["database.query"]
+    assert [finding.callee for finding, _entry in verdict.acknowledged] == ["eval"]
 
 
 def test_no_allowlist_leaves_raw_intact() -> None:

--- a/tests/utils/test_sighthound.py
+++ b/tests/utils/test_sighthound.py
@@ -17,6 +17,7 @@ from topos.mcp.security_findings import security_findings
 from topos.utils.sighthound import (
     count_findings,
     finding_callee,
+    finding_sink_text,
     finding_source_text,
     is_taint_finding,
     run_sighthound_scan,
@@ -76,6 +77,15 @@ MOCK_SEARCH_FINDING_CMD = {
         "variable": "subprocess",
     },
     "tags": ["command", "injection", "subprocess"],
+}
+
+MOCK_SIGHTHOUND_ONLY_FINDING = {
+    **MOCK_SEARCH_FINDING,
+    "line": 9,
+    "function": "database.query",
+    "finding_type": "SQL Injection",
+    "snippet": "database.query(user_input)",
+    "tags": ["sql", "injection"],
 }
 
 # Single-file taint finding tags from scanning_logic.rs.
@@ -166,10 +176,14 @@ def test_count_findings_real_schema():
     assert taint_only == 0
     d, t = count_findings([MOCK_CROSS_FILE_TAINT])
     assert (d, t) == (0, 1)
+    assert count_findings(MOCK_SIGHTHOUND_OUTPUT, {"eval"}) == (1, 1)
+    assert count_findings([MOCK_CROSS_FILE_TAINT], {"os.system"}) == (0, 0)
 
 
 def test_finding_callee():
     assert finding_callee(MOCK_SEARCH_FINDING) == "eval"
+    assert finding_callee(MOCK_CROSS_FILE_TAINT) == "os.system"
+    assert finding_sink_text(MOCK_CROSS_FILE_TAINT) == "os.system"
     assert finding_callee({"sink_info": {"function_name": "exec"}}) == "exec"
     assert finding_callee({}) is None
 
@@ -306,6 +320,33 @@ def test_security_findings_with_sighthound(mock_scan, mock_which):
     # Source text keeps the origin location alongside type and context.
     assert f3.source == "request.args @ app.py:10 (function: index)"
     assert f3.sink == "os.system"
+
+
+@patch("shutil.which")
+@patch("topos.utils.sighthound.run_sighthound_scan")
+def test_sighthound_allowlist_preserves_unrelated_rules(mock_scan, mock_which):
+    mock_which.return_value = "/usr/local/bin/sighthound"
+    mock_scan.return_value = [
+        MOCK_SEARCH_FINDING,
+        MOCK_SIGHTHOUND_ONLY_FINDING,
+        MOCK_CROSS_FILE_TAINT,
+    ]
+
+    span = SourceSpan("main.py", 0, 10, 1, 0, 1, 10)
+    native = NativeRef("tree-sitter", "0.22", "module")
+    uast = UASTNode("module", "python", span, native)
+    cpg = CodePropertyGraph.from_uast(uast, source="eval(x)")
+
+    assert cpg.metrics()["cpg.dangerous_calls"] == 2.0
+    adjusted = cpg.security_metrics(allow={"eval"})
+    assert adjusted["cpg.dangerous_calls"] == 1.0
+    assert adjusted["cpg.taint_flows"] == 1.0
+    findings = security_findings(cpg, allow={"eval"})
+    assert [finding.callee for finding in findings] == [
+        "database.query",
+        "os.system",
+    ]
+    assert findings[1].sink == "os.system"
 
 
 @patch("shutil.which")

--- a/topos/evaluation/suppression.py
+++ b/topos/evaluation/suppression.py
@@ -19,8 +19,7 @@ from dataclasses import dataclass, field
 from topos.config import AllowEntry, ToposConfig
 from topos.core.omega import EvaluationValue
 from topos.evaluation.characteristic_morphism import ClassificationResult
-from topos.functors.probes.cpg.danger import _matches_registry, dangerous_api_reachable
-from topos.functors.probes.cpg.taint import taint_flow_paths
+from topos.functors.probes.cpg.danger import _matches_registry
 from topos.graphs.cpg.object import CodePropertyGraph
 from topos.mcp.schemas import SecurityFinding
 
@@ -90,8 +89,9 @@ def apply_allowlist(
     # Recompute the adjusted SECURE gate from exact counts (gate == 0).
     allow_patterns = {entry.pattern for entry in entries}
     if allow_patterns and cpg is not None:
-        dangerous = dangerous_api_reachable(cpg, allow_patterns)
-        taint = taint_flow_paths(cpg, allow_patterns)
+        adjusted_metrics = cpg.security_metrics(allow=allow_patterns)
+        dangerous = adjusted_metrics["cpg.dangerous_calls"]
+        taint = adjusted_metrics["cpg.taint_flows"]
         adjusted_secure_pass = dangerous == 0 and taint == 0
     else:
         adjusted_secure_pass = raw_secure_pass

--- a/topos/graphs/cpg/object.py
+++ b/topos/graphs/cpg/object.py
@@ -67,6 +67,15 @@ class CodePropertyGraph:
     # ------------------------------------------------------------------
 
     def metrics(self) -> dict[str, float]:
+        """Return canonical SECURE metrics without acknowledgement overlays."""
+        return self.security_metrics()
+
+    def security_metrics(self, *, allow: set[str] | None = None) -> dict[str, float]:
+        """Return SECURE metrics with optional disclosed-risk exclusions.
+
+        ``metrics()`` remains the canonical raw Representation contract. This
+        explicit method is used only to compute the allowlist-adjusted view.
+        """
         if shutil.which("sighthound"):
             file_path = None
             for node in self.nodes.values():
@@ -76,7 +85,7 @@ class CodePropertyGraph:
             from topos.utils.sighthound import count_findings, run_sighthound_scan
 
             findings = run_sighthound_scan(self.source, self.language, file_path)
-            dangerous, taint = count_findings(findings)
+            dangerous, taint = count_findings(findings, allow=allow)
             return {
                 "cpg.dangerous_calls": float(dangerous),
                 "cpg.taint_flows": float(taint),
@@ -86,6 +95,6 @@ class CodePropertyGraph:
         from topos.functors.probes.cpg.taint import taint_flow_paths
 
         return {
-            "cpg.dangerous_calls": float(dangerous_api_reachable(self)),
-            "cpg.taint_flows": float(taint_flow_paths(self)),
+            "cpg.dangerous_calls": float(dangerous_api_reachable(self, allow)),
+            "cpg.taint_flows": float(taint_flow_paths(self, allow)),
         }

--- a/topos/mcp/security_findings.py
+++ b/topos/mcp/security_findings.py
@@ -25,8 +25,9 @@ def security_findings(
 ) -> list[SecurityFinding]:
     """Return concise dangerous-call and taint-flow diagnostics.
 
-    When *allow* is given, allowlisted patterns are excluded from the
-    registry first.  ``allow=None`` preserves canonical behavior.
+    When *allow* is given, matching callees are excluded using the same
+    suffix-aware rules as SECURE metrics. ``allow=None`` preserves canonical
+    behavior.
 
     If the ``sighthound`` CLI is on ``PATH``, findings come from its ruleset
     (via :mod:`topos.utils.sighthound`); otherwise local CPG probes are used.
@@ -62,13 +63,12 @@ def _sighthound_security_findings(
             break
 
     raw_findings = run_sighthound_scan(cpg.source, cpg.language, file_path)
-    registry = effective_registry(cpg.language, allow) if allow is not None else None
 
     findings: list[SecurityFinding] = []
     for raw in raw_findings:
         if not isinstance(raw, dict):
             continue
-        mapped = _map_sighthound_finding(raw, registry=registry)
+        mapped = _map_sighthound_finding(raw, allow=allow)
         if mapped is None:
             continue
         findings.append(mapped)
@@ -80,24 +80,23 @@ def _sighthound_security_findings(
 def _map_sighthound_finding(
     raw: dict[str, Any],
     *,
-    registry: set[str] | None,
+    allow: set[str] | None,
 ) -> SecurityFinding | None:
     """Convert one Sighthound finding; return None if allowlisted away."""
     from topos.utils.sighthound import (
         finding_callee,
         finding_line,
+        finding_matches_allowlist,
         finding_sink_text,
         finding_snippet,
         finding_source_text,
         is_taint_finding,
     )
 
-    callee = finding_callee(raw)
-    # When an allow set is active, ``effective_registry`` already dropped
-    # allowlisted callees. Skip findings whose callee is no longer dangerous.
-    if registry is not None and callee and not _matches_registry(callee, registry):
+    if finding_matches_allowlist(raw, allow):
         return None
 
+    callee = finding_callee(raw)
     taint = is_taint_finding(raw)
     kind = "taint_flow" if taint else "dangerous_call"
     source = finding_source_text(raw) if taint else None

--- a/topos/utils/sighthound.py
+++ b/topos/utils/sighthound.py
@@ -7,7 +7,8 @@ Sighthound's JSON schema (see ``Finding`` in Sighthound ``models.rs``):
   finding.
 * Taint findings are tagged with ``taint_analysis`` (plus ``data_flow`` and/or
   ``cross_file``). Search findings carry rule tags only.
-* ``source_info.context`` / ``sink_info.function_name`` — not ``snippet``.
+* Taint sink operations live under ``sink_info``; ``function`` may be the
+  containing function rather than the actionable callee.
 
 This module is the single source of truth for invoking the CLI and classifying
 findings into Topos SECURE metrics (``cpg.dangerous_calls`` /
@@ -115,15 +116,20 @@ def is_taint_finding(finding: dict[str, Any]) -> bool:
     return ftype in _TAINT_FINDING_TYPES
 
 
-def count_findings(findings: list[dict[str, Any]]) -> tuple[int, int]:
+def count_findings(
+    findings: list[dict[str, Any]], allow: set[str] | None = None
+) -> tuple[int, int]:
     """Count ``(dangerous_calls, taint_flows)`` for Topos SECURE metrics.
 
     Search-mode findings → ``cpg.dangerous_calls``.
     Taint-mode findings → ``cpg.taint_flows``.
+    Findings whose callee matches *allow* are excluded from both counts.
     """
     dangerous_calls = 0
     taint_flows = 0
     for finding in findings:
+        if finding_matches_allowlist(finding, allow):
+            continue
         if is_taint_finding(finding):
             taint_flows += 1
         else:
@@ -133,15 +139,36 @@ def count_findings(findings: list[dict[str, Any]]) -> tuple[int, int]:
 
 def finding_callee(finding: dict[str, Any]) -> str | None:
     """Best-effort callee / sink function name for allowlisting and display."""
+    sink = finding.get("sink_info")
+    if is_taint_finding(finding) and isinstance(sink, dict):
+        # Sighthound taint findings use ``function`` / ``function_name`` for
+        # the containing function. ``sink_type`` carries the matched sink
+        # operation (including for cross-file flows).
+        sink_type = sink.get("sink_type")
+        if isinstance(sink_type, str) and sink_type.strip():
+            return sink_type.strip()
+
     func = finding.get("function")
     if isinstance(func, str) and func.strip():
         return func.strip()
-    sink = finding.get("sink_info")
     if isinstance(sink, dict):
         name = sink.get("function_name")
         if isinstance(name, str) and name.strip():
             return name.strip()
     return None
+
+
+def finding_matches_allowlist(finding: dict[str, Any], allow: set[str] | None) -> bool:
+    """Whether a Sighthound finding's actionable callee is acknowledged."""
+    if not allow:
+        return False
+    callee = finding_callee(finding)
+    if not callee:
+        return False
+
+    from topos.functors.probes.cpg.danger import match_registry_key
+
+    return match_registry_key(callee, allow) is not None
 
 
 def _clean_str(value: Any) -> str | None:
@@ -182,6 +209,10 @@ def finding_sink_text(finding: dict[str, Any]) -> str | None:
     """Human-readable sink text from ``sink_info`` or the finding snippet."""
     sink = finding.get("sink_info")
     if isinstance(sink, dict):
+        if is_taint_finding(finding):
+            sink_type = sink.get("sink_type")
+            if isinstance(sink_type, str) and sink_type.strip():
+                return sink_type.strip()
         name = sink.get("function_name")
         if isinstance(name, str) and name.strip():
             return name.strip()

--- a/topos/utils/sighthound.py
+++ b/topos/utils/sighthound.py
@@ -209,20 +209,16 @@ def finding_sink_text(finding: dict[str, Any]) -> str | None:
     """Human-readable sink text from ``sink_info`` or the finding snippet."""
     sink = finding.get("sink_info")
     if isinstance(sink, dict):
-        if is_taint_finding(finding):
-            sink_type = sink.get("sink_type")
-            if isinstance(sink_type, str) and sink_type.strip():
-                return sink_type.strip()
-        name = sink.get("function_name")
-        if isinstance(name, str) and name.strip():
-            return name.strip()
-        sink_type = sink.get("sink_type")
-        if isinstance(sink_type, str) and sink_type.strip():
-            return sink_type.strip()
+        sink_type = _clean_str(sink.get("sink_type"))
+        if is_taint_finding(finding) and sink_type:
+            return sink_type
+        name = _clean_str(sink.get("function_name"))
+        if name:
+            return name
+        if sink_type:
+            return sink_type
     snippet = finding.get("snippet")
-    if isinstance(snippet, str) and snippet.strip():
-        return snippet.strip()
-    return None
+    return _clean_str(snippet)
 
 
 def finding_line(finding: dict[str, Any]) -> int:


### PR DESCRIPTION
## Summary

- preserve `CodePropertyGraph.metrics()` as the canonical raw SECURE representation contract
- compute allowlist-adjusted metrics through the same active engine as raw classification (Sighthound or local probes)
- share suffix-aware allowlist matching across Sighthound counts and diagnostics
- resolve taint findings to the actionable sink operation, including cross-file flows
- add regressions for Sighthound-only findings and unrelated active risks

## Root cause

Raw SECURE metrics used Sighthound when available, but `apply_allowlist()` always recomputed adjusted counts with the smaller local dangerous-API registry. The Sighthound diagnostics path also filtered through that local registry, so a non-allowlisted Sighthound-only finding could remain active while `secure_adjusted` incorrectly passed—or disappear from `security_findings` entirely.

The fix keeps raw scoring canonical and introduces an explicit allow-aware CPG metrics path used only by the disclosed acknowledgement overlay.

## Verification

- `uv run pytest -q` — 817 passed, 11 skipped
- `uv run ruff check topos tests`
- `uv run ruff format --check topos tests`
- `git diff --check`

Fixes #168