### PR TITLE
docs: refresh README messaging and link MCP Registry (#188)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 <!-- mcp-name: io.github.Krv-Labs/topos -->
 
 <p align="center">
-  <a href="#quick-start">Quick Start</a> ·
+  <a href="#install-and-quick-start">Install</a> ·
   <a href="#what-topos-checks">What it checks</a> ·
   <a href="#under-the-hood">Under the hood</a> ·
   <a href="https://docs.krv.ai/topos/">Docs</a> ·
@@ -65,19 +65,33 @@ Topos computes that signal from program structure—not from an LLM review or a 
 
 **Tests check behavior. Topos checks whether the implementation is built to keep changing.**
 
-## Quick Start
 
-### VS Code: install through MCP
+## Under the hood
 
-Open the Extensions view, search **`@mcp topos`**, select **Topos**, and choose **Install**. You can also open the [Topos page in GitHub's MCP Registry](https://github.com/mcp/Krv-Labs/topos) and use its **Install MCP server** menu.
+Topos is a self-contained Rust CLI and MCP server. Analysis runs locally; your source code is not sent to an external model or hosted analysis service.
+
+| Component | Role |
+| :--- | :--- |
+| [tree-sitter](https://tree-sitter.github.io/tree-sitter/) | Parses six languages and powers the native AST, CFG, CPG, PDG, and UAST representations. |
+| [GitNexus](https://github.com/abhigyanpatwari/GitNexus) | Supplies the repository dependency graph scored by COMPOSABLE (`topos depgraph generate`). |
+| [Sighthound](https://github.com/Corgea/Sighthound) | Embedded in the MCP server for supplementary security findings; native CPG probes remain the SECURE scoring source. |
+| [Graphify](https://github.com/Graphify-Labs/graphify) | Optional advisory orphan and fragile-edge detection; it does not affect the medal. |
+
+The result is one agent-facing contract over several structural lenses: one score to optimize, explicit evidence for each failure, and a verification loop that can tell a real improvement from cosmetic churn.
+
+## Install and Quick Start
+
+### VS Code MCP Extension
+
+Open the Extensions view, search **`@mcp topos`**, select **Topos**, and choose **Install**. Or view here: [Topos: GitHub's MCP Registry](https://github.com/mcp/Krv-Labs/topos).
 
 Then ask agent mode:
 
 > Use Topos to find this repository's worst structural problem, make one focused improvement, and verify the result.
 
-VS Code owns the MCP registration, trust prompt, and server lifecycle. No Marketplace extension is required. See the [agent setup guide](https://docs.krv.ai/topos/agents.html) for tool permissions and troubleshooting.
+See the [agent setup guide](https://docs.krv.ai/topos/agents.html) for tool permissions and troubleshooting.
 
-### Other MCP clients
+### Other MCP clients [*Claude Code*]
 
 Run the self-contained MCP server on demand—no persistent Topos or Python installation required:
 
@@ -91,7 +105,6 @@ Setup for Codex, Gemini CLI, Cursor, Windsurf, Antigravity, and manual JSON live
 
 ```bash
 curl -fsSL https://docs.krv.ai/topos/install.sh | sh
-# or: brew install krv-labs/tap/topos
 ```
 
 Prefer Homebrew?
@@ -100,21 +113,26 @@ Prefer Homebrew?
 brew install krv-labs/tap/topos
 ```
 
-On Homebrew 6+, that one-liner auto-taps and trusts only this formula. If you
-`brew tap krv-labs/tap` first, run `brew trust --formula krv-labs/tap/topos`
-before `brew install topos`.
+On Homebrew 6+, that one-liner auto-taps and trusts only this formula. If you `brew tap krv-labs/tap` first, run `brew trust --formula krv-labs/tap/topos` before `brew install topos`.
 
+
+Then run:
 ```bash
-pnpm add -g gitnexus   # once; enables COMPOSABLE / GOLD
-topos depgraph generate
-topos evaluate . -r --gitnexus-dir .gitnexus
+topos evaluate . -r
 ```
 
-`evaluate` ranks the files, shows which pillars pass, and surfaces the cheapest structural improvements.
-
-`COMPOSABLE` needs a cross-file dependency graph. Generate it once (or after large structural edits) with `topos depgraph generate`, then pass `--gitnexus-dir .gitnexus` (or set `TOPOS_GITNEXUS_DIR`). Without a graph, SIMPLE and SECURE still score; COMPOSABLE is skipped.
+> [!TIP]
+> Want GOLD? Run `topos depgraph generate` if your agent hasn't already (+ run again after big structural edits), then evaluate with the added CLI flag `--gitnexus-dir .gitnexus`.
 
 Topos supports Python, Rust, JavaScript, TypeScript, C++, and Go. The CLI defaults to Python; use `--language rust|go|javascript|typescript|cpp` for another language. See [Installation](https://docs.krv.ai/topos/installation.html) for platform support and alternative install paths.
+
+## More ways to use Topos
+
+- **OpenClaw / ClawHub:** [`openclaw skills install @Krv-Labs/topos`](https://clawhub.ai/krv-labs/skills/topos)
+- **Hermes:** `hermes skills tap add Krv-Labs/topos` then `hermes skills install Krv-Labs/topos/topos`
+- **MCP Registry name:** `io.github.Krv-Labs/topos`
+- **CLI reference:** [docs.krv.ai/topos/cli](https://docs.krv.ai/topos/cli.html)
+
 
 ## What Topos checks
 
@@ -182,26 +200,6 @@ graph BT
 [Measures](https://docs.krv.ai/topos/measures.html) · [Category-theory foundations](https://docs.krv.ai/topos/concepts.html)
 
 </details>
-
-## Under the hood
-
-Topos is a self-contained Rust CLI and MCP server. Analysis runs locally; your source code is not sent to an external model or hosted analysis service.
-
-| Component | Role |
-| :--- | :--- |
-| [tree-sitter](https://tree-sitter.github.io/tree-sitter/) | Parses six languages and powers the native AST, CFG, CPG, PDG, and UAST representations. |
-| [GitNexus](https://github.com/abhigyanpatwari/GitNexus) | Supplies the repository dependency graph scored by COMPOSABLE (`topos depgraph generate`). |
-| [Sighthound](https://github.com/Corgea/Sighthound) | Embedded in the MCP server for supplementary security findings; native CPG probes remain the SECURE scoring source. |
-| [Graphify](https://github.com/Graphify-Labs/graphify) | Optional advisory orphan and fragile-edge detection; it does not affect the medal. |
-
-The result is one agent-facing contract over several structural lenses: one score to optimize, explicit evidence for each failure, and a verification loop that can tell a real improvement from cosmetic churn.
-
-## More ways to use Topos
-
-- **OpenClaw / ClawHub:** [`openclaw skills install @Krv-Labs/topos`](https://clawhub.ai/krv-labs/skills/topos)
-- **Hermes:** `hermes skills tap add Krv-Labs/topos` then `hermes skills install Krv-Labs/topos/topos`
-- **MCP Registry name:** `io.github.Krv-Labs/topos`
-- **CLI reference:** [docs.krv.ai/topos/cli](https://docs.krv.ai/topos/cli.html)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@
   <a href="https://pypi.org/project/topos-mcp/"><img src="https://img.shields.io/pypi/v/topos-mcp.svg" alt="PyPI"></a>
   <a href="https://pypi.org/project/topos-mcp/"><img src="https://img.shields.io/pypi/pyversions/topos-mcp.svg" alt="Python versions"></a>
   <a href="https://github.com/Krv-Labs/topos/blob/main/LICENSE"><img src="https://img.shields.io/github/license/Krv-Labs/topos" alt="License"></a>
+  <a href="https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.Krv-Labs/topos"><img src="https://img.shields.io/badge/MCP-Registry-555" alt="MCP Registry"></a>
   <a href="https://glama.ai/mcp/servers/Krv-Labs/topos"><img src="https://glama.ai/mcp/servers/Krv-Labs/topos/badges/score.svg" alt="topos MCP server"></a>
+  <a href="https://clawhub.ai/krv-labs/skills/topos"><img src="https://img.shields.io/badge/ClawHub-topos-111" alt="ClawHub"></a>
 </p>
 
 <p align="center">
-  <b>Structural code quality metrics for agent-written programs.</b><br>
+  <b>Agent harness for tree-sitter and graph-based coding tools — so agents write clean, composable, secure code.</b><br>
   <a href="https://docs.krv.ai/topos/">Docs</a> ·
   <a href="#quick-start">Quick Start</a> ·
   <a href="#mcp-server-for-agents">MCP Server</a> ·
@@ -23,16 +25,21 @@
 </p>
 <!-- mcp-name: io.github.Krv-Labs/topos -->
 
-**Topos** is an _operating layer for AI agents_ that provides structural (geometric & topological) metrics computed over program graphs, surfacing deep
-architectural debt that conventional linters can't compute. It delivers complexity, coupling, and security metrics for your agents to wield as tools,
-establishing a precise, medal-scored (SLOP → GOLD) feedback loop to autonomously write clean, highly composable code.
+Topos is a category theory–inspired framework that sits on top of tree-sitter, [GitNexus](https://github.com/abhigyanpatwari/GitNexus), and [Sighthound](https://github.com/Corgea/Sighthound) — one scored target for structural code quality instead of disconnected tools. Passing unit tests proves your code works; **Topos** proves it's built to last, scoring complexity, coupling, and data-flow risk so agents have something concrete to optimize toward, instead of a vague "clean it up."
 
 ---
 
 ## Quick Start
 
+Install:
+
 ```bash
 curl -fsSL https://docs.krv.ai/topos/install.sh | sh
+```
+
+From your repo root (or `cd /path/to/your/repo` first):
+
+```bash
 topos evaluate src/ -r
 ```
 
@@ -50,15 +57,23 @@ before `brew install topos`.
 
 Other install paths (PyPI, source checkout) and the full command tour live at **[docs.krv.ai/topos/installation](https://docs.krv.ai/topos/installation.html)**.
 
+## Built on
+
+Topos doesn't reinvent graph analysis for code — it orchestrates specialist tools most agents would otherwise have to run separately, and scores their combined output as one medal:
+
+| Tool | Integration | What it gives Topos |
+| :--- | :--- | :--- |
+| [tree-sitter](https://tree-sitter.github.io/tree-sitter/) | wired in | ASTs / CFGs that power **SIMPLE** and structural coverage |
+| [GitNexus](https://github.com/abhigyanpatwari/GitNexus) | wired in (subprocess) | the module dependency graph that **COMPOSABLE** scores |
+| [Sighthound](https://github.com/Corgea/Sighthound) | optional (`PATH`) | supplementary SAST detail alongside the **SECURE** verdict |
+
 ## What you get
 
-Topos checks three independent pillars and awards a **Code Quality Medal** for how many pass:
+Three independent pillars roll up into one **Code Quality Medal**:
 
 - **SIMPLE** — avoids unnecessary complexity (AST entropy & CFG cyclomatic complexity)
-- **COMPOSABLE** — cleanly decoupled from other modules (MDG Martin instability via [GitNexus](https://github.com/abhigyanpatwari/GitNexus))
-- **SECURE** — free of dangerous API reachability and taint paths (CPG analysis; optionally powered by [Sighthound](https://github.com/Corgea/Sighthound))
-
-Topos is the **operator** over those graphs — not another one-off [tree-sitter](https://tree-sitter.github.io/tree-sitter/) script. Specialist engines (GitNexus for the module graph, Sighthound for SAST) feed one medal lattice agents can optimize toward.
+- **COMPOSABLE** — cleanly decoupled from other modules (MDG Martin instability via GitNexus)
+- **SECURE** — free of dangerous API reachability and taint paths (CPG analysis)
 
 | Medal         | Criteria                                    |
 | :------------ | :------------------------------------------ |
@@ -87,10 +102,12 @@ Give any MCP-compatible agent — Claude Code, Cursor, Gemini CLI, Windsurf — 
 claude mcp add --transport stdio topos -- topos mcp
 ```
 
+Topos is published on the [official MCP Registry](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.Krv-Labs/topos) (`io.github.Krv-Labs/topos`) and listed on [Glama](https://glama.ai/mcp/servers/Krv-Labs/topos).
+
 Setup for Cursor, VS Code, Gemini CLI, Codex, and Windsurf, plus troubleshooting and the full MCP tool list: **[docs.krv.ai/topos/agents](https://docs.krv.ai/topos/agents.html)**.
 
 > [!TIP]
-> **OpenClaw:** `openclaw skills install @Krv-Labs/topos`  
+> **OpenClaw / ClawHub:** [`openclaw skills install @Krv-Labs/topos`](https://clawhub.ai/krv-labs/skills/topos)  
 > **Hermes:** `hermes skills tap add Krv-Labs/topos` then `hermes skills install Krv-Labs/topos/topos`
 
 ---

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Topos is a self-contained Rust CLI and MCP server. Analysis runs locally; your s
 | [tree-sitter](https://tree-sitter.github.io/tree-sitter/) | Parses six languages and powers the native AST, CFG, CPG, PDG, and UAST representations. |
 | [GitNexus](https://github.com/abhigyanpatwari/GitNexus) | Supplies the repository dependency graph scored by COMPOSABLE (`topos depgraph generate`). |
 | [Sighthound](https://github.com/Corgea/Sighthound) | Embedded in the MCP server for supplementary security findings; native CPG probes remain the SECURE scoring source. |
-| [Graphify](https://github.com/Graphify-Labs/graphify) | Optional advisory orphan and fragile-edge detection; it does not affect the medal. |
+| [Graphify](https://github.com/Graphify-Labs/graphify) | Optional advisory orphan and fragile-edge detection; it does not affect the medal. *(Coming soon in v0.4.0)* |
 
 The result is one agent-facing contract over several structural lenses: one score to optimize, explicit evidence for each failure, and a verification loop that can tell a real improvement from cosmetic churn.
 
@@ -151,7 +151,7 @@ Those verdicts roll up into one memorable quality medal without hiding which pil
 | 🥉 **BRONZE** | Passes 1 of 3 |
 | ❌ **SLOP** | Passes 0, or fails to parse |
 
-Topos also returns ranked refactor guidance: failing metric locations, control-flow cycles, load-bearing dependency edges, process bottlenecks, and optional Graphify knowledge-graph findings. Advisory findings never silently change the scored medal.
+Topos also returns ranked refactor guidance: failing metric locations, control-flow cycles, load-bearing dependency edges, process bottlenecks, and optional Graphify knowledge-graph findings *(coming soon in v0.4.0)*. Advisory findings never silently change the scored medal.
 
 <details>
 <summary>How the medal system is derived</summary>

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 </p>
 
 <p align="center">
-  <b>Agent harness for tree-sitter and graph-based coding tools — so agents write clean, composable, secure code.</b><br>
+  <b>Harness for graph-based coding tools, designed to make agents write clean, composable, secure code.</b><br>
   <a href="https://docs.krv.ai/topos/">Docs</a> ·
   <a href="#quick-start">Quick Start</a> ·
   <a href="#mcp-server-for-agents">MCP Server</a> ·
@@ -25,7 +25,8 @@
 </p>
 <!-- mcp-name: io.github.Krv-Labs/topos -->
 
-Topos scores code quality from the geometric and topological structure of program graphs — structural debt conventional linters can't compute — and gives agents a medal-scored (SLOP → GOLD) feedback loop for cleaner, more composable code. Built on [tree-sitter](https://tree-sitter.github.io/tree-sitter/), [GitNexus](https://github.com/abhigyanpatwari/GitNexus), and [Sighthound](https://github.com/Corgea/Sighthound): one scored target instead of disconnected tools.
+Topos scores code quality from the geometric and topological structure of program graphs — structural debt conventional linters can't compute — and gives agents a medal-scored (SLOP → GOLD) feedback loop to optimize for quality. Inspired by concepts from category, Topos combines the power of [tree-sitter](https://tree-sitter.github.io/tree-sitter/), [GitNexus](https://github.com/abhigyanpatwari/GitNexus), and [Sighthound](https://github.com/Corgea/Sighthound) into a well-principled evaluation schema, giving your agents
+one scored target for code quality instead of disconnected tools.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 </p>
 
 <p align="center">
-  <b>Harness for graph-based coding tools, designed to make agents write clean, composable, secure code.</b><br>
+  <b>Harness for graph-based coding tools. Helping agents write clean, composable, secure code.</b><br>
   <a href="https://docs.krv.ai/topos/">Docs</a> ·
   <a href="#quick-start">Quick Start</a> ·
   <a href="#mcp-server-for-agents">MCP Server</a> ·
@@ -25,8 +25,8 @@
 </p>
 <!-- mcp-name: io.github.Krv-Labs/topos -->
 
-Topos scores code quality from the geometric and topological structure of program graphs — structural debt conventional linters can't compute — and gives agents a medal-scored (SLOP → GOLD) feedback loop to optimize for quality. Inspired by concepts from category, Topos combines the power of [tree-sitter](https://tree-sitter.github.io/tree-sitter/), [GitNexus](https://github.com/abhigyanpatwari/GitNexus), and [Sighthound](https://github.com/Corgea/Sighthound) into a well-principled evaluation schema, giving your agents
-one scored target for code quality instead of disconnected tools.
+Topos scores code quality based on the structure of the programs in your codebase. Inspired by concepts from category theory, we've built an extensible evaluation framework that combines [tree-sitter](https://tree-sitter.github.io/tree-sitter/), [GitNexus](https://github.com/abhigyanpatwari/GitNexus), and [Sighthound](https://github.com/Corgea/Sighthound) with custom geometric and topological measures that provide agents with clear, principled targets for writing higher quality code. Agents earn medals for quality in a tight feedback loop, and Topos surfaces the best places in your codebase to refactor and improve structure.
+
 
 ---
 
@@ -41,10 +41,10 @@ curl -fsSL https://docs.krv.ai/topos/install.sh | sh
 From your repo root (or `cd /path/to/your/repo` first):
 
 ```bash
-topos evaluate src/ -r
+topos evaluate . -r
 ```
 
-`evaluate -r` scores every file in `src/` and prints a ranked digest: which pillars pass, the worst-scoring files, and the cheapest fixes to flip a failing pillar. Add `-h` to any command for help, or `--json` for CI.
+`evaluate -r` scores every file in the `cwd` and prints a ranked digest: which pillars pass, the worst-scoring files, and the cheapest fixes to flip a failing pillar. Add `-h` to any command for help, or `--json` for CI.
 
 Prefer Homebrew?
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
   <a href="https://pypi.org/project/topos-mcp/"><img src="https://img.shields.io/pypi/v/topos-mcp.svg" alt="PyPI"></a>
   <a href="https://pypi.org/project/topos-mcp/"><img src="https://img.shields.io/pypi/pyversions/topos-mcp.svg" alt="Python versions"></a>
   <a href="https://github.com/Krv-Labs/topos/blob/main/LICENSE"><img src="https://img.shields.io/github/license/Krv-Labs/topos" alt="License"></a>
-  <a href="https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.Krv-Labs/topos"><img src="https://img.shields.io/badge/MCP-Registry-555" alt="MCP Registry"></a>
+  <a href="https://registry.modelcontextprotocol.io/?q=topos"><img src="https://img.shields.io/badge/MCP-Registry-555" alt="MCP Registry"></a>
   <a href="https://glama.ai/mcp/servers/Krv-Labs/topos"><img src="https://glama.ai/mcp/servers/Krv-Labs/topos/badges/score.svg" alt="topos MCP server"></a>
-  <a href="https://clawhub.ai/krv-labs/skills/topos"><img src="https://img.shields.io/badge/ClawHub-topos-111" alt="ClawHub"></a>
+  <a href="https://clawhub.ai/krv-labs/skills/topos"><img src="https://img.shields.io/badge/%F0%9F%A6%9E_ClawHub-topos-F97316" alt="ClawHub"></a>
 </p>
 
 <p align="center">
@@ -103,7 +103,7 @@ Give any MCP-compatible agent — Claude Code, Cursor, Gemini CLI, Windsurf — 
 claude mcp add --transport stdio topos -- topos mcp
 ```
 
-Topos is published on the [official MCP Registry](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.Krv-Labs/topos) (`io.github.Krv-Labs/topos`) and listed on [Glama](https://glama.ai/mcp/servers/Krv-Labs/topos).
+Topos is published on the [official MCP Registry](https://registry.modelcontextprotocol.io/?q=topos) (`io.github.Krv-Labs/topos`) and listed on [Glama](https://glama.ai/mcp/servers/Krv-Labs/topos).
 
 Setup for Cursor, VS Code, Gemini CLI, Codex, and Windsurf, plus troubleshooting and the full MCP tool list: **[docs.krv.ai/topos/agents](https://docs.krv.ai/topos/agents.html)**.
 

--- a/README.md
+++ b/README.md
@@ -6,45 +6,93 @@
   </picture>
 </p>
 
+<h3 align="center">A structural quality gate for coding agents.</h3>
+
 <p align="center">
-  <a href="https://github.com/Krv-Labs/topos/actions/workflows/ci.yml"><img src="https://github.com/Krv-Labs/topos/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="https://pypi.org/project/topos-mcp/"><img src="https://img.shields.io/pypi/v/topos-mcp.svg" alt="PyPI"></a>
-  <a href="https://pypi.org/project/topos-mcp/"><img src="https://img.shields.io/pypi/pyversions/topos-mcp.svg" alt="Python versions"></a>
-  <a href="https://github.com/Krv-Labs/topos/blob/main/LICENSE"><img src="https://img.shields.io/github/license/Krv-Labs/topos" alt="License"></a>
-  <a href="https://registry.modelcontextprotocol.io/?q=topos"><img src="https://img.shields.io/badge/MCP-Registry-555" alt="MCP Registry"></a>
-  <a href="https://glama.ai/mcp/servers/Krv-Labs/topos"><img src="https://glama.ai/mcp/servers/Krv-Labs/topos/badges/score.svg" alt="topos MCP server"></a>
-  <a href="https://clawhub.ai/krv-labs/skills/topos"><img src="https://img.shields.io/badge/%F0%9F%A6%9E_ClawHub-topos-F97316" alt="ClawHub"></a>
+  Topos measures complexity, coupling, and risky data flows, then gives your agent a concrete target&mdash;from SLOP to GOLD.
 </p>
 
 <p align="center">
-  <b>Harness for graph-based coding tools. Helping agents write clean, composable, secure code.</b><br>
-  <a href="https://docs.krv.ai/topos/">Docs</a> ·
-  <a href="#quick-start">Quick Start</a> ·
-  <a href="#mcp-server-for-agents">MCP Server</a> ·
-  <a href="https://github.com/Krv-Labs/topos/issues">Issues</a>
+  <a href="https://github.com/mcp/Krv-Labs/topos"><img src="https://img.shields.io/badge/VS_Code-Install_MCP-007ACC?logo=visualstudiocode&logoColor=white" alt="Install Topos MCP in VS Code"></a>
+  <a href="https://pypi.org/project/topos-mcp/"><img src="https://img.shields.io/pypi/v/topos-mcp.svg" alt="PyPI"></a>
+  <a href="https://github.com/Krv-Labs/topos/blob/main/LICENSE"><img src="https://img.shields.io/github/license/Krv-Labs/topos" alt="License"></a>
+  <a href="https://glama.ai/mcp/servers/Krv-Labs/topos"><img src="https://glama.ai/mcp/servers/Krv-Labs/topos/badges/score.svg" alt="Topos MCP server"></a>
+  <a href="https://clawhub.ai/krv-labs/skills/topos"><img src="https://img.shields.io/badge/%F0%9F%A6%9E_ClawHub-topos-F97316" alt="ClawHub"></a>
 </p>
 <!-- mcp-name: io.github.Krv-Labs/topos -->
 
-Topos scores code quality based on the structure of the programs in your codebase. Inspired by concepts from category theory, we've built an extensible evaluation framework that combines [tree-sitter](https://tree-sitter.github.io/tree-sitter/), [GitNexus](https://github.com/abhigyanpatwari/GitNexus), and [Sighthound](https://github.com/Corgea/Sighthound) with custom geometric and topological measures that provide agents with clear, principled targets for writing higher quality code. Agents earn medals for quality in a tight feedback loop, and Topos surfaces the best places in your codebase to refactor and improve structure.
-
+<p align="center">
+  <a href="#quick-start">Quick Start</a> ·
+  <a href="#what-topos-checks">What it checks</a> ·
+  <a href="#under-the-hood">Under the hood</a> ·
+  <a href="https://docs.krv.ai/topos/">Docs</a> ·
+  <a href="https://github.com/Krv-Labs/topos/issues">Issues</a>
+</p>
 
 ---
 
+<!--
+DEMO STUB — replace this comment only after recording the real release flow.
+
+Show, in under 20 seconds:
+1. an agent evaluates a repository;
+2. Topos identifies the exact failing pillar and source hotspot;
+3. the agent makes one focused refactor;
+4. Topos verifies the medal improvement while the project tests stay green.
+
+Prefer a checked-in, captioned GIF or SVG terminal recording with a stable
+repository-relative URL. Do not publish a synthetic or hand-written result.
+-->
+
+<!--
+STUDY STUB — keep hidden until the study, raw results, pinned repository SHAs,
+and reproduction method are public.
+
+Candidate headline:
+"We evaluated <N> public repositories at pinned commits. <result>."
+
+Required link target: a durable methodology/results page containing the corpus
+selection rule, Topos version and configuration, machine details, raw JSON,
+known limitations, and a reproduction command. Avoid labeling repositories as
+"AI-generated" unless that provenance is explicit and independently verifiable.
+-->
+
+## Why Topos
+
+Coding agents produce working code quickly. The harder question is whether the result is still easy to understand, safe to change, and well-fitted to the rest of the repository.
+
+Topos computes that signal from program structure—not from an LLM review or a style opinion—and returns concrete failure locations and next actions. It is fast enough to sit inside the agent loop: measure, edit, verify, repeat.
+
+**Tests check behavior. Topos checks whether the implementation is built to keep changing.**
+
 ## Quick Start
 
-Install:
+### VS Code: install through MCP
+
+Open the Extensions view, search **`@mcp topos`**, select **Topos**, and choose **Install**. You can also open the [Topos page in GitHub's MCP Registry](https://github.com/mcp/Krv-Labs/topos) and use its **Install MCP server** menu.
+
+Then ask agent mode:
+
+> Use Topos to find this repository's worst structural problem, make one focused improvement, and verify the result.
+
+VS Code owns the MCP registration, trust prompt, and server lifecycle. No Marketplace extension is required. See the [agent setup guide](https://docs.krv.ai/topos/agents.html) for tool permissions and troubleshooting.
+
+### Other MCP clients
+
+Run the self-contained MCP server on demand—no persistent Topos or Python installation required:
+
+```bash
+claude mcp add --transport stdio topos -- uvx topos-mcp
+```
+
+Setup for Codex, Gemini CLI, Cursor, Windsurf, Antigravity, and manual JSON lives in the [agent setup guide](https://docs.krv.ai/topos/agents.html).
+
+### Standalone CLI
 
 ```bash
 curl -fsSL https://docs.krv.ai/topos/install.sh | sh
+# or: brew install krv-labs/tap/topos
 ```
-
-From your repo root (or `cd /path/to/your/repo` first):
-
-```bash
-topos evaluate . -r
-```
-
-`evaluate -r` scores every file in the `cwd` and prints a ranked digest: which pillars pass, the worst-scoring files, and the cheapest fixes to flip a failing pillar. Add `-h` to any command for help, or `--json` for CI.
 
 Prefer Homebrew?
 
@@ -56,71 +104,48 @@ On Homebrew 6+, that one-liner auto-taps and trusts only this formula. If you
 `brew tap krv-labs/tap` first, run `brew trust --formula krv-labs/tap/topos`
 before `brew install topos`.
 
-Other install paths (PyPI, source checkout) and the full command tour live at **[docs.krv.ai/topos/installation](https://docs.krv.ai/topos/installation.html)**.
-
-## Built on
-
-Topos doesn't reinvent graph analysis for code — it orchestrates specialist tools most agents would otherwise have to run separately, and scores their combined output as one medal:
-
-| Tool | Integration | What it gives Topos |
-| :--- | :--- | :--- |
-| [tree-sitter](https://tree-sitter.github.io/tree-sitter/) | wired in | ASTs / CFGs that power **SIMPLE** and structural coverage |
-| [GitNexus](https://github.com/abhigyanpatwari/GitNexus) | wired in (subprocess) | the module dependency graph that **COMPOSABLE** scores |
-| [Sighthound](https://github.com/Corgea/Sighthound) | optional (`PATH`) | supplementary SAST detail alongside the **SECURE** verdict |
-
-## What you get
-
-Three independent pillars roll up into one **Code Quality Medal**:
-
-- **SIMPLE** — avoids unnecessary complexity (AST entropy & CFG cyclomatic complexity)
-- **COMPOSABLE** — cleanly decoupled from other modules (MDG Martin instability via GitNexus)
-- **SECURE** — free of dangerous API reachability and taint paths (CPG analysis)
-
-| Medal         | Criteria                                    |
-| :------------ | :------------------------------------------ |
-| 🥇 **GOLD**   | Passes all 3 (SIMPLE + COMPOSABLE + SECURE) |
-| 🥈 **SILVER** | Passes 2 of 3                               |
-| 🥉 **BRONZE** | Passes 1 of 3                               |
-| ❌ **SLOP**   | Passes 0 (or fails to parse)                |
-
-`COMPOSABLE` needs a cross-file dependency graph, which the CLI does not build automatically:
-
 ```bash
-pnpm add -g gitnexus  # or: npm install -g gitnexus
+pnpm add -g gitnexus   # once; enables COMPOSABLE / GOLD
 topos depgraph generate
-topos evaluate src/ -r --gitnexus-dir .gitnexus
+topos evaluate . -r --gitnexus-dir .gitnexus
 ```
 
-Put [Sighthound](https://github.com/Corgea/Sighthound) on `PATH` to deepen `SECURE` with Corgea's ruleset (auto-detected; local CPG probes still run without it).
+`evaluate` ranks the files, shows which pillars pass, and surfaces the cheapest structural improvements.
 
-Other commands: `topos inspect` for per-file metrics, `topos compare` for AST edit distance between two versions, `topos coverage` for structural test coverage, and `--preferences simple,composable,secure` to tell agents which pillar to protect first when 🥇 GOLD isn't reachable. Full reference: **[docs.krv.ai/topos/cli](https://docs.krv.ai/topos/cli.html)**.
+`COMPOSABLE` needs a cross-file dependency graph. Generate it once (or after large structural edits) with `topos depgraph generate`, then pass `--gitnexus-dir .gitnexus` (or set `TOPOS_GITNEXUS_DIR`). Without a graph, SIMPLE and SECURE still score; COMPOSABLE is skipped.
 
-## MCP server (for agents)
+Topos supports Python, Rust, JavaScript, TypeScript, C++, and Go. The CLI defaults to Python; use `--language rust|go|javascript|typescript|cpp` for another language. See [Installation](https://docs.krv.ai/topos/installation.html) for platform support and alternative install paths.
 
-Give any MCP-compatible agent — Claude Code, Cursor, Gemini CLI, Windsurf — a live feed of Topos verdicts so it can evaluate and iterate on its own output.
+## What Topos checks
 
-```bash
-claude mcp add --transport stdio topos -- topos mcp
-```
+Every file gets three independent verdicts:
 
-Topos is published on the [official MCP Registry](https://registry.modelcontextprotocol.io/?q=topos) (`io.github.Krv-Labs/topos`) and listed on [Glama](https://glama.ai/mcp/servers/Krv-Labs/topos).
+- **SIMPLE** — avoids unnecessary complexity using AST entropy and control-flow complexity.
+- **COMPOSABLE** — stays decoupled from the repository using module-dependency structure and Martin instability.
+- **SECURE** — avoids dangerous API reachability and taint paths in the code property graph.
 
-Setup for Cursor, VS Code, Gemini CLI, Codex, and Windsurf, plus troubleshooting and the full MCP tool list: **[docs.krv.ai/topos/agents](https://docs.krv.ai/topos/agents.html)**.
+Those verdicts roll up into one memorable quality medal without hiding which pillar failed:
 
-> [!TIP]
-> **OpenClaw / ClawHub:** [`openclaw skills install @Krv-Labs/topos`](https://clawhub.ai/krv-labs/skills/topos)  
-> **Hermes:** `hermes skills tap add Krv-Labs/topos` then `hermes skills install Krv-Labs/topos/topos`
+| Medal | Criteria |
+| :--- | :--- |
+| 🥇 **GOLD** | Passes all 3 |
+| 🥈 **SILVER** | Passes 2 of 3 |
+| 🥉 **BRONZE** | Passes 1 of 3 |
+| ❌ **SLOP** | Passes 0, or fails to parse |
 
----
-
-## How it works
-
-Topos measures code along the three pillars above and maps the result to an 8-element evaluation lattice — the three pillars are pairwise incomparable, and 🥇 GOLD is their intersection.
+Topos also returns ranked refactor guidance: failing metric locations, control-flow cycles, load-bearing dependency edges, process bottlenecks, and optional Graphify knowledge-graph findings. Advisory findings never silently change the scored medal.
 
 <details>
-<summary>Evaluation lattice diagram</summary>
+<summary>How the medal system is derived</summary>
+
+The three pillars are pairwise incomparable and form an eight-element evaluation lattice; GOLD is their intersection.
 
 ```mermaid
+---
+config:
+  layout: dagre
+  theme: neutral
+---
 graph BT
     SLOP["❌ SLOP<br/>No Medal"]
     SIMPLE["🥉 BRONZE<br/>Simple"]
@@ -154,20 +179,44 @@ graph BT
     style IDEAL      fill:#ffd700,stroke:#856404,color:#000
 ```
 
+[Measures](https://docs.krv.ai/topos/measures.html) · [Category-theory foundations](https://docs.krv.ai/topos/concepts.html)
+
 </details>
 
-Set your **Preferences** (e.g. `simple,composable,secure`) to tell your coding agent which pillars to prioritize when aiming for GOLD under token and time budgets, and how to relax that goal when GOLD isn't reachable. Details: [docs.krv.ai/topos/preferences](https://docs.krv.ai/topos/preferences.html) · [docs.krv.ai/topos/measures](https://docs.krv.ai/topos/measures.html) · [docs.krv.ai/topos/concepts](https://docs.krv.ai/topos/concepts.html).
+## Under the hood
+
+Topos is a self-contained Rust CLI and MCP server. Analysis runs locally; your source code is not sent to an external model or hosted analysis service.
+
+| Component | Role |
+| :--- | :--- |
+| [tree-sitter](https://tree-sitter.github.io/tree-sitter/) | Parses six languages and powers the native AST, CFG, CPG, PDG, and UAST representations. |
+| [GitNexus](https://github.com/abhigyanpatwari/GitNexus) | Supplies the repository dependency graph scored by COMPOSABLE (`topos depgraph generate`). |
+| [Sighthound](https://github.com/Corgea/Sighthound) | Embedded in the MCP server for supplementary security findings; native CPG probes remain the SECURE scoring source. |
+| [Graphify](https://github.com/Graphify-Labs/graphify) | Optional advisory orphan and fragile-edge detection; it does not affect the medal. |
+
+The result is one agent-facing contract over several structural lenses: one score to optimize, explicit evidence for each failure, and a verification loop that can tell a real improvement from cosmetic churn.
+
+## More ways to use Topos
+
+- **OpenClaw / ClawHub:** [`openclaw skills install @Krv-Labs/topos`](https://clawhub.ai/krv-labs/skills/topos)
+- **Hermes:** `hermes skills tap add Krv-Labs/topos` then `hermes skills install Krv-Labs/topos/topos`
+- **MCP Registry name:** `io.github.Krv-Labs/topos`
+- **CLI reference:** [docs.krv.ai/topos/cli](https://docs.krv.ai/topos/cli.html)
 
 ## Contributing
 
-Topos is used internally at [Krv Labs](https://krv.ai) to manage AI agent code output. We welcome bugs, ideas, and contributions.
+Topos is used internally at [Krv Labs](https://krv.ai) to manage AI-agent code output. We welcome bugs, ideas, and contributions.
 
-- **Bug?** Open an [Issue](https://github.com/Krv-Labs/topos/issues)
-- **Idea?** Start a [Discussion](https://github.com/Krv-Labs/topos/discussions) or open a PR
+- **Bug?** Open an [issue](https://github.com/Krv-Labs/topos/issues)
+- **Idea?** Start a [discussion](https://github.com/Krv-Labs/topos/discussions) or open a PR
 - **Collaborate?** [team@krv.ai](mailto:team@krv.ai)
 
 ---
 
-[Full Documentation](https://docs.krv.ai/topos/) · [Measures & Metrics](https://docs.krv.ai/topos/measures.html) · [Category Theory Concepts](https://docs.krv.ai/topos/concepts.html) · [Engineering notes](docs/)
+[Full documentation](https://docs.krv.ai/topos/) · [Measures and metrics](https://docs.krv.ai/topos/measures.html) · [Engineering notes](docs/)
 
-_Built with ❤️ by [Krv Labs](https://krv.ai)_
+<p align="left">
+  <a href="https://krv.ai">
+    <img src="docs/source/_static/made-by-krv.svg" alt="Made by Krv Labs" height="24">
+  </a>
+</p>

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 </p>
 <!-- mcp-name: io.github.Krv-Labs/topos -->
 
-Topos is a category theory–inspired framework that sits on top of tree-sitter, [GitNexus](https://github.com/abhigyanpatwari/GitNexus), and [Sighthound](https://github.com/Corgea/Sighthound) — one scored target for structural code quality instead of disconnected tools. Passing unit tests proves your code works; **Topos** proves it's built to last, scoring complexity, coupling, and data-flow risk so agents have something concrete to optimize toward, instead of a vague "clean it up."
+Topos scores code quality from the geometric and topological structure of program graphs — structural debt conventional linters can't compute — and gives agents a medal-scored (SLOP → GOLD) feedback loop for cleaner, more composable code. Built on [tree-sitter](https://tree-sitter.github.io/tree-sitter/), [GitNexus](https://github.com/abhigyanpatwari/GitNexus), and [Sighthound](https://github.com/Corgea/Sighthound): one scored target instead of disconnected tools.
 
 ---
 

--- a/docs/source/_static/made-by-krv.svg
+++ b/docs/source/_static/made-by-krv.svg
@@ -1,0 +1,36 @@
+<svg width="130" height="24" viewBox="0 0 130 24" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Built by Krv Labs">
+  <!--
+    Krv Labs brand badge for README / docs footers.
+    Aesthetic mirrors krv.ai: near-black field, muted lead-in, signature red mark, off-white wordmark.
+    Mark geometry sourced from docs/source/_static/krv-logo.svg (bbox center 257.3,250.4; 448x472 units).
+    Layout grid: 9px side insets, 6.3px gaps around the 13px-tall mark, shared text baseline at y=15.8
+    (cap-height optically centered on y=12). textLength values sit ~5% above natural width so
+    lengthAdjust="spacing" yields gentle, deterministic tracking instead of renderer-dependent kerning.
+  -->
+  <rect x="0.5" y="0.5" width="129" height="23" rx="3.2" fill="#0A0A0A" stroke="#FFFFFF" stroke-opacity="0.14"/>
+  <text
+    x="9"
+    y="15.8"
+    fill="#A1A1AA"
+    font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+    font-size="10.5"
+    font-weight="200"
+    textLength="39"
+    lengthAdjust="spacing">built by</text>
+  <!-- Krv mark between lead-in and wordmark -->
+  <g transform="translate(60.5, 12) scale(0.02754) translate(-257.3, -250.4)" fill="#E11D2E" fill-rule="evenodd">
+    <g transform="matrix(2.7434917,0,0,2.7434917,-37.861676,-40.016888)">
+      <path d="m 46.137654,106.32606 86.394976,-86.481927 56.48777,0.05938 -83.8588,84.858387 84.11445,85.53421 -55.3251,-0.17457 z"/>
+      <path d="m 26.444164,20.69278 41.461606,0.118739 0.08046,59.918852 -25.73253,25.745539 -0.0012,63.54146 34.0524,-20.96039 0.10566,42.81608 -50.533959,-0.32117 z"/>
+    </g>
+  </g>
+  <text
+    x="73"
+    y="15.8"
+    fill="#F4F4F5"
+    font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+    font-size="12"
+    font-weight="800"
+    textLength="48"
+    lengthAdjust="spacing">krv labs</text>
+</svg>

--- a/docs/source/agents.rst
+++ b/docs/source/agents.rst
@@ -20,7 +20,7 @@ Topos is published as ``io.github.Krv-Labs/topos`` on the official MCP Registry
 and mirrored on Glama. Use either listing when discovering servers from a host
 UI, or follow the setup tabs below to register it directly.
 
-- `Official MCP Registry <https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.Krv-Labs/topos>`_
+- `Official MCP Registry <https://registry.modelcontextprotocol.io/?q=topos>`_
 - `Glama MCP server page <https://glama.ai/mcp/servers/Krv-Labs/topos>`_
 - `ClawHub skill <https://clawhub.ai/krv-labs/skills/topos>`_ (OpenClaw):
   ``openclaw skills install @Krv-Labs/topos``

--- a/docs/source/agents.rst
+++ b/docs/source/agents.rst
@@ -13,6 +13,18 @@ For Agents
    Topos lets you set the quality target while the agent handles the loop:
    measure, change, verify, stop when the target or budget is reached.
 
+Find the MCP server
+-------------------
+
+Topos is published as ``io.github.Krv-Labs/topos`` on the official MCP Registry
+and mirrored on Glama. Use either listing when discovering servers from a host
+UI, or follow the setup tabs below to register it directly.
+
+- `Official MCP Registry <https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.Krv-Labs/topos>`_
+- `Glama MCP server page <https://glama.ai/mcp/servers/Krv-Labs/topos>`_
+- `ClawHub skill <https://clawhub.ai/krv-labs/skills/topos>`_ (OpenClaw):
+  ``openclaw skills install @Krv-Labs/topos``
+
 MCP Setup
 ---------
 

--- a/docs/source/agents.rst
+++ b/docs/source/agents.rst
@@ -36,22 +36,53 @@ Choose an agent path
 
 .. tab-set::
 
-   .. tab-item:: VS Code / Cursor extension
+   .. tab-item:: VS Code / Cursor
       :sync: vscode-extension
 
-      If you use VS Code or an MCP-capable Cursor build, install the Marketplace
-      extension instead of hand-editing MCP JSON:
+      VS Code exposes **two different install surfaces**. Pick **one** — do not
+      install both, or agent mode can register two Topos MCP servers and double
+      tool calls / trust prompts.
+
+      **Recommended — MCP server (``@mcp`` gallery)**
+
+      This is the official MCP Registry entry (``io.github.Krv-Labs/topos``),
+      not the Marketplace extension. The registry points at the PyPI package
+      ``topos-mcp``; VS Code installs/runs that package and owns registration,
+      trust, and lifecycle. You do **not** need a separate local Topos install
+      or the Marketplace extension.
+
+      1. Open the Extensions view (``Ctrl+Shift+X`` / ``Cmd+Shift+X``).
+      2. Search ``@mcp topos`` and install **Topos**.
+      3. Or open the `GitHub MCP Registry page
+         <https://github.com/mcp/Krv-Labs/topos>`_ and use **Install MCP
+         server**.
+
+      See `Add MCP servers in VS Code
+      <https://code.visualstudio.com/docs/copilot/customization/mcp-servers>`_
+      for gallery vs ``mcp.json`` details.
+
+      **Optional — full Marketplace extension**
+
+      Use this when you want Command Palette workflows (**Topos: Evaluate
+      Project**, **Topos: Generate Dependency Graph**), bundled runtime
+      resolution, and an editor-owned MCP provider — not only agent tools.
 
       .. button-link:: https://marketplace.visualstudio.com/items?itemName=KrvLabs.topos-vscode
          :color: primary
          :shadow:
 
-         Topos: Code Quality Targets for Agents
+         Topos: Code Quality Targets for Agents (``KrvLabs.topos-vscode``)
 
       The extension registers a ``topos-mcp`` server provider, resolves a
       bundled, cached, local, or downloaded Topos runtime, and starts
       ``topos mcp`` for agent mode. Topos still runs locally; the editor owns
       server registration and trust prompts.
+
+      .. important::
+         Install **either** ``@mcp topos`` **or** ``KrvLabs.topos-vscode``, not
+         both. If you already have the full extension, skip the ``@mcp``
+         install (and vice versa). Cursor builds that lack the MCP gallery
+         should use the Marketplace extension or the Manual JSON tab.
 
    .. tab-item:: Agent CLIs
       :sync: agent-cli
@@ -114,7 +145,8 @@ Choose an agent path
          The current ``agy`` CLI does not expose a documented ``mcp`` setup
          command. Use one of these verified paths instead:
 
-         - In VS Code or Cursor, install the Topos extension above.
+         - In VS Code or Cursor, use the VS Code tab above (``@mcp topos`` or
+           the full Marketplace extension — not both).
          - If your Antigravity build exposes manual MCP JSON, use the
            ``Manual JSON`` tab below.
          - If you already manage MCP through Claude or Gemini plugins, import

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -43,7 +43,7 @@ Topos
       :link: agents
       :link-type: doc
 
-      How AI coding agents use Topos to iteratively optimize code and hit quality targets.
+      MCP setup, the official registry listing, and how agents iterate toward quality targets.
 
    .. grid-item-card:: CLI Reference
       :link: cli
@@ -64,7 +64,7 @@ Topos
       A breakdown of the structural and coupling metrics used to evaluate code quality.
 
 .. hint::
-   **The scary maths are optional.** Topos is grounded in some very abstract fields (category & topos theory). Don't be alarmed! It's not required to understand (or appreciate) the maths to evaluate code quality with Topos. We find the formalism elegant, but know this isn't everyone's cup of tea. If you're curious about what we're building under the hood, check out :doc:`concepts`.
+   **Built on category theory.** Topos models code quality as a structural property of programs using topos theory — the formalism is precise by design, not decoration. You don't need the math to use Topos day to day; see :doc:`concepts` for the foundations.
 
 Beyond Correctness
 -------------------

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -21,9 +21,9 @@ that follows.
 .. admonition:: The short version
    :class: philosophy-box
 
-   **Recommended:** run Topos through Claude Code or the VS Code / Cursor
-   extension. If you want package installs, source builds, or other MCP hosts,
-   use :doc:`installation` and :doc:`agents`.
+   **Recommended:** run Topos through Claude Code, VS Code ``@mcp topos``, or
+   the optional full VS Code extension. If you want package installs, source
+   builds, or other MCP hosts, use :doc:`installation` and :doc:`agents`.
 
 Install
 -------
@@ -62,14 +62,25 @@ locally and expose the same structural quality tools.
 
 .. dropdown:: VS Code / Cursor
 
-   Best when your review happens in the editor. Install the extension and let
-   the editor own MCP registration, trust prompts, and runtime discovery.
+   Best when your review happens in the editor. Pick **one** install path — do
+   not install both, or agent mode can register two Topos MCP servers.
+
+   **Recommended — MCP server (``@mcp`` gallery)**
+
+   1. Extensions view → search ``@mcp topos`` → install **Topos**.
+   2. Or use **Install MCP server** on the `GitHub MCP Registry page
+      <https://github.com/mcp/Krv-Labs/topos>`_.
+
+   VS Code pulls the registry PyPI package (``topos-mcp``) and owns
+   registration, trust, and lifecycle — no separate Topos install required.
+
+   **Optional — full Marketplace extension** (Command Palette + bundled runtime)
 
    .. button-link:: https://marketplace.visualstudio.com/items?itemName=KrvLabs.topos-vscode
       :color: primary
       :shadow:
 
-      Install the VS Code extension
+      Install ``KrvLabs.topos-vscode``
 
    In agent mode, ask:
 
@@ -78,9 +89,7 @@ locally and expose the same structural quality tools.
       Use Topos to evaluate this project and identify the lowest-hanging
       structural improvement.
 
-   The extension is the least fussy option when it is available: no MCP JSON
-   hand-editing, no separate terminal ritual, and the quality feedback stays
-   where you are reading the diff.
+   Full setup, and why not to install both paths, is in :doc:`agents`.
 
 When to use Topos
 -----------------


### PR DESCRIPTION
## Summary

- Fixes #188 by linking the official MCP Registry (`io.github.Krv-Labs/topos`) and Glama listing in `README.md`, plus ClawHub / VS Code install paths and a Made by Krv footer badge.
- Surfaces those listings in Sphinx (`agents`, `index`, `quickstart`), including the VS Code dual-install path: recommended `@mcp topos` gallery vs optional Marketplace extension (pick one).
- Keeps generate-first COMPOSABLE docs (`topos depgraph generate`, `--gitnexus-dir`) honest for the current 0.3.x line — no v0.4.0 auto-ensure / `no_composable` contract claims.

Port the agent-harness positioning from the v0.4.0 README rewrite for messaging only; the real COMPOSABLE-by-default engine work stays on #159.

## Test plan

- [ ] Diff vs `main` is docs-only: `README.md`, `docs/source/_static/made-by-krv.svg`, `docs/source/agents.rst`, `docs/source/index.rst`, `docs/source/quickstart.rst`
- [ ] Grep gate clean for `no_composable`, `COMPOSABLE-by-default`, `auto-ensur`, `composable-by-default`, `generate/refresh`
- [ ] README badges/links resolve (MCP Registry UI, ClawHub, Glama, VS Code Install MCP, made-by-krv asset)
- [ ] Sphinx agents/quickstart dual-install copy is clear: `@mcp` **or** Marketplace, not both
- [ ] Homebrew trust note from main still present after rebase