### PR TITLE
security(vscode): bump transitive `fast-uri` to 3.1.4

### DIFF
--- a/extensions/vscode/pnpm-lock.yaml
+++ b/extensions/vscode/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   serialize-javascript: ^7.0.5
   diff: ^9.0.0
+  fast-uri: ^3.1.4
 
 importers:
 
@@ -962,8 +963,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.3:
-    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -2585,7 +2586,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.3
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -3041,7 +3042,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.3: {}
+  fast-uri@3.1.4: {}
 
   fastq@1.20.1:
     dependencies:

--- a/extensions/vscode/pnpm-workspace.yaml
+++ b/extensions/vscode/pnpm-workspace.yaml
@@ -6,6 +6,9 @@ packages:
 overrides:
   serialize-javascript: "^7.0.5"
   diff: "^9.0.0"
+  # GHSA-v2hh-gcrm-f6hx / CVE-2026-16221: host confusion via backslash authority.
+  # Transitive via @vscode/vsce → secretlint → ajv@8 (fast-uri ^3.0.1).
+  fast-uri: "^3.1.4"
 
 # Allow postinstall scripts required by the extension toolchain.
 allowBuilds:


### PR DESCRIPTION
> [!TIP]
> _**Fixes GitHub dependabot vulnerability finding**_

## Summary
- Dependabot alert number 7: `fast-uri` host confusion via literal `\` authority delimiter (GHSA-v2hh-gcrm-f6hx / CVE-2026-16221).
- Affected lock: `fast-uri@3.1.3` under `extensions/vscode` only (transitive via `@vscode/vsce` → secretlint → `ajv@8.20.0`).
- Dependabot could not auto-resolve because there is no direct dep and the lock stayed on 3.1.3 even though `ajv` allows `fast-uri: ^3.0.1`.

## Fix
- Add pnpm override `fast-uri: ^3.1.4` (same pattern as existing `serialize-javascript` / `diff` overrides).
- Relock to `fast-uri@3.1.4` (patched 3.x; do not jump to 4.x).

## Risk
- Dev/CI packaging toolchain only; not bundled into the shipped extension runtime (`--no-dependencies`).

## Test plan
- [x] `pnpm why fast-uri` → single version `3.1.4`
- [x] `pnpm run check-types`
- [x] `pnpm run lint`
- [x] `pnpm test` (24 unit + staging)
- [x] `pnpm run package`
- [ ] Confirm Dependabot alert closes after merge to `main`