### PR TITLE
refactor(mcp): fix topos-mcp SLOP violations found by dogfooding v0.4.0 (issue #104)

### DIFF
--- a/topos/mcp/src/context_budget.rs
+++ b/topos/mcp/src/context_budget.rs
@@ -1,0 +1,115 @@
+//! Context-budget ratchet for the MCP tool-definition surface.
+//!
+//! Every agent session pays for the JSON wire definition of *all* registered
+//! tools (name + description + inputSchema + annotations). These tests are
+//! upper-bound *ratchets*, not equality checks: ceilings match the former
+//! Python FastMCP suite (`tests/mcp/test_context_budget.py`) so the Rust
+//! rewrite does not silently regrow the discovery surface.
+//!
+//! Token cost is approximated as `chars / 4` — the same crude heuristic used
+//! for the Python baseline.
+
+#[cfg(test)]
+mod tests {
+    use crate::server::ToposServer;
+
+    /// Baseline from Python (2026-07-06 measured 33_736; ceiling = +~750).
+    const TOTAL_CEILING_CHARS: usize = 34_500;
+    const PER_TOOL_CEILING_CHARS: usize = 4_500;
+
+    fn approx_tokens(chars: usize) -> usize {
+        chars / 4
+    }
+
+    fn wire_sizes() -> Vec<(String, usize, String)> {
+        ToposServer::new()
+            .list_tool_defs()
+            .into_iter()
+            .map(|tool| {
+                let name = tool.name.to_string();
+                let wire = serde_json::to_string(&tool).expect("serialize tool wire def");
+                let chars = wire.len();
+                (name, chars, wire)
+            })
+            .collect()
+    }
+
+    fn report(sizes: &[(String, usize, String)]) -> String {
+        let mut lines: Vec<String> = sizes
+            .iter()
+            .map(|(name, chars, _)| {
+                format!(
+                    "{chars:8} chars (~{:5} tok)  {name}",
+                    approx_tokens(*chars)
+                )
+            })
+            .collect();
+        let total: usize = sizes.iter().map(|(_, c, _)| *c).sum();
+        lines.push(format!(
+            "{total:8} chars (~{:5} tok)  TOTAL",
+            approx_tokens(total)
+        ));
+        lines.join("\n")
+    }
+
+    #[test]
+    fn total_tool_surface_under_ceiling() {
+        let mut sizes = wire_sizes();
+        sizes.sort_by(|a, b| b.1.cmp(&a.1));
+        let total: usize = sizes.iter().map(|(_, c, _)| *c).sum();
+        assert!(
+            total <= TOTAL_CEILING_CHARS,
+            "MCP tool surface grew to {total} chars (~{} tok), ceiling {TOTAL_CEILING_CHARS}.\n{}",
+            approx_tokens(total),
+            report(&sizes)
+        );
+    }
+
+    #[test]
+    fn per_tool_surface_under_ceiling() {
+        let sizes = wire_sizes();
+        let over: Vec<(String, usize)> = sizes
+            .iter()
+            .filter(|(_, c, _)| *c > PER_TOOL_CEILING_CHARS)
+            .map(|(n, c, _)| (n.clone(), *c))
+            .collect();
+        assert!(
+            over.is_empty(),
+            "Tool(s) exceed per-tool ceiling {PER_TOOL_CEILING_CHARS} chars: {over:?}.\n{}",
+            report(&sizes)
+        );
+    }
+
+    #[test]
+    fn tool_surface_has_current_refactor_routing() {
+        let blob: String = wire_sizes()
+            .into_iter()
+            .map(|(_, _, wire)| wire)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            !blob.contains("STRONGLY PREFERRED for real refactor loops"),
+            "stale side-by-side guidance leaked into tool metadata"
+        );
+        assert!(
+            !blob.contains("Read this first on every new refactor session"),
+            "stale session-start guidance leaked into tool metadata"
+        );
+        assert!(
+            !blob.contains("topos_assess_improvement validates each accepted refactor"),
+            "stale assess_improvement routing leaked into tool metadata"
+        );
+        assert!(
+            blob.contains("topos_assess_worktree_change"),
+            "expected worktree-change routing in tool metadata"
+        );
+    }
+
+    #[test]
+    #[ignore = "convenience: cargo test -p topos-mcp dump_tool_surface -- --ignored --nocapture"]
+    fn dump_tool_surface() {
+        let mut sizes = wire_sizes();
+        sizes.sort_by(|a, b| b.1.cmp(&a.1));
+        println!("{}", report(&sizes));
+    }
+}

--- a/topos/mcp/src/formatting.rs
+++ b/topos/mcp/src/formatting.rs
@@ -225,37 +225,15 @@ pub fn build_agent_contract(
     let simple_ok = result.dimensions.get("simple") == Some(&EvaluationValue::Simple);
     let missing_gitnexus = blocked_by.iter().any(|b| b == "missing_gitnexus_dir");
 
-    let next_tool: Option<String>;
-    if let Some(first) = refactor_targets.and_then(|t| t.first()) {
-        next_tool = Some("topos_assess_worktree_change".into());
-        next_actions.push(format!(
-            "edit target {} ({}) — one focused structural change",
-            first.target_id, first.metric
-        ));
-        if let Some(action) = &composable.next_action {
-            next_actions.push(action.clone());
-        } else if missing_gitnexus {
-            next_actions.push("run topos_generate_depgraph to score COMPOSABLE".into());
-        }
-    } else if let Some(action) = &composable.next_action {
-        next_tool = composable.next_tool.clone();
-        next_actions.push(action.clone());
-    } else if summary == EvaluationValue::Ideal {
-        next_tool = Some("topos_evaluate_project".into());
-        next_actions.push("confirm project rollup and behavior tests before accepting".into());
-    } else if !simple_ok {
-        next_tool = Some("topos_inspect_code".into());
-        next_actions.push("inspect weakest measured pillar, then verify a focused patch".into());
-    } else if !security_findings.is_empty() {
-        next_tool = Some("topos_inspect_code".into());
-        next_actions.push("remove active SECURE findings or acknowledge intentional risk".into());
-    } else if missing_gitnexus {
-        next_tool = Some("topos_generate_depgraph".into());
-        next_actions.push("run topos_generate_depgraph to score COMPOSABLE".into());
-    } else {
-        next_tool = Some("topos_inspect_code".into());
-        next_actions.push("inspect weakest measured pillar, then verify a focused patch".into());
-    }
+    let (next_tool, step_actions) = next_step_for_contract(
+        &composable,
+        refactor_targets,
+        summary,
+        simple_ok,
+        security_findings,
+        missing_gitnexus,
+    );
+    next_actions.extend(step_actions);
 
     if offer_refactor_targets && summary != EvaluationValue::Ideal {
         next_actions.push(
@@ -275,6 +253,51 @@ pub fn build_agent_contract(
         ],
         risk_flags,
     }
+}
+
+/// Priority-ordered next-tool/next-action dispatch for the agent contract:
+/// an in-progress refactor target, then a COMPOSABLE setup blocker, then
+/// IDEAL confirmation, then the weakest unmet pillar, in that fixed order.
+fn next_step_for_contract(
+    composable: &ComposableContractSignals,
+    refactor_targets: Option<&[RefactorTarget]>,
+    summary: EvaluationValue,
+    simple_ok: bool,
+    security_findings: &[SecurityFinding],
+    missing_gitnexus: bool,
+) -> (Option<String>, Vec<String>) {
+    let mut actions = Vec::new();
+    let next_tool = if let Some(first) = refactor_targets.and_then(|t| t.first()) {
+        actions.push(format!(
+            "edit target {} ({}) — one focused structural change",
+            first.target_id, first.metric
+        ));
+        if let Some(action) = &composable.next_action {
+            actions.push(action.clone());
+        } else if missing_gitnexus {
+            actions.push("run topos_generate_depgraph to score COMPOSABLE".into());
+        }
+        Some("topos_assess_worktree_change".into())
+    } else if let Some(action) = &composable.next_action {
+        actions.push(action.clone());
+        composable.next_tool.clone()
+    } else if summary == EvaluationValue::Ideal {
+        actions.push("confirm project rollup and behavior tests before accepting".into());
+        Some("topos_evaluate_project".into())
+    } else if !simple_ok {
+        actions.push("inspect weakest measured pillar, then verify a focused patch".into());
+        Some("topos_inspect_code".into())
+    } else if !security_findings.is_empty() {
+        actions.push("remove active SECURE findings or acknowledge intentional risk".into());
+        Some("topos_inspect_code".into())
+    } else if missing_gitnexus {
+        actions.push("run topos_generate_depgraph to score COMPOSABLE".into());
+        Some("topos_generate_depgraph".into())
+    } else {
+        actions.push("inspect weakest measured pillar, then verify a focused patch".into());
+        Some("topos_inspect_code".into())
+    };
+    (next_tool, actions)
 }
 
 /// The 'COMPOSABLE not scored' note surfaced when no MDG is available.
@@ -557,6 +580,38 @@ pub fn render_evaluation_md(e: &EvaluationResult, title: Option<&str>, verbose: 
         return lines.join("\n");
     }
 
+    push_generators_section(&mut lines, e);
+
+    lines.push(String::new());
+    lines.push(format!("**Priority:** `{}`", e.priority));
+    lines.push(format!("**Guidance:** {}", e.guidance));
+    push_agent_contract_section(&mut lines, e);
+    push_preference_walk_section(&mut lines, e);
+    push_secure_overlay_section(&mut lines, e);
+    push_acknowledged_risks_section(&mut lines, e);
+    if e.grade_capped {
+        lines.push(
+            "> Max grade capped below IDEAL because an acknowledged security risk is active."
+                .into(),
+        );
+    }
+    push_metric_locations_section(&mut lines, e);
+    push_refactor_targets_section(&mut lines, e);
+    push_suggestions_section(&mut lines, e);
+    if verbose {
+        push_raw_metrics_section(&mut lines, e);
+    }
+    lines.join("\n")
+}
+
+// ---------------------------------------------------------------------------
+// render_evaluation_md section renderers
+// ---------------------------------------------------------------------------
+//
+// Each renders one independent markdown section, pushing onto the shared
+// `lines` buffer and no-opping when its section has nothing to show.
+
+fn push_generators_section(lines: &mut Vec<String>, e: &EvaluationResult) {
     lines.push(String::new());
     lines.push("## Generators".into());
     for (dim, val) in sorted_pairs(&e.dimensions) {
@@ -570,162 +625,179 @@ pub fn render_evaluation_md(e: &EvaluationResult, title: Option<&str>, verbose: 
                 .into(),
         );
     }
+}
 
+fn push_agent_contract_section(lines: &mut Vec<String>, e: &EvaluationResult) {
+    let Some(contract) = &e.agent_contract else {
+        return;
+    };
+    if contract.next_tool.is_none()
+        && contract.next_actions.is_empty()
+        && contract.blocked_by.is_empty()
+    {
+        return;
+    }
     lines.push(String::new());
-    lines.push(format!("**Priority:** `{}`", e.priority));
-    lines.push(format!("**Guidance:** {}", e.guidance));
-    if let Some(contract) = &e.agent_contract {
-        if contract.next_tool.is_some()
-            || !contract.next_actions.is_empty()
-            || !contract.blocked_by.is_empty()
-        {
-            lines.push(String::new());
-            lines.push("## Agent Contract".into());
-            if let Some(next_tool) = &contract.next_tool {
-                lines.push(format!("- **Next tool:** `{next_tool}`"));
-            }
-            for action in &contract.next_actions {
-                lines.push(format!("- **Action:** {action}"));
-            }
-            for blocked in &contract.blocked_by {
-                lines.push(format!("- **Blocked by:** `{blocked}`"));
-            }
-        }
+    lines.push("## Agent Contract".into());
+    if let Some(next_tool) = &contract.next_tool {
+        lines.push(format!("- **Next tool:** `{next_tool}`"));
     }
+    for action in &contract.next_actions {
+        lines.push(format!("- **Action:** {action}"));
+    }
+    for blocked in &contract.blocked_by {
+        lines.push(format!("- **Blocked by:** `{blocked}`"));
+    }
+}
 
-    if let Some(pw) = &e.preference_walk {
-        let ranking = pw
-            .ranking
+fn push_preference_walk_section(lines: &mut Vec<String>, e: &EvaluationResult) {
+    let Some(pw) = &e.preference_walk else {
+        return;
+    };
+    let ranking = pw
+        .ranking
+        .iter()
+        .map(|g| g.as_str())
+        .collect::<Vec<_>>()
+        .join(" ≻ ");
+    lines.push(String::new());
+    lines.push("## Preference Walk".into());
+    lines.push(format!("- **Ranking:** {ranking}"));
+    lines.push(format!(
+        "- **Target (aspirational):** {} ({:.0}% of the way)",
+        pw.target.as_str(),
+        pw.progress * 100.0
+    ));
+    lines.push(format!(
+        "- **Fallback (ideal intersection):** {} — divert here if IDEAL plateaus",
+        pw.fallback_target.as_str()
+    ));
+    if let Some(next_step) = pw.next_step {
+        lines.push(format!("- **Next step:** aim for `{}`", next_step.as_str()));
+    }
+    if pw.walk.is_empty() {
+        lines.push("- **Walk:** _at or beyond target — no further steps._".into());
+    } else {
+        let walk_str = pw
+            .walk
             .iter()
-            .map(|g| g.as_str())
+            .map(|v| v.as_str())
             .collect::<Vec<_>>()
-            .join(" ≻ ");
-        lines.push(String::new());
-        lines.push("## Preference Walk".into());
-        lines.push(format!("- **Ranking:** {ranking}"));
-        lines.push(format!(
-            "- **Target (aspirational):** {} ({:.0}% of the way)",
-            pw.target.as_str(),
-            pw.progress * 100.0
-        ));
-        lines.push(format!(
-            "- **Fallback (ideal intersection):** {} — divert here if IDEAL plateaus",
-            pw.fallback_target.as_str()
-        ));
-        if let Some(next_step) = pw.next_step {
-            lines.push(format!("- **Next step:** aim for `{}`", next_step.as_str()));
-        }
-        if pw.walk.is_empty() {
-            lines.push("- **Walk:** _at or beyond target — no further steps._".into());
-        } else {
-            let walk_str = pw
-                .walk
-                .iter()
-                .map(|v| v.as_str())
-                .collect::<Vec<_>>()
-                .join(" → ");
-            lines.push(format!("- **Walk:** {walk_str}"));
-        }
+            .join(" → ");
+        lines.push(format!("- **Walk:** {walk_str}"));
     }
+}
 
-    if let (Some(raw), adjusted) = (e.secure_raw, e.secure_adjusted) {
-        if Some(raw) != adjusted {
-            let raw_str = if raw { "PASS" } else { "FAIL" };
-            let adjusted_str = if adjusted == Some(true) {
-                "PASS"
+fn push_secure_overlay_section(lines: &mut Vec<String>, e: &EvaluationResult) {
+    let (Some(raw), adjusted) = (e.secure_raw, e.secure_adjusted) else {
+        return;
+    };
+    if Some(raw) == adjusted {
+        return;
+    }
+    let raw_str = if raw { "PASS" } else { "FAIL" };
+    let adjusted_str = if adjusted == Some(true) {
+        "PASS"
+    } else {
+        "FAIL"
+    };
+    lines.push(String::new());
+    lines.push(format!(
+        "**SECURE overlay:** {raw_str} (raw) -> {adjusted_str} (acknowledged)"
+    ));
+}
+
+fn push_acknowledged_risks_section(lines: &mut Vec<String>, e: &EvaluationResult) {
+    if e.acknowledged_risks.is_empty() {
+        return;
+    }
+    lines.push(String::new());
+    lines.push("## Acknowledged Risks".into());
+    for risk in &e.acknowledged_risks {
+        let name = risk.callee.clone().unwrap_or_else(|| risk.kind.clone());
+        lines.push(format!("- `{name}` line {}: {}", risk.line, risk.reason));
+    }
+}
+
+fn push_metric_locations_section(lines: &mut Vec<String>, e: &EvaluationResult) {
+    if e.metric_locations.is_empty() {
+        return;
+    }
+    lines.push(String::new());
+    lines.push("## Metric Locations".into());
+    for (metric, entries) in sorted_pairs(&e.metric_locations) {
+        lines.push(format!("- `{metric}`:"));
+        for func in entries.iter() {
+            let where_str = if func.kind.as_deref() == Some("module") {
+                "module-level (not attributable to a function)".to_string()
             } else {
-                "FAIL"
+                format!(
+                    "`{}` ({}) lines {}-{}",
+                    func.qualified_name
+                        .clone()
+                        .unwrap_or_else(|| func.name.clone()),
+                    func.kind.clone().unwrap_or_default(),
+                    func.start_line.map(|l| l.to_string()).unwrap_or_default(),
+                    func.end_line.map(|l| l.to_string()).unwrap_or_default()
+                )
             };
-            lines.push(String::new());
-            lines.push(format!(
-                "**SECURE overlay:** {raw_str} (raw) -> {adjusted_str} (acknowledged)"
-            ));
+            lines.push(format!("  - {where_str} — complexity {}", func.complexity));
         }
     }
-    if !e.acknowledged_risks.is_empty() {
-        lines.push(String::new());
-        lines.push("## Acknowledged Risks".into());
-        for risk in &e.acknowledged_risks {
-            let name = risk.callee.clone().unwrap_or_else(|| risk.kind.clone());
-            lines.push(format!("- `{name}` line {}: {}", risk.line, risk.reason));
-        }
-    }
-    if e.grade_capped {
-        lines.push(
-            "> Max grade capped below IDEAL because an acknowledged security risk is active."
-                .into(),
-        );
-    }
+}
 
-    if !e.metric_locations.is_empty() {
-        lines.push(String::new());
-        lines.push("## Metric Locations".into());
-        for (metric, entries) in sorted_pairs(&e.metric_locations) {
-            lines.push(format!("- `{metric}`:"));
-            for func in entries.iter() {
-                let where_str = if func.kind.as_deref() == Some("module") {
-                    "module-level (not attributable to a function)".to_string()
-                } else {
-                    format!(
-                        "`{}` ({}) lines {}-{}",
-                        func.qualified_name
-                            .clone()
-                            .unwrap_or_else(|| func.name.clone()),
-                        func.kind.clone().unwrap_or_default(),
-                        func.start_line.map(|l| l.to_string()).unwrap_or_default(),
-                        func.end_line.map(|l| l.to_string()).unwrap_or_default()
-                    )
-                };
-                lines.push(format!("  - {where_str} — complexity {}", func.complexity));
-            }
-        }
+fn push_refactor_targets_section(lines: &mut Vec<String>, e: &EvaluationResult) {
+    if e.refactor_targets.is_empty() {
+        return;
     }
+    lines.push(String::new());
+    lines.push("## Refactor Targets".into());
+    lines.push("| Target | Kind | Metric | Location | Operations |".into());
+    lines.push("| --- | --- | --- | --- | --- |".into());
+    for target in &e.refactor_targets {
+        let loc = match (target.line_start, target.line_end) {
+            (Some(start), Some(end)) if end != start => format!("{start}-{end}"),
+            (Some(start), _) => start.to_string(),
+            _ => "?".to_string(),
+        };
+        let symbol = target
+            .symbol
+            .clone()
+            .unwrap_or_else(|| "<module>".to_string())
+            .replace('|', "\\|");
+        let ops = target
+            .recommended_operations
+            .iter()
+            .map(|op| format!("`{op}`"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        lines.push(format!(
+            "| `{}` `{symbol}` | {} | `{}` | {loc} | {ops} |",
+            target.target_id, target.kind, target.metric
+        ));
+    }
+}
 
-    if !e.refactor_targets.is_empty() {
-        lines.push(String::new());
-        lines.push("## Refactor Targets".into());
-        lines.push("| Target | Kind | Metric | Location | Operations |".into());
-        lines.push("| --- | --- | --- | --- | --- |".into());
-        for target in &e.refactor_targets {
-            let loc = match (target.line_start, target.line_end) {
-                (Some(start), Some(end)) if end != start => format!("{start}-{end}"),
-                (Some(start), _) => start.to_string(),
-                _ => "?".to_string(),
-            };
-            let symbol = target
-                .symbol
-                .clone()
-                .unwrap_or_else(|| "<module>".to_string())
-                .replace('|', "\\|");
-            let ops = target
-                .recommended_operations
-                .iter()
-                .map(|op| format!("`{op}`"))
-                .collect::<Vec<_>>()
-                .join(", ");
-            lines.push(format!(
-                "| `{}` `{symbol}` | {} | `{}` | {loc} | {ops} |",
-                target.target_id, target.kind, target.metric
-            ));
-        }
+fn push_suggestions_section(lines: &mut Vec<String>, e: &EvaluationResult) {
+    if e.suggestions.is_empty() {
+        return;
     }
+    lines.push(String::new());
+    lines.push("## Suggestions".into());
+    for s in &e.suggestions {
+        lines.push(format!("- [ ] ({}) {}", s.pillar, s.message));
+    }
+}
 
-    if !e.suggestions.is_empty() {
-        lines.push(String::new());
-        lines.push("## Suggestions".into());
-        for s in &e.suggestions {
-            lines.push(format!("- [ ] ({}) {}", s.pillar, s.message));
-        }
+fn push_raw_metrics_section(lines: &mut Vec<String>, e: &EvaluationResult) {
+    if e.raw_metrics.is_empty() {
+        return;
     }
-
-    if verbose && !e.raw_metrics.is_empty() {
-        lines.push(String::new());
-        lines.push("## Raw Metrics".into());
-        for (k, v) in sorted_pairs(&e.raw_metrics) {
-            lines.push(format!("- `{k}`: {v:.3}"));
-        }
+    lines.push(String::new());
+    lines.push("## Raw Metrics".into());
+    for (k, v) in sorted_pairs(&e.raw_metrics) {
+        lines.push(format!("- `{k}`: {v:.3}"));
     }
-    lines.join("\n")
 }
 
 #[cfg(test)]

--- a/topos/mcp/src/lib.rs
+++ b/topos/mcp/src/lib.rs
@@ -18,3 +18,6 @@ pub mod server;
 pub mod sighthound;
 pub mod snapshots;
 pub mod tools;
+
+#[cfg(test)]
+mod context_budget;

--- a/topos/mcp/src/schemas.rs
+++ b/topos/mcp/src/schemas.rs
@@ -556,23 +556,33 @@ fn default_refactor_limit() -> usize {
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct RefactorInput {
-    /// cycles | dependencies | process | graphify
+    /// Which analysis engine to run: `cycles` (CFG), `dependencies` /
+    /// `process` (need `.gitnexus`), or `graphify` (need Graphify graph).
     pub target: RefactorTargetKind,
+    /// Source file path relative to the MCP file root.
     pub filepath: String,
+    /// Override `.gitnexus` directory (`dependencies` / `process` targets).
     #[serde(default)]
     pub gitnexus_dir: Option<String>,
+    /// Override Graphify output directory (`target=graphify` only).
     #[serde(default)]
     pub graphify_dir: Option<String>,
+    /// Maximum hotspots to return (default 5).
     #[serde(default = "default_refactor_limit")]
     pub limit: usize,
 }
 
+/// Engine selector for `topos_refactor`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum RefactorTargetKind {
+    /// CFG cycle-basis: loop/branch bodies driving cyclomatic complexity.
     Cycles,
+    /// MDG Forman curvature: load-bearing import edges (needs `.gitnexus`).
     Dependencies,
+    /// Process-graph choke points (needs `.gitnexus`).
     Process,
+    /// Graphify orphan nodes / fragile inferred edges.
     Graphify,
 }
 

--- a/topos/mcp/src/security_findings.rs
+++ b/topos/mcp/src/security_findings.rs
@@ -127,7 +127,17 @@ pub fn taint_flow_findings(
         return Vec::new();
     }
 
-    // Deterministic scan order.
+    let (sources, sinks) = collect_taint_sources_and_sinks(cpg, &source_registry, &sink_registry);
+    join_sources_to_sinks(cpg, &forward, &sources, &sinks, max_findings)
+}
+
+/// Deterministic single pass: bucket CPG nodes into taint sources and
+/// dangerous-sink call sites.
+fn collect_taint_sources_and_sinks<'a>(
+    cpg: &'a CodePropertyGraph,
+    source_registry: &HashSet<&str>,
+    sink_registry: &HashSet<&str>,
+) -> (Vec<&'a str>, Vec<(&'a str, String)>) {
     let mut node_items: Vec<_> = cpg.nodes.iter().collect();
     node_items.sort_by_key(|(_, n)| (n.uast.span.start_line, n.uast.span.start_byte));
 
@@ -150,11 +160,21 @@ pub fn taint_flow_findings(
             sources.push(node_id.as_str());
         }
     }
+    (sources, sinks)
+}
 
+/// BFS-reachability join: emit one finding per source with a DDG path to a sink.
+fn join_sources_to_sinks(
+    cpg: &CodePropertyGraph,
+    forward: &HashMap<&str, Vec<&str>>,
+    sources: &[&str],
+    sinks: &[(&str, String)],
+    max_findings: usize,
+) -> Vec<SecurityFinding> {
     let mut findings = Vec::new();
-    for source_id in sources {
-        let reachable = bfs_reachable(&forward, source_id);
-        for (sink_id, sink_snippet) in &sinks {
+    for &source_id in sources {
+        let reachable = bfs_reachable(forward, source_id);
+        for (sink_id, sink_snippet) in sinks {
             if !reachable.contains(sink_id) {
                 continue;
             }

--- a/topos/mcp/src/server.rs
+++ b/topos/mcp/src/server.rs
@@ -64,6 +64,14 @@ impl ToposServer {
             + Self::refactor_router();
         ToposServer { tool_router }
     }
+
+    /// MCP tool definitions as shipped over the wire (`tools/list`).
+    ///
+    /// Used by the context-budget ratchet so agent-visible name + description
+    /// + inputSchema + annotations stay under the Python-era ceilings.
+    pub fn list_tool_defs(&self) -> Vec<rmcp::model::Tool> {
+        self.tool_router.list_all()
+    }
 }
 
 fn doc_resources() -> Vec<Resource> {

--- a/topos/mcp/src/tools/assess.rs
+++ b/topos/mcp/src/tools/assess.rs
@@ -479,6 +479,30 @@ fn status_meaning(status: AssessmentStatus) -> &'static str {
     }
 }
 
+/// The "## Agent Contract" section of the assessment markdown report.
+fn push_assessment_agent_contract_lines(lines: &mut Vec<String>, r: &AssessmentResult) {
+    let Some(contract) = &r.agent_contract else {
+        return;
+    };
+    if contract.next_tool.is_none()
+        && contract.next_actions.is_empty()
+        && contract.blocked_by.is_empty()
+    {
+        return;
+    }
+    lines.push(String::new());
+    lines.push("## Agent Contract".to_string());
+    if let Some(next_tool) = &contract.next_tool {
+        lines.push(format!("- **Next tool:** `{next_tool}`"));
+    }
+    for action in &contract.next_actions {
+        lines.push(format!("- **Action:** {action}"));
+    }
+    for blocked in &contract.blocked_by {
+        lines.push(format!("- **Blocked by:** `{blocked}`"));
+    }
+}
+
 pub(crate) fn render_assessment_md(r: &AssessmentResult) -> String {
     if let Some(err) = &r.error {
         return format!("**Error:** {err}");
@@ -503,24 +527,7 @@ pub(crate) fn render_assessment_md(r: &AssessmentResult) -> String {
             .unwrap_or_default();
         lines.push(format!("**Structural distance:** {distance:.3}{sim}"));
     }
-    if let Some(contract) = &r.agent_contract {
-        if contract.next_tool.is_some()
-            || !contract.next_actions.is_empty()
-            || !contract.blocked_by.is_empty()
-        {
-            lines.push(String::new());
-            lines.push("## Agent Contract".to_string());
-            if let Some(next_tool) = &contract.next_tool {
-                lines.push(format!("- **Next tool:** `{next_tool}`"));
-            }
-            for action in &contract.next_actions {
-                lines.push(format!("- **Action:** {action}"));
-            }
-            for blocked in &contract.blocked_by {
-                lines.push(format!("- **Blocked by:** `{blocked}`"));
-            }
-        }
-    }
+    push_assessment_agent_contract_lines(&mut lines, r);
     if !r.score_deltas.is_empty() {
         let mut pairs: Vec<_> = r.score_deltas.iter().collect();
         pairs.sort_by(|a, b| a.0.cmp(b.0));
@@ -706,6 +713,38 @@ fn ref_exists(repo_root: &Path, git_ref: &str) -> bool {
 // Snapshot / changeset helpers
 // ---------------------------------------------------------------------------
 
+fn priority_from_str(s: &str) -> Option<Priority> {
+    match s {
+        "simple" => Some(Priority::Simple),
+        "composable" => Some(Priority::Composable),
+        "secure" => Some(Priority::Secure),
+        _ => None,
+    }
+}
+
+fn generator_input_from_str(s: &str) -> Option<GeneratorInput> {
+    match s {
+        "simple" => Some(GeneratorInput::Simple),
+        "composable" => Some(GeneratorInput::Composable),
+        "secure" => Some(GeneratorInput::Secure),
+        _ => None,
+    }
+}
+
+fn lattice_element_from_str(s: &str) -> Option<LatticeElement> {
+    match s {
+        "SLOP" => Some(LatticeElement::SLOP),
+        "SIMPLE" => Some(LatticeElement::SIMPLE),
+        "COMPOSABLE" => Some(LatticeElement::COMPOSABLE),
+        "SECURE" => Some(LatticeElement::SECURE),
+        "SIMPLE_COMPOSABLE" => Some(LatticeElement::SIMPLE_COMPOSABLE),
+        "SIMPLE_SECURE" => Some(LatticeElement::SIMPLE_SECURE),
+        "COMPOSABLE_SECURE" => Some(LatticeElement::COMPOSABLE_SECURE),
+        "IDEAL" => Some(LatticeElement::IDEAL),
+        _ => None,
+    }
+}
+
 fn priority_from_meta(
     meta: &HashMap<String, Value>,
 ) -> (
@@ -719,12 +758,7 @@ fn priority_from_meta(
             let priority = meta
                 .get("priority")
                 .and_then(Value::as_str)
-                .and_then(|s| match s {
-                    "simple" => Some(Priority::Simple),
-                    "composable" => Some(Priority::Composable),
-                    "secure" => Some(Priority::Secure),
-                    _ => None,
-                })
+                .and_then(priority_from_str)
                 .unwrap_or(Priority::Simple);
             (priority, PrioritySource::Default, None)
         }
@@ -732,27 +766,12 @@ fn priority_from_meta(
             let generators: Vec<GeneratorInput> = ranking
                 .iter()
                 .filter_map(Value::as_str)
-                .filter_map(|s| match s {
-                    "simple" => Some(GeneratorInput::Simple),
-                    "composable" => Some(GeneratorInput::Composable),
-                    "secure" => Some(GeneratorInput::Secure),
-                    _ => None,
-                })
+                .filter_map(generator_input_from_str)
                 .collect();
             let target = meta
                 .get("target")
                 .and_then(Value::as_str)
-                .and_then(|t| match t {
-                    "SLOP" => Some(LatticeElement::SLOP),
-                    "SIMPLE" => Some(LatticeElement::SIMPLE),
-                    "COMPOSABLE" => Some(LatticeElement::COMPOSABLE),
-                    "SECURE" => Some(LatticeElement::SECURE),
-                    "SIMPLE_COMPOSABLE" => Some(LatticeElement::SIMPLE_COMPOSABLE),
-                    "SIMPLE_SECURE" => Some(LatticeElement::SIMPLE_SECURE),
-                    "COMPOSABLE_SECURE" => Some(LatticeElement::COMPOSABLE_SECURE),
-                    "IDEAL" => Some(LatticeElement::IDEAL),
-                    _ => None,
-                });
+                .and_then(lattice_element_from_str);
             let prefs_input = UserPreferencesInput {
                 ranking: generators,
                 target,

--- a/topos/mcp/src/tools/evaluate.rs
+++ b/topos/mcp/src/tools/evaluate.rs
@@ -887,6 +887,45 @@ fn project_contract(
     }
 }
 
+/// The "## Agent Contract" section of the project markdown report.
+fn push_agent_contract_lines(lines: &mut Vec<String>, r: &ProjectEvaluationResult) {
+    let Some(contract) = &r.agent_contract else {
+        return;
+    };
+    lines.push(String::new());
+    lines.push("## Agent Contract".to_string());
+    if let Some(next_tool) = &contract.next_tool {
+        lines.push(format!("- **Next tool:** `{next_tool}`"));
+    }
+    for action in &contract.next_actions {
+        lines.push(format!("- **Action:** {action}"));
+    }
+    for blocked in &contract.blocked_by {
+        lines.push(format!("- **Blocked by:** `{blocked}`"));
+    }
+}
+
+/// The "## Per-language rollups" section of the project markdown report.
+fn push_language_rollup_lines(lines: &mut Vec<String>, r: &ProjectEvaluationResult) {
+    if r.language_rollups.is_empty() {
+        return;
+    }
+    lines.push(String::new());
+    lines.push("## Per-language rollups".to_string());
+    for rollup in &r.language_rollups {
+        lines.push(format!(
+            "- **{}**: {} (files={}, parse_failures={})",
+            rollup.language,
+            rollup.aggregate_floor_verdict.as_str(),
+            rollup.file_count,
+            rollup.parse_failures
+        ));
+        if let (Some(path), Some(verdict)) = (&rollup.worst_file_path, rollup.worst_file_verdict) {
+            lines.push(format!("  - worst: `{path}` ({})", verdict.as_str()));
+        }
+    }
+}
+
 fn render_project_entry(entry: &ProjectFileEntry, verbose: bool) -> Vec<String> {
     let mut lines = Vec::new();
     let mut score_pairs: Vec<(&String, &f64)> = entry.scores.iter().collect();
@@ -925,19 +964,7 @@ pub(crate) fn render_project_md(r: &ProjectEvaluationResult) -> String {
     if !r.coupling_available {
         lines.push("> ⚠️ No `.gitnexus/` present — coupling dimension not scored.".to_string());
     }
-    if let Some(contract) = &r.agent_contract {
-        lines.push(String::new());
-        lines.push("## Agent Contract".to_string());
-        if let Some(next_tool) = &contract.next_tool {
-            lines.push(format!("- **Next tool:** `{next_tool}`"));
-        }
-        for action in &contract.next_actions {
-            lines.push(format!("- **Action:** {action}"));
-        }
-        for blocked in &contract.blocked_by {
-            lines.push(format!("- **Blocked by:** `{blocked}`"));
-        }
-    }
+    push_agent_contract_lines(&mut lines, r);
     lines.push(String::new());
     lines.push("## Rolled-up dimensions".to_string());
     let mut dims: Vec<(&String, &LatticeElement)> = r.rolled_up_dimensions.iter().collect();
@@ -950,24 +977,7 @@ pub(crate) fn render_project_md(r: &ProjectEvaluationResult) -> String {
             .unwrap_or_default();
         lines.push(format!("- **{dim}**: {}{score}", val.as_str()));
     }
-    if !r.language_rollups.is_empty() {
-        lines.push(String::new());
-        lines.push("## Per-language rollups".to_string());
-        for rollup in &r.language_rollups {
-            lines.push(format!(
-                "- **{}**: {} (files={}, parse_failures={})",
-                rollup.language,
-                rollup.aggregate_floor_verdict.as_str(),
-                rollup.file_count,
-                rollup.parse_failures
-            ));
-            if let (Some(path), Some(verdict)) =
-                (&rollup.worst_file_path, rollup.worst_file_verdict)
-            {
-                lines.push(format!("  - worst: `{path}` ({})", verdict.as_str()));
-            }
-        }
-    }
+    push_language_rollup_lines(&mut lines, r);
     lines.push(String::new());
     lines.push(format!(
         "## Worst files (showing {} of {}, offset {})",

--- a/topos/mcp/src/tools/graphify.rs
+++ b/topos/mcp/src/tools/graphify.rs
@@ -54,10 +54,11 @@ impl ToposServer {
     /// Generate the Graphify knowledge graph (`graphify-out/graph.json`)
     /// via the external `graphify` CLI (side-effecting).
     ///
-    /// Skips running `graphify` when a graph is already present, unless
-    /// `force=true`. Wholly independent of `.gitnexus`/GitNexus — feeds
-    /// only `topos_refactor(target="graphify")`, never SIMPLE/COMPOSABLE/
-    /// SECURE.
+    /// Use before `topos_refactor(target="graphify")` when no graph exists.
+    /// Skips regeneration when a graph is already present unless
+    /// `force=true`. Wholly independent of `.gitnexus`/GitNexus — never
+    /// feeds SIMPLE/COMPOSABLE/SECURE. For GitNexus dep graphs use
+    /// `topos_generate_depgraph` instead.
     #[tool(
         name = "topos_generate_graphify_graph",
         annotations(

--- a/topos/mcp/src/tools/refactor.rs
+++ b/topos/mcp/src/tools/refactor.rs
@@ -367,12 +367,16 @@ fn refactor_graphify(params: &RefactorInput) -> (RefactorResult, String) {
 
 #[tool_router(router = refactor_router, vis = "pub(crate)")]
 impl ToposServer {
-    /// Refactor hotspots (read-only). Four targets: `cycles` (CFG cycle
-    /// basis pointing at loop bodies), `dependencies` (MDG Forman curvature
-    /// naming load-bearing import edges), `process` (process-graph choke
-    /// points), `graphify` (orphan nodes / fragile inferred edges in a
-    /// Graphify knowledge graph). All purely advisory — none feeds the
-    /// lattice score.
+    /// Rank structural refactor hotspots for one file (read-only, advisory).
+    ///
+    /// Does not score SIMPLE/COMPOSABLE/SECURE — use `topos_evaluate_*` for
+    /// medals and `topos_assess_*` to verify edits afterward. `target`
+    /// selects the engine: `cycles` (CFG loop/branch bodies),
+    /// `dependencies` (MDG Forman curvature on imports; needs `.gitnexus`),
+    /// `process` (execution choke points; needs `.gitnexus`), or `graphify`
+    /// (orphan/fragile edges; needs a Graphify graph from
+    /// `topos_generate_graphify_graph`). Returns a RefactorResult with ranked
+    /// `hotspots` (`kind`, `label`, `score`, `suggestion`, optional lines).
     #[tool(
         name = "topos_refactor",
         annotations(


### PR DESCRIPTION
## Summary

Dogfooded the v0.4.0 binary against `topos-mcp` (issue #104) and fixed every genuine `ast.max_function_complexity` violation it surfaced — all pure code motion, no behavior change.

| File | Function | Before → After |
|---|---|---|
| `formatting.rs` | `render_evaluation_md` | 32 → 10 |
| `security_findings.rs` | `taint_flow_findings` | 12 → 7 |
| `tools/evaluate.rs` | `render_project_md` | 13 → 6 |
| `tools/assess.rs` | `priority_from_meta` + `render_assessment_md` | 16 → 9 |

Each fix follows the SIMPLE gate's own prescribed remedy (`extract_helper`), split along the function's natural phase/section boundary:

- **`render_evaluation_md`**: split its ~9 independent markdown sections into `push_*_section` helpers, then extracted `build_agent_contract`'s priority-dispatch chain into `next_step_for_contract`.
- **`taint_flow_findings`**: split node-classification (bucket CPG nodes into taint sources vs. dangerous-sink call sites) from the BFS-reachability join, mirroring the phase split already used for `taint_flow_paths` in the engine crate.
- **`render_project_md`**: same markdown-section shape as above; extracted its Agent Contract and per-language-rollup blocks.
- **`priority_from_meta`**: extracted three inline string→enum match tables (8–9 arms each) into named lookup functions (`priority_from_str`, `generator_input_from_str`, `lattice_element_from_str`), matching the existing `generator_wire`/`generator_for_dim` idiom in `formatting.rs`. `render_assessment_md`: same Agent Contract section extraction as the other two `render_*_md` functions.

## Known limitation not addressed here

File-level `cfg.cyclomatic` still reports SLOP on these files — topos merges every function in a file into one CFG and sums complexity across all of them, so a file with many individually-simple functions can still exceed the flat threshold by count alone. This is a documented gate-design limitation (also present on the parallel `issue104/engine-refactor` branch), not a regression from this change; splitting further to dodge the aggregate would be gaming the metric rather than improving the code.

One dedup opportunity flagged but not chased: the "Agent Contract" markdown block is now near-identical across three files (`formatting.rs`, `evaluate.rs`, `assess.rs`), but each operates on a different result struct and their skip-when-empty semantics already differ slightly — unifying them would be a small behavior change to already-committed code, not a pure extraction.

## Verification

- 306 workspace tests pass (24 in `topos-mcp`)
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo fmt --all --check` clean
- Complexity drops verified against the actual gate (`topos inspect`) after each change, not just the extraction diff

Targets `worktree-rust-migration-v0.4.0` (PR #159) since this branch was forked from its head to isolate `topos-mcp`-scoped work from the parallel `topos-engine`-scoped work happening on `issue104/engine-refactor`.