### PR TITLE
refactor(cli): split evaluate.rs and graphify.rs by concern (issue #104)

### DIFF
--- a/topos/cli/src/commands/classify.rs
+++ b/topos/cli/src/commands/classify.rs
@@ -1,0 +1,103 @@
+//! Shared classification step for `evaluate` and `inspect`: build every
+//! representation the characteristic morphism needs and classify once.
+//!
+//! Split out of `evaluate.rs` -- `inspect.rs` already depended on this
+//! function through it, which was really a sign it belongs to neither
+//! command specifically.
+
+use topos_engine::core::characteristic_morphism::{CharacteristicMorphism, ClassificationResult};
+use topos_engine::core::morphism::ProgramMorphism;
+use topos_engine::evaluation::policies::base::Priority;
+use topos_engine::functors::probes::uast::abstractness::AbstractnessRepresentation;
+use topos_engine::graphs::base::Representation;
+use topos_engine::graphs::mdg::object::ModuleDependencyGraph;
+
+/// Build the CFG (SIMPLE), PDG (diagnostic), CPG (SECURE), and — when
+/// `mdg` is provided — MDG (COMPOSABLE) representations for `morphism`
+/// and classify it. `mdg` is expected to already have its `target_file`
+/// set to the file currently being classified.
+pub(crate) fn classify_with_representations(
+    classifier: &CharacteristicMorphism,
+    morphism: &mut ProgramMorphism,
+    mdg: Option<&ModuleDependencyGraph>,
+) -> ClassificationResult {
+    let cfg = morphism.build_cfg().cloned();
+    let pdg = morphism.build_pdg().cloned();
+    let cpg = morphism.build_cpg().cloned();
+    let abstractness = morphism
+        .ast
+        .as_ref()
+        .map(|ast| AbstractnessRepresentation::new(&ast.uast_root));
+    let mut representations: Vec<&dyn Representation> = Vec::new();
+    if let Some(cfg) = &cfg {
+        representations.push(cfg);
+    }
+    if let Some(pdg) = &pdg {
+        representations.push(pdg);
+    }
+    if let Some(cpg) = &cpg {
+        representations.push(cpg);
+    }
+    if let Some(abstractness) = &abstractness {
+        representations.push(abstractness);
+    }
+    if let Some(mdg) = mdg {
+        representations.push(mdg);
+    }
+    classifier.classify_detailed(morphism, &representations, Priority::default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use topos_engine::graphs::mdg::models::{GraphNode, GraphRelationship};
+
+    fn node(id: &str, label: &str, file_path: &str) -> GraphNode {
+        let mut properties = HashMap::new();
+        properties.insert(
+            "filePath".to_string(),
+            serde_json::Value::String(file_path.to_string()),
+        );
+        GraphNode {
+            id: id.to_string(),
+            label: label.to_string(),
+            properties,
+        }
+    }
+
+    fn rel(id: &str, source: &str, target: &str, rel_type: &str) -> GraphRelationship {
+        GraphRelationship {
+            id: id.to_string(),
+            source_id: source.to_string(),
+            target_id: target.to_string(),
+            rel_type: rel_type.to_string(),
+            confidence: 1.0,
+            reason: String::new(),
+            properties: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn classify_with_representations_scores_composable_when_mdg_present() {
+        let classifier = CharacteristicMorphism;
+        let mut morphism = ProgramMorphism::new("def f():\n    return 1\n", "python");
+
+        let mut mdg = ModuleDependencyGraph::new("a.py");
+        mdg.add_node(node("File:a.py", "File", "a.py"));
+        mdg.add_node(node("File:b.py", "File", "b.py"));
+        mdg.add_relationship(rel("i1", "File:a.py", "File:b.py", "IMPORTS"));
+
+        let without = classify_with_representations(&classifier, &mut morphism, None);
+        assert!(
+            !without.dimensions.contains_key("composable"),
+            "composable must not appear without an MDG representation"
+        );
+
+        let with = classify_with_representations(&classifier, &mut morphism, Some(&mdg));
+        assert!(
+            with.dimensions.contains_key("composable"),
+            "composable must appear once an MDG representation is attached"
+        );
+    }
+}

--- a/topos/cli/src/commands/composable.rs
+++ b/topos/cli/src/commands/composable.rs
@@ -1,0 +1,93 @@
+//! Resolve-or-generate the COMPOSABLE `.gitnexus` dependency graph for
+//! `topos evaluate`.
+//!
+//! Split out of `evaluate.rs` -- this is GitNexus/MDG resolution
+//! infrastructure, not `evaluate`-command orchestration.
+
+use std::path::Path;
+
+use topos_engine::adapters::gitnexus::{current_git_branch, resolve_lbug_store};
+use topos_engine::graphs::mdg::object::ModuleDependencyGraph;
+use topos_mcp::evaluation::ensure_gitnexus_dir;
+
+/// Ensure a fresh `.gitnexus` build exists for `project_root` and load its
+/// `ModuleDependencyGraph`, or return `None` (with an explanatory `stderr`
+/// notice) if that isn't possible. Never returns an `Err` — COMPOSABLE is
+/// optional and its absence must not fail the whole evaluate run.
+///
+/// The resolve-or-generate decision itself (present/missing/stale, GitNexus
+/// availability, generation) is shared with the MCP evaluate tools via
+/// `topos_mcp::evaluation::ensure_gitnexus_dir` — this function only adds
+/// the CLI-specific "load once, reuse across every file in this run" MDG
+/// parsing on top (unlike MCP's `load_dep_graph`, which caches per
+/// `target_file` — a fit for arbitrary single-file tool calls, but N cache
+/// misses across a directory walk of N files).
+pub(crate) fn resolve_composable_mdg(
+    project_root: &Path,
+    gitnexus_dir_override: Option<&str>,
+) -> Option<ModuleDependencyGraph> {
+    let outcome = ensure_gitnexus_dir(
+        gitnexus_dir_override,
+        project_root,
+        /* skip = */ false,
+        /* capture = */ false,
+    );
+    if let Some(note) = &outcome.generation_note {
+        eprintln!("gitnexus: {note}");
+    }
+    let gitnexus_dir = outcome.gitnexus_dir?;
+
+    let branch = current_git_branch(project_root);
+    let resolved = resolve_lbug_store(&gitnexus_dir, branch.as_deref());
+    let lbug_path = match resolved.path {
+        Some(path) if path.is_dir() => path,
+        _ => {
+            eprintln!(
+                "gitnexus: no indexed store found at {} — evaluating SIMPLE/SECURE only.",
+                gitnexus_dir.display()
+            );
+            return None;
+        }
+    };
+
+    match ModuleDependencyGraph::from_json_dir(&lbug_path, project_root.to_string_lossy()) {
+        Ok(graph) => Some(graph),
+        Err(e) => {
+            eprintln!(
+                "gitnexus: failed to load dependency graph ({e}) — evaluating SIMPLE/SECURE only."
+            );
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_composable_mdg_returns_none_for_override_outside_project_root_without_shelling_out()
+    {
+        // An override outside `project_root` is rejected by
+        // `resolve_gitnexus_dir`/`depgraph_status` before any
+        // availability check or subprocess call, so this stays
+        // deterministic regardless of whether gitnexus happens to be
+        // installed on the machine running the test.
+        let temp_dir = |label: &str| -> std::path::PathBuf {
+            let dir = std::env::temp_dir().join(format!(
+                "topos_cli_composable_test_{label}_{}",
+                std::process::id()
+            ));
+            std::fs::create_dir_all(&dir).unwrap();
+            dir
+        };
+        let project_root = temp_dir("root");
+        let outside = temp_dir("outside");
+
+        let result = resolve_composable_mdg(&project_root, Some(&outside.to_string_lossy()));
+        assert!(result.is_none());
+
+        std::fs::remove_dir_all(&project_root).ok();
+        std::fs::remove_dir_all(&outside).ok();
+    }
+}

--- a/topos/cli/src/commands/evaluate.rs
+++ b/topos/cli/src/commands/evaluate.rs
@@ -30,19 +30,17 @@
 //! [`ModuleDependencyGraph`]: topos_engine::graphs::mdg::object::ModuleDependencyGraph
 //! [`ProgramDependenceGraph`]: topos_engine::graphs::pdg::object::ProgramDependenceGraph
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use clap::Args;
 use topos_engine::adapters::discovery::collect_source_files;
-use topos_engine::adapters::gitnexus::{current_git_branch, resolve_lbug_store};
-use topos_engine::core::characteristic_morphism::{CharacteristicMorphism, ClassificationResult};
+use topos_engine::core::characteristic_morphism::CharacteristicMorphism;
 use topos_engine::core::morphism::ProgramMorphism;
-use topos_engine::evaluation::policies::base::Priority;
-use topos_engine::functors::probes::uast::abstractness::AbstractnessRepresentation;
 use topos_engine::graphs::ast::languages::{language_file_suffixes, SUPPORTED_LANGUAGES};
-use topos_engine::graphs::base::Representation;
-use topos_engine::graphs::mdg::object::ModuleDependencyGraph;
-use topos_mcp::evaluation::ensure_gitnexus_dir;
+
+use super::classify::classify_with_representations;
+use super::composable::resolve_composable_mdg;
+use super::render::print_classification;
 
 #[derive(Args)]
 pub struct EvaluateArgs {
@@ -120,197 +118,4 @@ pub fn run(args: EvaluateArgs) -> Result<(), String> {
         }
     }
     Ok(())
-}
-
-/// Ensure a fresh `.gitnexus` build exists for `project_root` and load its
-/// `ModuleDependencyGraph`, or return `None` (with an explanatory `stderr`
-/// notice) if that isn't possible. Never returns an `Err` — COMPOSABLE is
-/// optional and its absence must not fail the whole evaluate run.
-///
-/// The resolve-or-generate decision itself (present/missing/stale, GitNexus
-/// availability, generation) is shared with the MCP evaluate tools via
-/// `topos_mcp::evaluation::ensure_gitnexus_dir` — this function only adds
-/// the CLI-specific "load once, reuse across every file in this run" MDG
-/// parsing on top (unlike MCP's `load_dep_graph`, which caches per
-/// `target_file` — a fit for arbitrary single-file tool calls, but N cache
-/// misses across a directory walk of N files).
-fn resolve_composable_mdg(
-    project_root: &Path,
-    gitnexus_dir_override: Option<&str>,
-) -> Option<ModuleDependencyGraph> {
-    let outcome = ensure_gitnexus_dir(
-        gitnexus_dir_override,
-        project_root,
-        /* skip = */ false,
-        /* capture = */ false,
-    );
-    if let Some(note) = &outcome.generation_note {
-        eprintln!("gitnexus: {note}");
-    }
-    let gitnexus_dir = outcome.gitnexus_dir?;
-
-    let branch = current_git_branch(project_root);
-    let resolved = resolve_lbug_store(&gitnexus_dir, branch.as_deref());
-    let lbug_path = match resolved.path {
-        Some(path) if path.is_dir() => path,
-        _ => {
-            eprintln!(
-                "gitnexus: no indexed store found at {} — evaluating SIMPLE/SECURE only.",
-                gitnexus_dir.display()
-            );
-            return None;
-        }
-    };
-
-    match ModuleDependencyGraph::from_json_dir(&lbug_path, project_root.to_string_lossy()) {
-        Ok(graph) => Some(graph),
-        Err(e) => {
-            eprintln!(
-                "gitnexus: failed to load dependency graph ({e}) — evaluating SIMPLE/SECURE only."
-            );
-            None
-        }
-    }
-}
-
-/// Build the CFG (SIMPLE), PDG (diagnostic), CPG (SECURE), and — when
-/// `mdg` is provided — MDG (COMPOSABLE) representations for `morphism`
-/// and classify it. `mdg` is expected to already have its `target_file`
-/// set to the file currently being classified.
-pub(crate) fn classify_with_representations(
-    classifier: &CharacteristicMorphism,
-    morphism: &mut ProgramMorphism,
-    mdg: Option<&ModuleDependencyGraph>,
-) -> ClassificationResult {
-    let cfg = morphism.build_cfg().cloned();
-    let pdg = morphism.build_pdg().cloned();
-    let cpg = morphism.build_cpg().cloned();
-    let abstractness = morphism
-        .ast
-        .as_ref()
-        .map(|ast| AbstractnessRepresentation::new(&ast.uast_root));
-    let mut representations: Vec<&dyn Representation> = Vec::new();
-    if let Some(cfg) = &cfg {
-        representations.push(cfg);
-    }
-    if let Some(pdg) = &pdg {
-        representations.push(pdg);
-    }
-    if let Some(cpg) = &cpg {
-        representations.push(cpg);
-    }
-    if let Some(abstractness) = &abstractness {
-        representations.push(abstractness);
-    }
-    if let Some(mdg) = mdg {
-        representations.push(mdg);
-    }
-    classifier.classify_detailed(morphism, &representations, Priority::default())
-}
-
-/// Print a verdict, per-generator scores, and raw metrics for one result.
-pub(crate) fn print_classification(result: &ClassificationResult) {
-    if !result.is_parseable {
-        println!("  {}", result.summary());
-        return;
-    }
-    println!("  Verdict: {}", result.summary());
-    for dim in ["simple", "composable", "secure"] {
-        let Some(val) = result.dimensions.get(dim) else {
-            continue;
-        };
-        let score = result.scores.get(dim).copied().unwrap_or(0.0) * 100.0;
-        println!("    {dim}: {val} [{score:.0}%]");
-    }
-    if !result.raw_metrics.is_empty() {
-        println!("  Raw metrics:");
-        let mut keys: Vec<&String> = result.raw_metrics.keys().collect();
-        keys.sort();
-        for key in keys {
-            let value = result.raw_metrics[key];
-            println!("    {key}: {value:.3}");
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::collections::HashMap;
-    use topos_engine::graphs::mdg::models::{GraphNode, GraphRelationship};
-
-    fn temp_dir(label: &str) -> PathBuf {
-        let dir = std::env::temp_dir().join(format!(
-            "topos_cli_evaluate_test_{label}_{}",
-            std::process::id()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
-        dir
-    }
-
-    fn node(id: &str, label: &str, file_path: &str) -> GraphNode {
-        let mut properties = HashMap::new();
-        properties.insert(
-            "filePath".to_string(),
-            serde_json::Value::String(file_path.to_string()),
-        );
-        GraphNode {
-            id: id.to_string(),
-            label: label.to_string(),
-            properties,
-        }
-    }
-
-    fn rel(id: &str, source: &str, target: &str, rel_type: &str) -> GraphRelationship {
-        GraphRelationship {
-            id: id.to_string(),
-            source_id: source.to_string(),
-            target_id: target.to_string(),
-            rel_type: rel_type.to_string(),
-            confidence: 1.0,
-            reason: String::new(),
-            properties: HashMap::new(),
-        }
-    }
-
-    #[test]
-    fn classify_with_representations_scores_composable_when_mdg_present() {
-        let classifier = CharacteristicMorphism;
-        let mut morphism = ProgramMorphism::new("def f():\n    return 1\n", "python");
-
-        let mut mdg = ModuleDependencyGraph::new("a.py");
-        mdg.add_node(node("File:a.py", "File", "a.py"));
-        mdg.add_node(node("File:b.py", "File", "b.py"));
-        mdg.add_relationship(rel("i1", "File:a.py", "File:b.py", "IMPORTS"));
-
-        let without = classify_with_representations(&classifier, &mut morphism, None);
-        assert!(
-            !without.dimensions.contains_key("composable"),
-            "composable must not appear without an MDG representation"
-        );
-
-        let with = classify_with_representations(&classifier, &mut morphism, Some(&mdg));
-        assert!(
-            with.dimensions.contains_key("composable"),
-            "composable must appear once an MDG representation is attached"
-        );
-    }
-
-    #[test]
-    fn resolve_composable_mdg_returns_none_for_override_outside_project_root_without_shelling_out()
-    {
-        // An override outside `project_root` is rejected by
-        // `resolve_gitnexus_dir`/`depgraph_status` before any
-        // availability check or subprocess call, so this stays
-        // deterministic regardless of whether gitnexus happens to be
-        // installed on the machine running the test.
-        let project_root = temp_dir("root");
-        let outside = temp_dir("outside");
-
-        let result = resolve_composable_mdg(&project_root, Some(&outside.to_string_lossy()));
-        assert!(result.is_none());
-
-        std::fs::remove_dir_all(&project_root).ok();
-        std::fs::remove_dir_all(&outside).ok();
-    }
 }

--- a/topos/cli/src/commands/graphify.rs
+++ b/topos/cli/src/commands/graphify.rs
@@ -10,50 +10,13 @@
 //! MCP tools use (`topos/mcp/src/tools/{graphify,refactor}.rs`) — no
 //! logic duplicated between CLI and MCP.
 
-use std::path::PathBuf;
+mod generate;
+mod orphans;
 
 use clap::{Args, Subcommand};
-use topos_engine::adapters::graphify::{ensure_graphify_graph, GRAPHIFY_GRAPH_FILE};
-use topos_engine::functors::probes::graphify::orphans::{
-    calculate_graphify_orphans, FragileEdge, GraphifyOrphanResult, OrphanNode,
-};
-use topos_engine::graphs::graphify::GraphifyGraph;
 
-const DEFAULT_ORPHAN_DEGREE_THRESHOLD: usize = 1;
-
-/// Scope orphan nodes / fragile edges to `filepath`, truncated to `limit`.
-///
-/// `FragileEdge.source`/`target` are Graphify node ids, not file paths — an
-/// edge is scoped in by looking up each endpoint's own `node.source_file`
-/// in `graph`, not by comparing the edge's fields directly against
-/// `filepath`.
-fn scope_to_file<'a>(
-    graph: &GraphifyGraph,
-    result: &'a GraphifyOrphanResult,
-    filepath: &str,
-    limit: usize,
-) -> (Vec<&'a OrphanNode>, Vec<&'a FragileEdge>) {
-    let orphan_nodes: Vec<&OrphanNode> = result
-        .orphan_nodes
-        .iter()
-        .filter(|node| node.source_file.as_deref() == Some(filepath))
-        .take(limit)
-        .collect();
-    let fragile_edges: Vec<&FragileEdge> = result
-        .fragile_edges
-        .iter()
-        .filter(|edge| {
-            [&edge.source, &edge.target].into_iter().any(|id| {
-                graph
-                    .node(id)
-                    .and_then(|n| n.source_file.as_deref())
-                    .is_some_and(|f| f == filepath)
-            })
-        })
-        .take(limit)
-        .collect();
-    (orphan_nodes, fragile_edges)
-}
+use generate::{run_generate, GenerateArgs};
+use orphans::{run_orphans, OrphansArgs};
 
 #[derive(Args)]
 pub struct GraphifyArgs {
@@ -70,33 +33,6 @@ pub enum GraphifyAction {
     Orphans(OrphansArgs),
 }
 
-#[derive(Args)]
-pub struct GenerateArgs {
-    /// Directory to analyze (default: current directory).
-    pub path: Option<PathBuf>,
-    /// Regenerate even when a graph is already present.
-    #[arg(long)]
-    pub force: bool,
-    /// Output the result as a single JSON object.
-    #[arg(long)]
-    pub json: bool,
-}
-
-#[derive(Args)]
-pub struct OrphansArgs {
-    /// The file to scope orphan nodes / fragile edges to (matched against
-    /// each node/edge's `source_file`).
-    pub filepath: PathBuf,
-    /// Directory containing `graph.json` (default: `./graphify-out`).
-    #[arg(long)]
-    pub graphify_dir: Option<PathBuf>,
-    #[arg(long, default_value_t = 5)]
-    pub limit: usize,
-    /// Output the result as a single JSON object.
-    #[arg(long)]
-    pub json: bool,
-}
-
 pub fn run(args: GraphifyArgs) -> Result<(), String> {
     match args.action {
         GraphifyAction::Generate(args) => run_generate(args),
@@ -104,175 +40,10 @@ pub fn run(args: GraphifyArgs) -> Result<(), String> {
     }
 }
 
-fn run_generate(args: GenerateArgs) -> Result<(), String> {
-    let target_dir = args.path.unwrap_or_else(|| PathBuf::from("."));
-    if !target_dir.is_dir() {
-        return Err(format!("Not a directory: {}", target_dir.display()));
-    }
-
-    let graph_file =
-        topos_engine::adapters::graphify::graphify_out_dir(&target_dir).join(GRAPHIFY_GRAPH_FILE);
-    if !args.force && graph_file.is_file() {
-        let message = format!("Graphify graph already current: {}", graph_file.display());
-        if args.json {
-            print_json(&serde_json::json!({
-                "ok": true,
-                "generated": false,
-                "graphify_out_dir": graph_file.parent().map(|p| p.display().to_string()),
-                "message": message,
-            }))?;
-        } else {
-            println!("{message}");
-        }
-        return Ok(());
-    }
-
-    let result = ensure_graphify_graph(&target_dir, args.json, None);
-    if args.json {
-        print_json(&serde_json::json!({
-            "ok": result.ok,
-            "returncode": result.returncode,
-            "generated": result.ok,
-            "graphify_out_dir": result.graphify_out_dir.map(|p| p.display().to_string()),
-            "message": result.message,
-        }))?;
-    }
-
-    if result.ok {
-        Ok(())
-    } else {
-        Err(result.message)
-    }
-}
-
-fn run_orphans(args: OrphansArgs) -> Result<(), String> {
-    let graphify_dir = args
-        .graphify_dir
-        .unwrap_or_else(|| PathBuf::from("graphify-out"));
-    let graph = GraphifyGraph::from_json_file(graphify_dir.join(GRAPHIFY_GRAPH_FILE))
-        .map_err(|e| e.to_string())?;
-
-    let result = calculate_graphify_orphans(&graph, DEFAULT_ORPHAN_DEGREE_THRESHOLD);
-    let filepath = args.filepath.to_string_lossy().to_string();
-    let (orphan_nodes, fragile_edges) = scope_to_file(&graph, &result, &filepath, args.limit);
-
-    if args.json {
-        let nodes_json: Vec<_> = orphan_nodes
-            .iter()
-            .map(|n| {
-                serde_json::json!({
-                    "node_id": n.node_id, "label": n.label, "degree": n.degree,
-                    "source_file": n.source_file, "source_location": n.source_location,
-                })
-            })
-            .collect();
-        let edges_json: Vec<_> = fragile_edges
-            .iter()
-            .map(|e| {
-                serde_json::json!({
-                    "source": e.source, "target": e.target,
-                    "relation": e.relation, "confidence": e.confidence.as_str(),
-                })
-            })
-            .collect();
-        print_json(&serde_json::json!({
-            "orphan_nodes": nodes_json,
-            "fragile_edges": edges_json,
-        }))?;
-        return Ok(());
-    }
-
-    println!("Orphan nodes ({})", filepath);
-    println!("{}", "-".repeat(40));
-    if orphan_nodes.is_empty() {
-        println!("  (none)");
-    }
-    for node in &orphan_nodes {
-        println!(
-            "  [{}] {} (degree {})",
-            node.node_id, node.label, node.degree
-        );
-    }
-
-    println!();
-    println!("Fragile edges (INFERRED | AMBIGUOUS)");
-    println!("{}", "-".repeat(40));
-    if fragile_edges.is_empty() {
-        println!("  (none)");
-    }
-    for edge in &fragile_edges {
-        println!(
-            "  {} -> {} ({}, {})",
-            edge.source,
-            edge.target,
-            edge.relation,
-            edge.confidence.as_str()
-        );
-    }
-
-    Ok(())
-}
-
-fn print_json(value: &serde_json::Value) -> Result<(), String> {
+pub(super) fn print_json(value: &serde_json::Value) -> Result<(), String> {
     println!(
         "{}",
         serde_json::to_string_pretty(value).map_err(|e| e.to_string())?
     );
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    const FIXTURE: &str = r#"{
-        "nodes": [
-            {"id": "a", "label": "a()", "source_file": "src/a.rs"},
-            {"id": "b", "label": "b()", "source_file": "src/b.rs"},
-            {"id": "c", "label": "c()", "source_file": "src/a.rs"}
-        ],
-        "links": [
-            {"source": "a", "target": "b", "confidence": "INFERRED", "relation": "calls"},
-            {"source": "b", "target": "c", "confidence": "EXTRACTED", "relation": "calls"}
-        ]
-    }"#;
-
-    #[test]
-    fn scope_to_file_smoke_test() {
-        let graph = GraphifyGraph::from_json_str(FIXTURE).unwrap();
-        let result = calculate_graphify_orphans(&graph, DEFAULT_ORPHAN_DEGREE_THRESHOLD);
-
-        let (nodes, edges) = scope_to_file(&graph, &result, "src/a.rs", 5);
-        // Both "a" and "c" live in src/a.rs and are degree-1 orphans;
-        // "b" (src/b.rs) must not leak in.
-        let node_ids: Vec<&str> = nodes.iter().map(|n| n.node_id.as_str()).collect();
-        assert_eq!(node_ids, vec!["a", "c"]);
-
-        // Only the INFERRED edge (a -> b) is fragile at all; it touches
-        // src/a.rs via its source endpoint "a", even though "a" itself
-        // isn't a path in the edge's own source/target fields.
-        assert_eq!(edges.len(), 1);
-        assert_eq!(edges[0].source, "a");
-        assert_eq!(edges[0].target, "b");
-
-        // "b" has degree 2 (touches both edges) so it's not an orphan
-        // itself, but src/b.rs still surfaces the fragile edge via "b"'s
-        // target endpoint.
-        let (b_nodes, b_edges) = scope_to_file(&graph, &result, "src/b.rs", 5);
-        assert!(b_nodes.is_empty());
-        assert_eq!(b_edges.len(), 1);
-
-        // limit truncates.
-        let (limited, _) = scope_to_file(&graph, &result, "src/a.rs", 1);
-        assert_eq!(limited.len(), 1);
-    }
-
-    #[test]
-    fn scope_to_file_returns_nothing_for_an_unknown_file() {
-        let graph = GraphifyGraph::from_json_str(FIXTURE).unwrap();
-        let result = calculate_graphify_orphans(&graph, DEFAULT_ORPHAN_DEGREE_THRESHOLD);
-        let (nodes, edges) = scope_to_file(&graph, &result, "src/nonexistent.rs", 5);
-        assert!(nodes.is_empty());
-        assert!(edges.is_empty());
-    }
 }

--- a/topos/cli/src/commands/graphify/generate.rs
+++ b/topos/cli/src/commands/graphify/generate.rs
@@ -1,0 +1,66 @@
+//! `topos graphify generate` — (re)generate `graphify-out/graph.json`.
+//!
+//! Split out of `graphify.rs` alongside [`super::orphans`] -- these are
+//! two independent subcommands bundled under one CLI action, and kept
+//! together were pushing the parent file's cyclomatic total over the
+//! SIMPLE gate.
+
+use std::path::PathBuf;
+
+use clap::Args;
+use topos_engine::adapters::graphify::{ensure_graphify_graph, GRAPHIFY_GRAPH_FILE};
+
+use super::print_json;
+
+#[derive(Args)]
+pub struct GenerateArgs {
+    /// Directory to analyze (default: current directory).
+    pub path: Option<PathBuf>,
+    /// Regenerate even when a graph is already present.
+    #[arg(long)]
+    pub force: bool,
+    /// Output the result as a single JSON object.
+    #[arg(long)]
+    pub json: bool,
+}
+
+pub fn run_generate(args: GenerateArgs) -> Result<(), String> {
+    let target_dir = args.path.unwrap_or_else(|| PathBuf::from("."));
+    if !target_dir.is_dir() {
+        return Err(format!("Not a directory: {}", target_dir.display()));
+    }
+
+    let graph_file =
+        topos_engine::adapters::graphify::graphify_out_dir(&target_dir).join(GRAPHIFY_GRAPH_FILE);
+    if !args.force && graph_file.is_file() {
+        let message = format!("Graphify graph already current: {}", graph_file.display());
+        if args.json {
+            print_json(&serde_json::json!({
+                "ok": true,
+                "generated": false,
+                "graphify_out_dir": graph_file.parent().map(|p| p.display().to_string()),
+                "message": message,
+            }))?;
+        } else {
+            println!("{message}");
+        }
+        return Ok(());
+    }
+
+    let result = ensure_graphify_graph(&target_dir, args.json, None);
+    if args.json {
+        print_json(&serde_json::json!({
+            "ok": result.ok,
+            "returncode": result.returncode,
+            "generated": result.ok,
+            "graphify_out_dir": result.graphify_out_dir.map(|p| p.display().to_string()),
+            "message": result.message,
+        }))?;
+    }
+
+    if result.ok {
+        Ok(())
+    } else {
+        Err(result.message)
+    }
+}

--- a/topos/cli/src/commands/graphify/orphans.rs
+++ b/topos/cli/src/commands/graphify/orphans.rs
@@ -1,0 +1,190 @@
+//! `topos graphify orphans` — list orphan nodes / fragile edges for a file.
+//!
+//! Split out of `graphify.rs` alongside [`super::generate`] -- see that
+//! module's doc comment for why.
+
+use std::path::PathBuf;
+
+use clap::Args;
+use topos_engine::adapters::graphify::GRAPHIFY_GRAPH_FILE;
+use topos_engine::functors::probes::graphify::orphans::{
+    calculate_graphify_orphans, FragileEdge, GraphifyOrphanResult, OrphanNode,
+};
+use topos_engine::graphs::graphify::GraphifyGraph;
+
+use super::print_json;
+
+const DEFAULT_ORPHAN_DEGREE_THRESHOLD: usize = 1;
+
+#[derive(Args)]
+pub struct OrphansArgs {
+    /// The file to scope orphan nodes / fragile edges to (matched against
+    /// each node/edge's `source_file`).
+    pub filepath: PathBuf,
+    /// Directory containing `graph.json` (default: `./graphify-out`).
+    #[arg(long)]
+    pub graphify_dir: Option<PathBuf>,
+    #[arg(long, default_value_t = 5)]
+    pub limit: usize,
+    /// Output the result as a single JSON object.
+    #[arg(long)]
+    pub json: bool,
+}
+
+/// Scope orphan nodes / fragile edges to `filepath`, truncated to `limit`.
+///
+/// `FragileEdge.source`/`target` are Graphify node ids, not file paths — an
+/// edge is scoped in by looking up each endpoint's own `node.source_file`
+/// in `graph`, not by comparing the edge's fields directly against
+/// `filepath`.
+fn scope_to_file<'a>(
+    graph: &GraphifyGraph,
+    result: &'a GraphifyOrphanResult,
+    filepath: &str,
+    limit: usize,
+) -> (Vec<&'a OrphanNode>, Vec<&'a FragileEdge>) {
+    let orphan_nodes: Vec<&OrphanNode> = result
+        .orphan_nodes
+        .iter()
+        .filter(|node| node.source_file.as_deref() == Some(filepath))
+        .take(limit)
+        .collect();
+    let fragile_edges: Vec<&FragileEdge> = result
+        .fragile_edges
+        .iter()
+        .filter(|edge| {
+            [&edge.source, &edge.target].into_iter().any(|id| {
+                graph
+                    .node(id)
+                    .and_then(|n| n.source_file.as_deref())
+                    .is_some_and(|f| f == filepath)
+            })
+        })
+        .take(limit)
+        .collect();
+    (orphan_nodes, fragile_edges)
+}
+
+pub fn run_orphans(args: OrphansArgs) -> Result<(), String> {
+    let graphify_dir = args
+        .graphify_dir
+        .unwrap_or_else(|| PathBuf::from("graphify-out"));
+    let graph = GraphifyGraph::from_json_file(graphify_dir.join(GRAPHIFY_GRAPH_FILE))
+        .map_err(|e| e.to_string())?;
+
+    let result = calculate_graphify_orphans(&graph, DEFAULT_ORPHAN_DEGREE_THRESHOLD);
+    let filepath = args.filepath.to_string_lossy().to_string();
+    let (orphan_nodes, fragile_edges) = scope_to_file(&graph, &result, &filepath, args.limit);
+
+    if args.json {
+        let nodes_json: Vec<_> = orphan_nodes
+            .iter()
+            .map(|n| {
+                serde_json::json!({
+                    "node_id": n.node_id, "label": n.label, "degree": n.degree,
+                    "source_file": n.source_file, "source_location": n.source_location,
+                })
+            })
+            .collect();
+        let edges_json: Vec<_> = fragile_edges
+            .iter()
+            .map(|e| {
+                serde_json::json!({
+                    "source": e.source, "target": e.target,
+                    "relation": e.relation, "confidence": e.confidence.as_str(),
+                })
+            })
+            .collect();
+        print_json(&serde_json::json!({
+            "orphan_nodes": nodes_json,
+            "fragile_edges": edges_json,
+        }))?;
+        return Ok(());
+    }
+
+    println!("Orphan nodes ({})", filepath);
+    println!("{}", "-".repeat(40));
+    if orphan_nodes.is_empty() {
+        println!("  (none)");
+    }
+    for node in &orphan_nodes {
+        println!(
+            "  [{}] {} (degree {})",
+            node.node_id, node.label, node.degree
+        );
+    }
+
+    println!();
+    println!("Fragile edges (INFERRED | AMBIGUOUS)");
+    println!("{}", "-".repeat(40));
+    if fragile_edges.is_empty() {
+        println!("  (none)");
+    }
+    for edge in &fragile_edges {
+        println!(
+            "  {} -> {} ({}, {})",
+            edge.source,
+            edge.target,
+            edge.relation,
+            edge.confidence.as_str()
+        );
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FIXTURE: &str = r#"{
+        "nodes": [
+            {"id": "a", "label": "a()", "source_file": "src/a.rs"},
+            {"id": "b", "label": "b()", "source_file": "src/b.rs"},
+            {"id": "c", "label": "c()", "source_file": "src/a.rs"}
+        ],
+        "links": [
+            {"source": "a", "target": "b", "confidence": "INFERRED", "relation": "calls"},
+            {"source": "b", "target": "c", "confidence": "EXTRACTED", "relation": "calls"}
+        ]
+    }"#;
+
+    #[test]
+    fn scope_to_file_smoke_test() {
+        let graph = GraphifyGraph::from_json_str(FIXTURE).unwrap();
+        let result = calculate_graphify_orphans(&graph, DEFAULT_ORPHAN_DEGREE_THRESHOLD);
+
+        let (nodes, edges) = scope_to_file(&graph, &result, "src/a.rs", 5);
+        // Both "a" and "c" live in src/a.rs and are degree-1 orphans;
+        // "b" (src/b.rs) must not leak in.
+        let node_ids: Vec<&str> = nodes.iter().map(|n| n.node_id.as_str()).collect();
+        assert_eq!(node_ids, vec!["a", "c"]);
+
+        // Only the INFERRED edge (a -> b) is fragile at all; it touches
+        // src/a.rs via its source endpoint "a", even though "a" itself
+        // isn't a path in the edge's own source/target fields.
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0].source, "a");
+        assert_eq!(edges[0].target, "b");
+
+        // "b" has degree 2 (touches both edges) so it's not an orphan
+        // itself, but src/b.rs still surfaces the fragile edge via "b"'s
+        // target endpoint.
+        let (b_nodes, b_edges) = scope_to_file(&graph, &result, "src/b.rs", 5);
+        assert!(b_nodes.is_empty());
+        assert_eq!(b_edges.len(), 1);
+
+        // limit truncates.
+        let (limited, _) = scope_to_file(&graph, &result, "src/a.rs", 1);
+        assert_eq!(limited.len(), 1);
+    }
+
+    #[test]
+    fn scope_to_file_returns_nothing_for_an_unknown_file() {
+        let graph = GraphifyGraph::from_json_str(FIXTURE).unwrap();
+        let result = calculate_graphify_orphans(&graph, DEFAULT_ORPHAN_DEGREE_THRESHOLD);
+        let (nodes, edges) = scope_to_file(&graph, &result, "src/nonexistent.rs", 5);
+        assert!(nodes.is_empty());
+        assert!(edges.is_empty());
+    }
+}

--- a/topos/cli/src/commands/inspect.rs
+++ b/topos/cli/src/commands/inspect.rs
@@ -12,7 +12,7 @@ use topos_engine::core::morphism::ProgramMorphism;
 use topos_engine::evaluation::policies::simple::describe_entropy_ratio;
 use topos_engine::functors::probes::ast::entropy::calculate_kolmogorov_proxy;
 
-use super::evaluate::classify_with_representations;
+use super::classify::classify_with_representations;
 use super::lang::detect_language;
 
 #[derive(Args)]

--- a/topos/cli/src/commands/mod.rs
+++ b/topos/cli/src/commands/mod.rs
@@ -1,9 +1,12 @@
 //! One module per `topos` subcommand, plus a shared [`lang`] helper.
 
+mod classify;
 pub mod compare;
+mod composable;
 pub mod coverage;
 pub mod evaluate;
 pub mod graphify;
 pub mod inspect;
 mod lang;
 pub mod mcp;
+mod render;

--- a/topos/cli/src/commands/render.rs
+++ b/topos/cli/src/commands/render.rs
@@ -1,0 +1,33 @@
+//! Human-readable rendering of a [`ClassificationResult`], shared by
+//! `evaluate`'s per-file + rollup output.
+//!
+//! Split out of `evaluate.rs` -- printing is a separate concern from
+//! `run`'s file-discovery/classification orchestration, and bundling
+//! both pushed the file's cyclomatic total over the SIMPLE gate.
+
+use topos_engine::core::characteristic_morphism::ClassificationResult;
+
+/// Print a verdict, per-generator scores, and raw metrics for one result.
+pub(crate) fn print_classification(result: &ClassificationResult) {
+    if !result.is_parseable {
+        println!("  {}", result.summary());
+        return;
+    }
+    println!("  Verdict: {}", result.summary());
+    for dim in ["simple", "composable", "secure"] {
+        let Some(val) = result.dimensions.get(dim) else {
+            continue;
+        };
+        let score = result.scores.get(dim).copied().unwrap_or(0.0) * 100.0;
+        println!("    {dim}: {val} [{score:.0}%]");
+    }
+    if !result.raw_metrics.is_empty() {
+        println!("  Raw metrics:");
+        let mut keys: Vec<&String> = result.raw_metrics.keys().collect();
+        keys.sort();
+        for key in keys {
+            let value = result.raw_metrics[key];
+            println!("    {key}: {value:.3}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Topos-driven refactor of `topos-cli` (issue #104), scoped to the crate only — the engine crate is being handled separately.

Dogfooding the v0.4.0 binary (`downloaded_binaries/v0.4.0/topos-macos-arm64`) against `topos/cli/src` surfaced 2 of 14 files failing the SIMPLE gate:

```
topos/cli/src/commands/evaluate.rs   simple: ❌ SLOP [22%]
topos/cli/src/commands/graphify.rs   simple: ❌ SLOP [50%]
```

In both cases `ast.max_function_complexity` was **within** threshold (no single function was too complex) but `cfg.cyclomatic` **exceeded** threshold at the file level — several modestly-complex functions bundled into one file summed past the gate even though none individually tripped it.

## What changed

**`evaluate.rs`** mixed four concerns in one file: GitNexus/MDG resolution, the shared classify-with-representations step, result rendering, and `run()` orchestration. `inspect.rs` was already importing `classify_with_representations` from `evaluate` — a sign that function belonged to neither command specifically. Split into:
- `composable.rs` — `resolve_composable_mdg` (GitNexus/MDG resolve-or-generate)
- `classify.rs` — `classify_with_representations` (shared by `evaluate` and `inspect`)
- `render.rs` — `print_classification` (output formatting)
- `evaluate.rs` now holds only `EvaluateArgs` + `run()`

**`graphify.rs`** bundled two independent subcommands (`generate`, `orphans`) in one file. Split into a `graphify/` submodule:
- `graphify/generate.rs` — `GenerateArgs` + `run_generate`
- `graphify/orphans.rs` — `OrphansArgs` + `scope_to_file` + `run_orphans` (+ its tests)
- `graphify.rs` now holds only `GraphifyArgs`/`GraphifyAction` + dispatch + the shared `print_json` helper

All existing tests moved with their code, unchanged — no behavior change, no new tests needed (this is a pure module reorganization).

## Result

```
Directory rollup (14 files)
  simple: 🥉 SIMPLE
  secure: 🥉 SECURE
```

`cargo test -p topos`: 6/6 pass. `cargo clippy -p topos --all-targets -- -D warnings`: clean. `cargo fmt -p topos --check`: clean.

## Dogfooding finding (not fixed in this PR — flagging for visibility)

While evaluating the engine crate against this same v0.4.0 binary, `ast.entropy`'s gzip-ratio proxy false-positives on very short files: trivial 4–6 line `mod.rs` re-export shims (e.g. `topos/engine/src/graphs/{mdg,pdg,cpg}/mod.rs`) score **98%** but still get **❌ SLOP**, purely from compression overhead dominating on tiny input — not real complexity. This is in the same family as the already-fixed issue #152 (entropy penalizing small/dense-but-simple functions) but reproduces on the current v0.4.0 build for near-empty files specifically. Didn't touch it here since it's an engine-crate metric issue and out of this PR's scope, but it's likely inflating SLOP counts elsewhere in the engine crate's own dogfooding pass too.

## Scope note

This branch targets `worktree-rust-migration-v0.4.0` (PR #159, still open/draft) rather than `main`, since issue #104 work is scoped to the unmerged v0.4.0 milestone. The engine-crate side of issue #104 is being worked separately on `issue104/engine-refactor`.
