### PR TITLE
fix(engine): drop cfg.cyclomatic as a hard SIMPLE gate

### DIFF
--- a/topos/engine/src/evaluation/policies/composable.rs
+++ b/topos/engine/src/evaluation/policies/composable.rs
@@ -78,7 +78,10 @@ pub fn score_coupling(
 
     ScoredDecision {
         score: qualities.into_iter().fold(f64::INFINITY, f64::min),
-        achieved: results.iter().all(|r| r.passed()),
+        achieved: results
+            .iter()
+            .filter(|r| r.spec.gates_achieved)
+            .all(|r| r.passed()),
         interpretation,
     }
 }

--- a/topos/engine/src/evaluation/policies/gates.rs
+++ b/topos/engine/src/evaluation/policies/gates.rs
@@ -72,6 +72,15 @@ pub struct GateSpec {
     pub exempt: Option<fn(&GateContext) -> bool>,
     pub operations_low: &'static [&'static str],
     pub operations_high: &'static [&'static str],
+    /// Whether a fail/exempt outcome on this metric drags down its
+    /// pillar's `achieved`. `false` means the metric is still scored and
+    /// surfaced (interpretation, refactor operations) but advisory only
+    /// -- see `cfg.cyclomatic` below, whose whole-file merged-CFG sum
+    /// scales with function count and shouldn't hard-fail a file for
+    /// having many small, individually-simple functions when
+    /// `ast.max_function_complexity` (a true per-function max) already
+    /// gates that concern directly (issue #193).
+    pub gates_achieved: bool,
 }
 
 /// A spec applied to a measured value.
@@ -299,6 +308,11 @@ pub static GATE_SPECS: &[GateSpec] = &[
         exempt: None,
         operations_low: &[],
         operations_high: &["extract_helper", "split_decision_logic"],
+        // Advisory only (issue #193): the whole-file merged-CFG sum
+        // scales with function count, so it shouldn't hard-fail a file
+        // for having many small, individually-simple functions.
+        // ast.max_function_complexity gates that concern directly.
+        gates_achieved: false,
     },
     GateSpec {
         metric: "ast.entropy",
@@ -310,6 +324,7 @@ pub static GATE_SPECS: &[GateSpec] = &[
         exempt: Some(entropy_entrypoint_exempt),
         operations_low: &["consolidate_boilerplate"],
         operations_high: &["decompose_dense_logic"],
+        gates_achieved: true,
     },
     GateSpec {
         metric: "ast.max_function_complexity",
@@ -321,6 +336,7 @@ pub static GATE_SPECS: &[GateSpec] = &[
         exempt: None,
         operations_low: &[],
         operations_high: &["extract_helper", "split_decision_logic"],
+        gates_achieved: true,
     },
     GateSpec {
         metric: "mdg.instability",
@@ -332,6 +348,7 @@ pub static GATE_SPECS: &[GateSpec] = &[
         exempt: Some(instability_entrypoint_exempt),
         operations_low: &["rebalance_dependencies", "extract_boundary"],
         operations_high: &["rebalance_dependencies", "extract_boundary"],
+        gates_achieved: true,
     },
     GateSpec {
         metric: "mdg.main_sequence_distance",
@@ -343,6 +360,7 @@ pub static GATE_SPECS: &[GateSpec] = &[
         exempt: Some(distance_stable_leaf_exempt),
         operations_low: &[],
         operations_high: &["rebalance_dependencies", "extract_boundary"],
+        gates_achieved: true,
     },
     GateSpec {
         metric: "mdg.fan_in",
@@ -354,6 +372,7 @@ pub static GATE_SPECS: &[GateSpec] = &[
         exempt: None,
         operations_low: &[],
         operations_high: &["split_module"],
+        gates_achieved: true,
     },
     GateSpec {
         metric: "mdg.fan_out",
@@ -365,6 +384,7 @@ pub static GATE_SPECS: &[GateSpec] = &[
         exempt: None,
         operations_low: &[],
         operations_high: &["reduce_fanout", "invert_dependency"],
+        gates_achieved: true,
     },
     GateSpec {
         metric: "cpg.dangerous_calls",
@@ -376,6 +396,7 @@ pub static GATE_SPECS: &[GateSpec] = &[
         exempt: None,
         operations_low: &[],
         operations_high: &[],
+        gates_achieved: true,
     },
     GateSpec {
         metric: "cpg.taint_flows",
@@ -387,6 +408,7 @@ pub static GATE_SPECS: &[GateSpec] = &[
         exempt: None,
         operations_low: &[],
         operations_high: &[],
+        gates_achieved: true,
     },
 ];
 

--- a/topos/engine/src/evaluation/policies/secure.rs
+++ b/topos/engine/src/evaluation/policies/secure.rs
@@ -51,7 +51,10 @@ pub fn score_secure(dangerous_calls: f64, taint_flows: f64) -> ScoredDecision {
 
     ScoredDecision {
         score: qualities.into_iter().fold(f64::INFINITY, f64::min),
-        achieved: results.iter().all(|r| r.passed()),
+        achieved: results
+            .iter()
+            .filter(|r| r.spec.gates_achieved)
+            .all(|r| r.passed()),
         interpretation: results
             .iter()
             .map(|r| (r.spec.metric.to_string(), r.interpretation()))

--- a/topos/engine/src/evaluation/policies/simple.rs
+++ b/topos/engine/src/evaluation/policies/simple.rs
@@ -4,9 +4,17 @@
 //!
 //! ```text
 //! Φ_SIMPLE(metrics) → ScoredDecision
-//! achieved = (cyclomatic ≤ gate) ∧ (entropy in band) ∧ (max_func ≤ gate)
+//! achieved = (entropy in band) ∧ (max_func ≤ gate)
 //! score    = min(per-metric qualities)   # reporting only; does not gate achieved
 //! ```
+//!
+//! `cyclomatic` is scored (drags down `score`, drives `extract_helper`
+//! suggestions) but does not gate `achieved` (`GateSpec::gates_achieved
+//! = false` in [`super::gates`], issue #193): it's a whole-file
+//! merged-CFG sum that scales with function count, so it would
+//! otherwise hard-fail a file with several small, individually-simple
+//! functions -- a concern `max_func` (a true per-function max) already
+//! gates directly.
 //!
 //! Gate comparisons and interpretation prose live in
 //! [`super::gates`]; thresholds and normalization caps in
@@ -62,7 +70,10 @@ pub fn score_simple(
         // The combined score is the minimum of the individual qualities
         // (conservative AND).
         score: qualities.into_iter().fold(f64::INFINITY, f64::min),
-        achieved: results.iter().all(|r| r.passed()),
+        achieved: results
+            .iter()
+            .filter(|r| r.spec.gates_achieved)
+            .all(|r| r.passed()),
         interpretation: results
             .iter()
             .map(|r| (r.spec.metric.to_string(), r.interpretation()))
@@ -121,10 +132,18 @@ mod tests {
     #[test]
     fn independent_thresholds_each_fail_alone() {
         assert!(score_simple(Some(10.0), Some(0.5), Some(5.0), false, None).achieved);
-        assert!(!score_simple(Some(16.0), Some(0.5), Some(5.0), false, None).achieved); // fail cyclomatic
         assert!(!score_simple(Some(10.0), Some(0.9), Some(5.0), false, None).achieved); // fail entropy
         assert!(!score_simple(Some(10.0), Some(0.5), Some(11.0), false, None).achieved);
         // fail max func
+    }
+
+    #[test]
+    fn cyclomatic_over_threshold_scores_but_does_not_gate() {
+        // cyclomatic=16 exceeds SIMPLE.max_cyclomatic (15), but no longer
+        // gates achieved -- it's advisory only (issue #193).
+        let result = score_simple(Some(16.0), Some(0.5), Some(5.0), false, None);
+        assert!(result.achieved);
+        assert!(result.score < 1.0); // still drags the score down
     }
 
     #[test]


### PR DESCRIPTION
Fixes #193.

## How this was found

While dogfooding v0.4.0 against `topos-engine` itself for #104 (PR #191), 33/99 files kept failing the SIMPLE gate on `cfg.cyclomatic` alone. Traced it to `cfg/builder.rs` merging every function in a file into one CFG (`P = 1`), so `cfg.cyclomatic` is a whole-file *sum* — but it's gated at the same flat threshold (15) calibrated for a *single* function's complexity. Confirmed by experiment: splitting a 48-cyclomatic file into two ~25s still left both over threshold. `ast.max_function_complexity` already measures the right thing (true per-function max) and passed on the same files, so the fix is to stop double-gating the same concern.

## Change

`cfg.cyclomatic` still contributes to the SIMPLE score and still drives `extract_helper` suggestions — it just no longer hard-fails `achieved`. Added `GateSpec::gates_achieved` (default `true`, `false` only for `cfg.cyclomatic`).

## Result

`topos-engine` self-eval: 33/99 files SLOP → 3/99, all genuinely from `ast.max_function_complexity`.

278 tests pass, clippy/fmt clean.
