### PR TITLE
release: v0.3.12

### DIFF
--- a/.mcp/server.json
+++ b/.mcp/server.json
@@ -17,13 +17,13 @@
     "url": "https://github.com/Krv-Labs/topos",
     "source": "github"
   },
-  "version": "0.3.11",
+  "version": "0.3.12",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "topos-mcp",
-      "version": "0.3.11",
+      "version": "0.3.12",
       "transport": {
         "type": "stdio"
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.12] - 2026-07-20
+
 ### Added
 
-- **Sighthound/Corgea SECURE Outsourcing:** Deprecates Python-based pattern matching and BFS taint-path tracing on the Code Property Graph (CPG) by outsourcing security analysis directly to Corgea/Sighthound when available on system `PATH`. When `sighthound` is present, Topos invokes it to parse JSON-formatted findings and maps them into standard `cpg.dangerous_calls` and `cpg.taint_flows`. If `sighthound` is absent, Topos gracefully falls back to local CPG danger and taint probes.
+- **Sighthound/Corgea SECURE Outsourcing:** Deprecates Python-based pattern matching and BFS taint-path tracing on the Code Property Graph (CPG) by outsourcing security analysis directly to Corgea/Sighthound when available on system `PATH`. When `sighthound` is present, Topos invokes it to parse JSON-formatted findings and maps them into standard `cpg.dangerous_calls` and `cpg.taint_flows`. If `sighthound` is absent, Topos gracefully falls back to local CPG danger and taint probes. (Closes [#130](https://github.com/Krv-Labs/topos/issues/130))
+- **OpenWiki engineering wiki:** Regenerated repository documentation under `openwiki/` (architecture, workflows, domain concepts, operations, integrations) with CI refresh on merges to `main`. ([#169](https://github.com/Krv-Labs/topos/pull/169))
+
+### Changed
+
+- **VS Code extension package manager:** Migrated `extensions/vscode` from npm to pnpm (`packageManager: pnpm@11.8.0`), updated CI/release workflows to `pnpm/action-setup` with frozen lockfile, and publish with `vsce --no-dependencies`. GitNexus install hints now prefer `pnpm add -g` with npm fallback. ([#175](https://github.com/Krv-Labs/topos/pull/175), closes [#71](https://github.com/Krv-Labs/topos/issues/71))
 
 ### Fixed
 
-- **Consistent allowlisting for Sighthound SECURE metrics:** Standardized `cpg.security_metrics` to filter Sighthound findings and local CPG probes through the same active engine, resolving discrepancies where Sighthound-only findings stayed active while `secure_adjusted` passed. Sighthound taint findings now correctly resolve to the actionable sink operation (`sink_type`) instead of the containing function name, ensuring consistent suffix-aware allowlist mapping. (Closes #168)
+- **Consistent allowlisting for Sighthound SECURE metrics:** Standardized `cpg.security_metrics` to filter Sighthound findings and local CPG probes through the same active engine, resolving discrepancies where Sighthound-only findings stayed active while `secure_adjusted` passed. Sighthound taint findings now correctly resolve to the actionable sink operation (`sink_type`) instead of the containing function name, ensuring consistent suffix-aware allowlist mapping. (Closes [#168](https://github.com/Krv-Labs/topos/issues/168), [#174](https://github.com/Krv-Labs/topos/pull/174))
+- **VS Code extension failed binary downloads:** Deferred creation of the download destination stream until the HTTP response is confirmed as 200, preventing redirects and non-200 responses from leaving an empty file on disk. (Closes [#173](https://github.com/Krv-Labs/topos/issues/173), [#172](https://github.com/Krv-Labs/topos/pull/172))
 
 ## [0.3.11] - 2026-07-13
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topos-functors"
-version = "0.3.11"
+version = "0.3.12"
 edition = "2021"
 
 [lib]

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "topos-vscode",
   "displayName": "Topos: Code Quality Targets for Agents",
   "description": "Structural code-quality targets your coding agents can optimize toward, delivered as MCP tools for agent mode.",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "publisher": "KrvLabs",
   "icon": "icon.png",
   "license": "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
## Summary

- Bump version to **0.3.12** in `Cargo.toml`, VS Code extension, and MCP registry manifest.
- Finalize changelog for changes merged since v0.3.11:
  - **Sighthound/Corgea SECURE outsourcing** — delegate security analysis to Sighthound when available, with graceful fallback to local CPG probes ([#134](https://github.com/Krv-Labs/topos/pull/134), closes [#130](https://github.com/Krv-Labs/topos/issues/130))
  - **Consistent Sighthound allowlisting** — unified active-engine filtering for `cpg.security_metrics` and correct taint sink resolution ([#174](https://github.com/Krv-Labs/topos/pull/174), closes [#168](https://github.com/Krv-Labs/topos/issues/168))
  - **VS Code extension pnpm migration** — npm → pnpm for extension deps, CI, and GitNexus install hints ([#175](https://github.com/Krv-Labs/topos/pull/175), closes [#71](https://github.com/Krv-Labs/topos/issues/71))
  - **VS Code download fix** — avoid creating empty files on failed binary downloads ([#172](https://github.com/Krv-Labs/topos/pull/172), closes [#173](https://github.com/Krv-Labs/topos/issues/173))
  - **OpenWiki engineering wiki** — regenerated docs under `openwiki/` with CI refresh ([#169](https://github.com/Krv-Labs/topos/pull/169))

## Test plan

- [x] `python3 scripts/check_versions.py` passes (0.3.12)
- [x] CI green on release PR (build matrix + packaging smoke tests)
- [ ] After merge: tag `v0.3.12` to trigger release workflow (binaries, PyPI, VS Code Marketplace)


Made with [Cursor](https://cursor.com)