### PR TITLE
fix: address PR #185 review findings

### DIFF
--- a/.github/workflows/clawhub-publish.yml
+++ b/.github/workflows/clawhub-publish.yml
@@ -6,7 +6,10 @@
 #   2. GitHub → Settings → Secrets and variables → Actions → New repository secret
 #      Name: CLAWHUB_TOKEN
 #      Value: <paste token>
-# Without this secret, PR dry-runs still work; pushes to main and v* tags skip real publish.
+# Without this secret, PR dry-runs still work, but pushes to main and v* tags FAIL:
+# the upstream workflow exits 1 ("Real skill publishes need secrets.clawhub_token").
+# Fork PRs also fail: the upstream workflow requires an OIDC token, and fork-originated
+# pull_request runs never receive id-token: write.
 name: ClawHub Skill Publish
 
 on:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,14 @@
 <!-- OPENWIKI:START -->
 
+## OpenWiki
+
+This repository uses OpenWiki for recurring code documentation. Start with `openwiki/quickstart.md`, then follow its links to architecture, workflows, domain concepts, operations, integrations, testing guidance, and source maps.
+
+The scheduled OpenWiki GitHub Actions workflow refreshes the repository wiki. Do not hand-edit generated OpenWiki pages unless explicitly asked; prefer updating source code/docs and letting OpenWiki regenerate.
+
+<!-- OPENWIKI:END -->
+
+<!-- SKILLS:START (repo-owned; OpenWiki must not edit this block) -->
 ## Agent Skills
 
 Canonical skill at [`skills/topos/SKILL.md`](skills/topos/SKILL.md) — published to ClawHub and installable via Hermes taps.
@@ -13,15 +22,7 @@ Canonical skill at [`skills/topos/SKILL.md`](skills/topos/SKILL.md) — publishe
 Validate with `python scripts/check_skill.py` (requires each skill's `version:` to match `Cargo.toml`).
 
 **ClawHub publish setup:** add repo secret `CLAWHUB_TOKEN` — create a token at [clawhub.ai](https://clawhub.ai) (`clh_...`), then GitHub → Settings → Secrets and variables → Actions. The [ClawHub Skill Publish](.github/workflows/clawhub-publish.yml) workflow dry-runs on PRs and publishes on `main` (`skills/**`) and `v*` tags. Manual fallback: `clawhub skill publish ./skills/topos --owner Krv-Labs`.
-
-
-## OpenWiki
-
-This repository uses OpenWiki for recurring code documentation. Start with `openwiki/quickstart.md`, then follow its links to architecture, workflows, domain concepts, operations, integrations, testing guidance, and source maps.
-
-The scheduled OpenWiki GitHub Actions workflow refreshes the repository wiki. Do not hand-edit generated OpenWiki pages unless explicitly asked; prefer updating source code/docs and letting OpenWiki regenerate.
-
-<!-- OPENWIKI:END -->
+<!-- SKILLS:END -->
 
 <!-- OPENWIKI-POLICY:START -->
 ## OpenWiki CI (repo-owned policy)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@
 </p>
 <!-- mcp-name: io.github.Krv-Labs/topos -->
 
-
 **Topos** is an _operating layer for AI agents_ that provides structural (geometric & topological) metrics computed over program graphs, surfacing deep
 architectural debt that conventional linters can't compute. It delivers complexity, coupling, and security metrics for your agents to wield as tools,
 establishing a precise, medal-scored (SLOP → GOLD) feedback loop to autonomously write clean, highly composable code.

--- a/scripts/check_skill.py
+++ b/scripts/check_skill.py
@@ -13,7 +13,6 @@ SKILLS_ROOT = ROOT / "skills"
 SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 REQUIRED_SECTIONS = ("## When to Use", "## Pitfalls", "## Verification")
-REQUIRED_FRONTMATTER_KEYS = ("name:", "description:", "version:")
 
 
 def cargo_version() -> str:
@@ -33,8 +32,20 @@ def parse_scalar(block: str, key: str) -> str | None:
     return value
 
 
-def frontmatter_contains(block: str, needle: str) -> bool:
-    return needle in block
+def extract_block(block: str, key: str) -> str | None:
+    """Return the lines nested under `key:`, or None if the key is absent."""
+    lines = block.splitlines()
+    for index, line in enumerate(lines):
+        if not line.strip().startswith(f"{key}:"):
+            continue
+        indent = len(line) - len(line.lstrip())
+        nested = []
+        for candidate in lines[index + 1 :]:
+            if candidate.strip() and len(candidate) - len(candidate.lstrip()) <= indent:
+                break
+            nested.append(candidate)
+        return "\n".join(nested)
+    return None
 
 
 def validate_skill(skill_dir: Path, expected_version: str) -> list[str]:
@@ -50,10 +61,6 @@ def validate_skill(skill_dir: Path, expected_version: str) -> list[str]:
 
     frontmatter = match.group(1)
     body = text[match.end() :]
-
-    for key in REQUIRED_FRONTMATTER_KEYS:
-        if not frontmatter_contains(frontmatter, key):
-            errors.append(f"{skill_md}: frontmatter missing {key.rstrip(':')}")
 
     name = parse_scalar(frontmatter, "name")
     if not name:
@@ -85,20 +92,23 @@ def validate_skill(skill_dir: Path, expected_version: str) -> list[str]:
         if section not in body:
             errors.append(f"{skill_md}: missing section {section}")
 
-    if "metadata:" not in frontmatter:
+    metadata = extract_block(frontmatter, "metadata")
+    if metadata is None:
         errors.append(f"{skill_md}: frontmatter missing metadata block")
     else:
-        if "openclaw:" not in frontmatter:
+        openclaw = extract_block(metadata, "openclaw")
+        if openclaw is None:
             errors.append(f"{skill_md}: metadata.openclaw block is required")
-        elif "bins:" not in frontmatter:
+        elif "bins:" not in openclaw:
             errors.append(f"{skill_md}: metadata.openclaw.requires.bins is required")
 
-        if "hermes:" not in frontmatter:
+        hermes = extract_block(metadata, "hermes")
+        if hermes is None:
             errors.append(f"{skill_md}: metadata.hermes block is required")
         else:
-            if "tags:" not in frontmatter:
+            if "tags:" not in hermes:
                 errors.append(f"{skill_md}: metadata.hermes.tags is required")
-            if "category:" not in frontmatter:
+            if "category:" not in hermes:
                 errors.append(f"{skill_md}: metadata.hermes.category is required")
 
     return errors


### PR DESCRIPTION
Companion PR into #185. Fixes the findings from review; merge this, then #185.

## Changes

- **AGENTS.md** — moved the Agent Skills section outside the `OPENWIKI:START/END` managed block into its own `SKILLS:START/END` block (mirroring `OPENWIKI-POLICY`). OpenWiki regenerates the managed region and commits AGENTS.md in its docs PR, so the section would have been deleted on the next run. Content is unchanged.
- **clawhub-publish.yml** — corrected the header comment: without `CLAWHUB_TOKEN`, pushes to `main`/`v*` tags **fail** (upstream exits 1), they do not skip. Noted that fork PRs also fail because fork-originated `pull_request` runs never get `id-token: write`.
- **check_skill.py** — nested metadata checks are now scoped to their actual blocks (a `tags:` under `metadata.openclaw` no longer satisfies the `metadata.hermes.tags` requirement). Removed the `REQUIRED_FRONTMATTER_KEYS` loop (duplicated the `parse_scalar` checks, producing double errors) and the single-use `frontmatter_contains` wrapper.
- **README.md** — dropped a stray blank line.

## Verified

- `python scripts/check_skill.py` passes (1 skill, version 0.3.12).
- Negative test: misplaced keys under the wrong metadata block are now rejected.
- Workflow YAML parses.
- Not changed: `owner: Krv-Labs` casing — the PR's own dry-run (run 29837947288) accepted it and reports the skill `alreadySynced` on clawhub.ai.

🤖 Generated with [Claude Code](https://claude.com/claude-code)