### PR TITLE
fix: detect Homebrew installs across platforms

### DIFF
--- a/tests/cli/test_helpers.py
+++ b/tests/cli/test_helpers.py
@@ -230,6 +230,22 @@ def test_detect_install_method_homebrew_cellar(monkeypatch):
         assert info.uninstall_cmd == "brew uninstall topos"
 
 
+def test_detect_install_method_homebrew_apple_silicon_linked_keg(monkeypatch):
+    def raise_not_found(name: str):
+        raise PackageNotFoundError
+
+    with monkeypatch.context() as m:
+        m.setattr("importlib.metadata.distribution", raise_not_found)
+        m.setattr("topos.cli.installation.load_provenance", lambda: None)
+        m.setattr(
+            "topos.cli.installation.active_executable",
+            lambda: Path("/opt/homebrew/bin/topos"),
+        )
+        m.delenv("HOMEBREW_PREFIX", raising=False)
+
+        assert detect_install_info().method == "homebrew"
+
+
 def test_detect_install_method_homebrew_intel_cellar(monkeypatch):
     def raise_not_found(name: str):
         raise PackageNotFoundError

--- a/tests/cli/test_helpers.py
+++ b/tests/cli/test_helpers.py
@@ -230,6 +230,38 @@ def test_detect_install_method_homebrew_cellar(monkeypatch):
         assert info.uninstall_cmd == "brew uninstall topos"
 
 
+def test_detect_install_method_homebrew_intel_cellar(monkeypatch):
+    def raise_not_found(name: str):
+        raise PackageNotFoundError
+
+    with monkeypatch.context() as m:
+        m.setattr("importlib.metadata.distribution", raise_not_found)
+        m.setattr("topos.cli.installation.load_provenance", lambda: None)
+        m.setattr(
+            "topos.cli.installation.active_executable",
+            lambda: Path("/usr/local/Cellar/topos/0.3.12/bin/topos"),
+        )
+        m.delenv("HOMEBREW_PREFIX", raising=False)
+
+        assert detect_install_info().method == "homebrew"
+
+
+def test_detect_install_method_homebrew_linux_cellar(monkeypatch):
+    def raise_not_found(name: str):
+        raise PackageNotFoundError
+
+    with monkeypatch.context() as m:
+        m.setattr("importlib.metadata.distribution", raise_not_found)
+        m.setattr("topos.cli.installation.load_provenance", lambda: None)
+        m.setattr(
+            "topos.cli.installation.active_executable",
+            lambda: Path("/home/linuxbrew/.linuxbrew/Cellar/topos/0.3.12/bin/topos"),
+        )
+        m.delenv("HOMEBREW_PREFIX", raising=False)
+
+        assert detect_install_info().method == "homebrew"
+
+
 def test_detect_install_method_homebrew_prefix_env(monkeypatch, tmp_path: Path):
     def raise_not_found(name: str):
         raise PackageNotFoundError
@@ -245,6 +277,61 @@ def test_detect_install_method_homebrew_prefix_env(monkeypatch, tmp_path: Path):
 
         info = detect_install_info()
         assert info.method == "homebrew"
+
+
+def test_detect_install_method_ignores_unrelated_cellar(monkeypatch, tmp_path: Path):
+    def raise_not_found(name: str):
+        raise PackageNotFoundError
+
+    with monkeypatch.context() as m:
+        m.setattr("importlib.metadata.distribution", raise_not_found)
+        m.setattr("topos.cli.installation.load_provenance", lambda: None)
+        m.setattr(
+            "topos.cli.installation.active_executable",
+            lambda: tmp_path / "fake" / "Cellar" / "topos" / "0.3.12" / "bin" / "topos",
+        )
+        m.delenv("HOMEBREW_PREFIX", raising=False)
+
+        assert detect_install_info().method == "unknown"
+
+
+def test_detect_install_method_binary_in_usr_local_bin(monkeypatch):
+    def raise_not_found(name: str):
+        raise PackageNotFoundError
+
+    provenance = {
+        "install_method": "binary-installer",
+        "install_path": "/usr/local/bin/topos",
+    }
+
+    with monkeypatch.context() as m:
+        m.setattr("importlib.metadata.distribution", raise_not_found)
+        m.setattr("topos.cli.installation.load_provenance", lambda: provenance)
+        m.setattr(
+            "topos.cli.installation.active_executable",
+            lambda: Path("/usr/local/bin/topos"),
+        )
+        m.delenv("HOMEBREW_PREFIX", raising=False)
+
+        info = detect_install_info()
+        assert info.method == "binary-installer"
+        assert info.provenance == provenance
+
+
+def test_detect_install_method_ignores_malformed_homebrew_prefix(monkeypatch):
+    def raise_not_found(name: str):
+        raise PackageNotFoundError
+
+    with monkeypatch.context() as m:
+        m.setattr("importlib.metadata.distribution", raise_not_found)
+        m.setattr("topos.cli.installation.load_provenance", lambda: None)
+        m.setattr(
+            "topos.cli.installation.active_executable",
+            lambda: Path("/opt/homebrew/Cellar/topos/0.3.12/bin/topos"),
+        )
+        m.setenv("HOMEBREW_PREFIX", "~definitely_no_such_topos_user_200")
+
+        assert detect_install_info().method == "homebrew"
 
 
 def test_detect_install_method_homebrew_wins_over_stale_binary_provenance(monkeypatch):

--- a/topos/cli/installation.py
+++ b/topos/cli/installation.py
@@ -127,7 +127,8 @@ def _is_homebrew_executable(path: Path) -> bool:
     Three-tier classification:
     1. Explicit ``HOMEBREW_PREFIX`` — broad prefix match (custom roots, linked kegs).
     2. Private default roots (``/opt/homebrew``, Linuxbrew) — broad prefix match.
-    3. Shared ``/usr/local`` — Cellar layout only (avoids ``/usr/local/bin`` false positives).
+    3. Shared ``/usr/local`` — Cellar layout only
+       (avoids ``/usr/local/bin`` false positives).
     """
     try:
         resolved_path = path.expanduser().resolve()

--- a/topos/cli/installation.py
+++ b/topos/cli/installation.py
@@ -11,6 +11,11 @@ from pathlib import Path
 import click
 
 _PACKAGE_NAME = "topos-mcp"
+_DEFAULT_HOMEBREW_PREFIXES = (
+    Path("/opt/homebrew"),
+    Path("/usr/local"),
+    Path("/home/linuxbrew/.linuxbrew"),
+)
 
 
 @dataclass(frozen=True)
@@ -108,15 +113,38 @@ def _install_info_from_distribution(
 
 def _is_homebrew_executable(path: Path) -> bool:
     """True when the resolved executable lives inside a Homebrew prefix."""
-    if "Cellar" in path.parts:
-        return True
-    prefix = os.environ.get("HOMEBREW_PREFIX", "").strip()
-    if not prefix:
-        return False
     try:
-        return path.is_relative_to(Path(prefix).expanduser().resolve())
+        resolved_path = path.expanduser().resolve()
     except OSError:
         return False
+
+    configured_prefix = os.environ.get("HOMEBREW_PREFIX", "").strip()
+    if configured_prefix:
+        try:
+            prefix_path = Path(configured_prefix).expanduser()
+            if prefix_path.is_absolute():
+                prefix = prefix_path.resolve()
+                if resolved_path.is_relative_to(prefix):
+                    return True
+        except (OSError, RuntimeError):
+            pass
+
+    for prefix_path in _DEFAULT_HOMEBREW_PREFIXES:
+        try:
+            prefix = prefix_path.expanduser().resolve()
+            relative_parts = resolved_path.relative_to(prefix).parts
+        except (OSError, ValueError):
+            continue
+
+        if (
+            len(relative_parts) >= 4
+            and relative_parts[0] == "Cellar"
+            and bool(relative_parts[1])
+            and bool(relative_parts[2])
+        ):
+            return True
+
+    return False
 
 
 def _homebrew_info() -> InstallInfo:

--- a/topos/cli/installation.py
+++ b/topos/cli/installation.py
@@ -11,11 +11,12 @@ from pathlib import Path
 import click
 
 _PACKAGE_NAME = "topos-mcp"
-_DEFAULT_HOMEBREW_PREFIXES = (
+# Default roots where broad prefix matching is safe (not shared with binary installs).
+_PRIVATE_HOMEBREW_PREFIXES = (
     Path("/opt/homebrew"),
-    Path("/usr/local"),
     Path("/home/linuxbrew/.linuxbrew"),
 )
+_SHARED_HOMEBREW_PREFIX = Path("/usr/local")
 
 
 @dataclass(frozen=True)
@@ -111,8 +112,23 @@ def _install_info_from_distribution(
     return _package_manager_info(installer)
 
 
+def _is_homebrew_cellar_layout(relative_parts: tuple[str, ...]) -> bool:
+    return (
+        len(relative_parts) >= 4
+        and relative_parts[0] == "Cellar"
+        and bool(relative_parts[1])
+        and bool(relative_parts[2])
+    )
+
+
 def _is_homebrew_executable(path: Path) -> bool:
-    """True when the resolved executable lives inside a Homebrew prefix."""
+    """True when the resolved executable lives inside a Homebrew prefix.
+
+    Three-tier classification:
+    1. Explicit ``HOMEBREW_PREFIX`` — broad prefix match (custom roots, linked kegs).
+    2. Private default roots (``/opt/homebrew``, Linuxbrew) — broad prefix match.
+    3. Shared ``/usr/local`` — Cellar layout only (avoids ``/usr/local/bin`` false positives).
+    """
     try:
         resolved_path = path.expanduser().resolve()
     except OSError:
@@ -129,20 +145,21 @@ def _is_homebrew_executable(path: Path) -> bool:
         except (OSError, RuntimeError):
             pass
 
-    for prefix_path in _DEFAULT_HOMEBREW_PREFIXES:
+    for prefix_path in _PRIVATE_HOMEBREW_PREFIXES:
         try:
             prefix = prefix_path.expanduser().resolve()
-            relative_parts = resolved_path.relative_to(prefix).parts
-        except (OSError, ValueError):
+            if resolved_path.is_relative_to(prefix):
+                return True
+        except OSError:
             continue
 
-        if (
-            len(relative_parts) >= 4
-            and relative_parts[0] == "Cellar"
-            and bool(relative_parts[1])
-            and bool(relative_parts[2])
-        ):
+    try:
+        usr_local = _SHARED_HOMEBREW_PREFIX.resolve()
+        relative_parts = resolved_path.relative_to(usr_local).parts
+        if _is_homebrew_cellar_layout(relative_parts):
             return True
+    except (OSError, ValueError):
+        pass
 
     return False
 


### PR DESCRIPTION
## Summary
- detect standard Apple Silicon, Intel macOS, and Linuxbrew Cellar layouts even when `HOMEBREW_PREFIX` is absent
- preserve custom Homebrew-prefix support while ignoring malformed or relative prefix values
- avoid misclassifying direct `/usr/local/bin/topos` binary-installer installs as Homebrew
- add regression coverage for standard, custom, unrelated, malformed, and provenance cases

## Verification
- `pytest -q` (839 passed, 11 skipped)
- `ruff check topos tests`
- `ruff format --check topos tests`
- `cargo test` (39 passed)
- `cargo clippy -- -D warnings`
- `cargo fmt --check`
- independent review completed with no remaining findings

Closes #200