### PR TITLE
docs(mcp): Glama TDQS tool defs + wire budget ratchet

### DIFF
--- a/topos/mcp/src/context_budget.rs
+++ b/topos/mcp/src/context_budget.rs
@@ -1,0 +1,115 @@
+//! Context-budget ratchet for the MCP tool-definition surface.
+//!
+//! Every agent session pays for the JSON wire definition of *all* registered
+//! tools (name + description + inputSchema + annotations). These tests are
+//! upper-bound *ratchets*, not equality checks: ceilings match the former
+//! Python FastMCP suite (`tests/mcp/test_context_budget.py`) so the Rust
+//! rewrite does not silently regrow the discovery surface.
+//!
+//! Token cost is approximated as `chars / 4` — the same crude heuristic used
+//! for the Python baseline.
+
+#[cfg(test)]
+mod tests {
+    use crate::server::ToposServer;
+
+    /// Baseline from Python (2026-07-06 measured 33_736; ceiling = +~750).
+    const TOTAL_CEILING_CHARS: usize = 34_500;
+    const PER_TOOL_CEILING_CHARS: usize = 4_500;
+
+    fn approx_tokens(chars: usize) -> usize {
+        chars / 4
+    }
+
+    fn wire_sizes() -> Vec<(String, usize, String)> {
+        ToposServer::new()
+            .list_tool_defs()
+            .into_iter()
+            .map(|tool| {
+                let name = tool.name.to_string();
+                let wire = serde_json::to_string(&tool).expect("serialize tool wire def");
+                let chars = wire.len();
+                (name, chars, wire)
+            })
+            .collect()
+    }
+
+    fn report(sizes: &[(String, usize, String)]) -> String {
+        let mut lines: Vec<String> = sizes
+            .iter()
+            .map(|(name, chars, _)| {
+                format!(
+                    "{chars:8} chars (~{:5} tok)  {name}",
+                    approx_tokens(*chars)
+                )
+            })
+            .collect();
+        let total: usize = sizes.iter().map(|(_, c, _)| *c).sum();
+        lines.push(format!(
+            "{total:8} chars (~{:5} tok)  TOTAL",
+            approx_tokens(total)
+        ));
+        lines.join("\n")
+    }
+
+    #[test]
+    fn total_tool_surface_under_ceiling() {
+        let mut sizes = wire_sizes();
+        sizes.sort_by(|a, b| b.1.cmp(&a.1));
+        let total: usize = sizes.iter().map(|(_, c, _)| *c).sum();
+        assert!(
+            total <= TOTAL_CEILING_CHARS,
+            "MCP tool surface grew to {total} chars (~{} tok), ceiling {TOTAL_CEILING_CHARS}.\n{}",
+            approx_tokens(total),
+            report(&sizes)
+        );
+    }
+
+    #[test]
+    fn per_tool_surface_under_ceiling() {
+        let sizes = wire_sizes();
+        let over: Vec<(String, usize)> = sizes
+            .iter()
+            .filter(|(_, c, _)| *c > PER_TOOL_CEILING_CHARS)
+            .map(|(n, c, _)| (n.clone(), *c))
+            .collect();
+        assert!(
+            over.is_empty(),
+            "Tool(s) exceed per-tool ceiling {PER_TOOL_CEILING_CHARS} chars: {over:?}.\n{}",
+            report(&sizes)
+        );
+    }
+
+    #[test]
+    fn tool_surface_has_current_refactor_routing() {
+        let blob: String = wire_sizes()
+            .into_iter()
+            .map(|(_, _, wire)| wire)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            !blob.contains("STRONGLY PREFERRED for real refactor loops"),
+            "stale side-by-side guidance leaked into tool metadata"
+        );
+        assert!(
+            !blob.contains("Read this first on every new refactor session"),
+            "stale session-start guidance leaked into tool metadata"
+        );
+        assert!(
+            !blob.contains("topos_assess_improvement validates each accepted refactor"),
+            "stale assess_improvement routing leaked into tool metadata"
+        );
+        assert!(
+            blob.contains("topos_assess_worktree_change"),
+            "expected worktree-change routing in tool metadata"
+        );
+    }
+
+    #[test]
+    #[ignore = "convenience: cargo test -p topos-mcp dump_tool_surface -- --ignored --nocapture"]
+    fn dump_tool_surface() {
+        let mut sizes = wire_sizes();
+        sizes.sort_by(|a, b| b.1.cmp(&a.1));
+        println!("{}", report(&sizes));
+    }
+}

--- a/topos/mcp/src/lib.rs
+++ b/topos/mcp/src/lib.rs
@@ -18,3 +18,6 @@ pub mod server;
 pub mod sighthound;
 pub mod snapshots;
 pub mod tools;
+
+#[cfg(test)]
+mod context_budget;

--- a/topos/mcp/src/schemas.rs
+++ b/topos/mcp/src/schemas.rs
@@ -556,23 +556,33 @@ fn default_refactor_limit() -> usize {
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct RefactorInput {
-    /// cycles | dependencies | process | graphify
+    /// Which analysis engine to run: `cycles` (CFG), `dependencies` /
+    /// `process` (need `.gitnexus`), or `graphify` (need Graphify graph).
     pub target: RefactorTargetKind,
+    /// Source file path relative to the MCP file root.
     pub filepath: String,
+    /// Override `.gitnexus` directory (`dependencies` / `process` targets).
     #[serde(default)]
     pub gitnexus_dir: Option<String>,
+    /// Override Graphify output directory (`target=graphify` only).
     #[serde(default)]
     pub graphify_dir: Option<String>,
+    /// Maximum hotspots to return (default 5).
     #[serde(default = "default_refactor_limit")]
     pub limit: usize,
 }
 
+/// Engine selector for `topos_refactor`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum RefactorTargetKind {
+    /// CFG cycle-basis: loop/branch bodies driving cyclomatic complexity.
     Cycles,
+    /// MDG Forman curvature: load-bearing import edges (needs `.gitnexus`).
     Dependencies,
+    /// Process-graph choke points (needs `.gitnexus`).
     Process,
+    /// Graphify orphan nodes / fragile inferred edges.
     Graphify,
 }
 

--- a/topos/mcp/src/server.rs
+++ b/topos/mcp/src/server.rs
@@ -64,6 +64,14 @@ impl ToposServer {
             + Self::refactor_router();
         ToposServer { tool_router }
     }
+
+    /// MCP tool definitions as shipped over the wire (`tools/list`).
+    ///
+    /// Used by the context-budget ratchet so agent-visible name + description
+    /// + inputSchema + annotations stay under the Python-era ceilings.
+    pub fn list_tool_defs(&self) -> Vec<rmcp::model::Tool> {
+        self.tool_router.list_all()
+    }
 }
 
 fn doc_resources() -> Vec<Resource> {

--- a/topos/mcp/src/tools/graphify.rs
+++ b/topos/mcp/src/tools/graphify.rs
@@ -54,10 +54,11 @@ impl ToposServer {
     /// Generate the Graphify knowledge graph (`graphify-out/graph.json`)
     /// via the external `graphify` CLI (side-effecting).
     ///
-    /// Skips running `graphify` when a graph is already present, unless
-    /// `force=true`. Wholly independent of `.gitnexus`/GitNexus — feeds
-    /// only `topos_refactor(target="graphify")`, never SIMPLE/COMPOSABLE/
-    /// SECURE.
+    /// Use before `topos_refactor(target="graphify")` when no graph exists.
+    /// Skips regeneration when a graph is already present unless
+    /// `force=true`. Wholly independent of `.gitnexus`/GitNexus — never
+    /// feeds SIMPLE/COMPOSABLE/SECURE. For GitNexus dep graphs use
+    /// `topos_generate_depgraph` instead.
     #[tool(
         name = "topos_generate_graphify_graph",
         annotations(

--- a/topos/mcp/src/tools/refactor.rs
+++ b/topos/mcp/src/tools/refactor.rs
@@ -367,12 +367,16 @@ fn refactor_graphify(params: &RefactorInput) -> (RefactorResult, String) {
 
 #[tool_router(router = refactor_router, vis = "pub(crate)")]
 impl ToposServer {
-    /// Refactor hotspots (read-only). Four targets: `cycles` (CFG cycle
-    /// basis pointing at loop bodies), `dependencies` (MDG Forman curvature
-    /// naming load-bearing import edges), `process` (process-graph choke
-    /// points), `graphify` (orphan nodes / fragile inferred edges in a
-    /// Graphify knowledge graph). All purely advisory — none feeds the
-    /// lattice score.
+    /// Rank structural refactor hotspots for one file (read-only, advisory).
+    ///
+    /// Does not score SIMPLE/COMPOSABLE/SECURE — use `topos_evaluate_*` for
+    /// medals and `topos_assess_*` to verify edits afterward. `target`
+    /// selects the engine: `cycles` (CFG loop/branch bodies),
+    /// `dependencies` (MDG Forman curvature on imports; needs `.gitnexus`),
+    /// `process` (execution choke points; needs `.gitnexus`), or `graphify`
+    /// (orphan/fragile edges; needs a Graphify graph from
+    /// `topos_generate_graphify_graph`). Returns a RefactorResult with ranked
+    /// `hotspots` (`kind`, `label`, `score`, `suggestion`, optional lines).
     #[tool(
         name = "topos_refactor",
         annotations(


### PR DESCRIPTION
## Summary
- Rewrite `topos_refactor` (and tighten `topos_generate_graphify_graph`) tool descriptions for Glama TDQS: purpose, when/when-not, prereqs, return shape
- Add schemars-visible field/variant docs on `RefactorInput` / `RefactorTargetKind` (was 0% schema coverage on live Glama)
- Port Python MCP context-budget ceilings (`34_500` total / `4_500` per tool) as Rust tests via `ToposServer::list_tool_defs()`

Stacked on #194 (`issue104/mcp-refactor`).

## Test plan
- [x] `cargo test -p topos-mcp` (27 passed)
- [x] `cargo test -p topos-mcp --lib dump_tool_surface -- --ignored --nocapture` (measured ~32.3k chars total, under ceiling)
- [ ] After merge into #194 / 0.4 release: Glama sync and confirm `topos_refactor` TDQS rises from 1.7/5