### PR TITLE
fix(ci): put PNPM_HOME/bin on PATH for OpenWiki global install

### DIFF
--- a/.github/workflows/openwiki.yml
+++ b/.github/workflows/openwiki.yml
@@ -40,13 +40,20 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           version: 11.8.0
-          run_install: |
-            - args: [--global, openwiki]
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "22"
+
+      - name: Install OpenWiki
+        # pnpm refuses global installs unless $PNPM_HOME/bin is on PATH.
+        # action-setup exposes pnpm but not the global prefix; wire both here.
+        run: |
+          echo "${PNPM_HOME}/bin" >> "$GITHUB_PATH"
+          pnpm add --global openwiki
+        env:
+          PATH: ${{ env.PNPM_HOME }}/bin:${{ env.PATH }}
 
       - name: Run OpenWiki
         # --update also handles the first run for code docs when env vars are set.


### PR DESCRIPTION
## Summary

- Fixes **OpenWiki Update** still failing after #179.
- #179 used `pnpm/action-setup` `run_install: [--global, openwiki]`, but that runs the same global install and hits the identical error: global bin dir `$PNPM_HOME/bin` is not on PATH.
- Explicitly adds `$PNPM_HOME/bin` to PATH for the install step and persists it via `GITHUB_PATH` for `Run OpenWiki`.

## Root cause (why #179 failed too)

`run_install` ultimately runs `pnpm install --global openwiki` inside the action — it does **not** configure the global prefix on PATH. Same failure as the original #175 change:

```
[ERROR] The configured global bin directory ".../bin" is not in PATH
```

## Test plan

- [ ] Merge and re-run **OpenWiki Update** on `main`
- [ ] Confirm **Install OpenWiki** and **Run OpenWiki** both pass


Made with [Cursor](https://cursor.com)