### PR TITLE
fix(ci): install OpenWiki via pnpm action run_install

### DIFF
--- a/.github/workflows/openwiki.yml
+++ b/.github/workflows/openwiki.yml
@@ -40,16 +40,13 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           version: 11.8.0
+          run_install: |
+            - args: [--global, openwiki]
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "22"
-
-      - name: Install OpenWiki
-        # pnpm/action-setup configures PNPM_HOME on PATH, so the global
-        # `openwiki` binary is available to the next step.
-        run: pnpm add --global openwiki
 
       - name: Run OpenWiki
         # --update also handles the first run for code docs when env vars are set.


### PR DESCRIPTION
## Summary

- Fixes the **OpenWiki Update** workflow failure introduced in #175 when OpenWiki install was switched from `npm install --global` to `pnpm add --global`.
- Uses `pnpm/action-setup`'s documented `run_install` global pattern so `$PNPM_HOME/bin` is on PATH before the `openwiki` CLI runs.
- Removes the separate **Install OpenWiki** step; global install happens during pnpm setup.

## Root cause

`pnpm/action-setup` puts the `pnpm` binary on PATH, but a standalone `pnpm add --global` step fails because global CLIs install to `$PNPM_HOME/bin`, which was not on PATH:

```
[ERROR] The configured global bin directory ".../bin" is not in PATH
```

## Test plan

- [ ] Merge and manually re-run **OpenWiki Update** on `main` to confirm the `update` job passes **Install OpenWiki** / **Run OpenWiki**
- [ ] Verify the generated docs PR is opened as before


Made with [Cursor](https://cursor.com)