### PR TITLE
fix(cli): tighten Homebrew Cellar path detection (#200)

### DIFF
--- a/tests/cli/test_helpers.py
+++ b/tests/cli/test_helpers.py
@@ -270,6 +270,65 @@ def test_detect_install_method_homebrew_wins_over_stale_binary_provenance(monkey
         assert info.uninstall_cmd == "brew uninstall topos"
 
 
+def test_detect_install_method_homebrew_cellar_false_positive(monkeypatch):
+    """A path containing ``Cellar`` but NOT under a Homebrew prefix must NOT
+    be detected as Homebrew (regression test for #200)."""
+
+    def raise_not_found(name: str):
+        raise PackageNotFoundError
+
+    with monkeypatch.context() as m:
+        m.setattr("importlib.metadata.distribution", raise_not_found)
+        m.setattr("topos.cli.installation.load_provenance", lambda: None)
+        m.setattr(
+            "topos.cli.installation.active_executable",
+            lambda: Path("/Users/me/projects/Cellar/bin/topos"),
+        )
+        m.delenv("HOMEBREW_PREFIX", raising=False)
+
+        info = detect_install_info()
+        assert info.method != "homebrew"
+
+
+def test_detect_install_method_homebrew_cellar_under_real_prefix(monkeypatch):
+    """A real Cellar path under ``/opt/homebrew`` MUST still be detected."""
+
+    def raise_not_found(name: str):
+        raise PackageNotFoundError
+
+    with monkeypatch.context() as m:
+        m.setattr("importlib.metadata.distribution", raise_not_found)
+        m.setattr("topos.cli.installation.load_provenance", lambda: None)
+        m.setattr(
+            "topos.cli.installation.active_executable",
+            lambda: Path("/opt/homebrew/Cellar/topos/0.3.12/bin/topos"),
+        )
+        m.delenv("HOMEBREW_PREFIX", raising=False)
+
+        info = detect_install_info()
+        assert info.method == "homebrew"
+
+
+def test_detect_install_method_homebrew_prefix_only(monkeypatch, tmp_path: Path):
+    """A binary directly under ``HOMEBREW_PREFIX/bin`` (linked keg) without a
+    Cellar segment is still recognised as Homebrew."""
+
+    def raise_not_found(name: str):
+        raise PackageNotFoundError
+
+    prefix = tmp_path / "linuxbrew"
+    binary = prefix / "bin" / "topos"
+
+    with monkeypatch.context() as m:
+        m.setattr("importlib.metadata.distribution", raise_not_found)
+        m.setattr("topos.cli.installation.load_provenance", lambda: None)
+        m.setattr("topos.cli.installation.active_executable", lambda: binary)
+        m.setenv("HOMEBREW_PREFIX", str(prefix))
+
+        info = detect_install_info()
+        assert info.method == "homebrew"
+
+
 def test_channel_label_homebrew():
     from topos.cli.installation import InstallInfo, channel_label
 

--- a/topos/cli/installation.py
+++ b/topos/cli/installation.py
@@ -106,17 +106,49 @@ def _install_info_from_distribution(
     return _package_manager_info(installer)
 
 
+# Known default Homebrew installation roots (ordered by likelihood).
+_HOMEBREW_DEFAULT_PREFIXES = (
+    "/opt/homebrew",   # Apple Silicon (macOS)
+    "/usr/local",      # Intel macOS / Linuxbrew (default)
+    "/home/linuxbrew/.linuxbrew",  # Linuxbrew
+)
+
+
+def _homebrew_prefixes() -> list[Path]:
+    """Return resolved Homebrew prefix candidates: env var then defaults."""
+    prefixes: list[Path] = []
+    env_prefix = os.environ.get("HOMEBREW_PREFIX", "").strip()
+    if env_prefix:
+        try:
+            prefixes.append(Path(env_prefix).expanduser().resolve())
+        except OSError:
+            pass
+    for candidate in _HOMEBREW_DEFAULT_PREFIXES:
+        resolved = Path(candidate).resolve()
+        if resolved not in prefixes:
+            prefixes.append(resolved)
+    return prefixes
+
+
 def _is_homebrew_executable(path: Path) -> bool:
-    """True when the resolved executable lives inside a Homebrew prefix."""
-    if "Cellar" in path.parts:
-        return True
-    prefix = os.environ.get("HOMEBREW_PREFIX", "").strip()
-    if not prefix:
-        return False
-    try:
-        return path.is_relative_to(Path(prefix).expanduser().resolve())
-    except OSError:
-        return False
+    """True when the resolved executable lives inside a Homebrew prefix.
+
+    A path is recognised as Homebrew-installed only when it sits under a
+    *known* Homebrew root prefix (``HOMEBREW_PREFIX`` or one of the
+    standard defaults).  A bare ``Cellar`` segment match is **not**
+    sufficient — that avoids false positives for projects whose directory
+    tree happens to contain a ``Cellar``-named folder.
+    """
+    # Fast path: check against all known Homebrew root prefixes.
+    for prefix in _homebrew_prefixes():
+        try:
+            if path.is_relative_to(prefix):
+                # Under a known prefix → accept whether it goes through
+                # Cellar/<formula>/<version> or is a linked keg in <prefix>/bin.
+                return True
+        except (OSError, ValueError):
+            continue
+    return False
 
 
 def _homebrew_info() -> InstallInfo:


### PR DESCRIPTION
## Background

Closes #200

`_is_homebrew_executable()` used a bare `"Cellar" in path.parts` check that **false-positived on any path containing a `Cellar`-named segment** — even project directories like `/Users/me/projects/Cellar/bin/topos`. This caused `topos update` / `uninstall` to suggest `brew …` commands for non-Homebrew installations.

## Solution

Replace the overly broad heuristic with a **prefix-aware** check:

1. Resolve known Homebrew root prefixes (env `HOMEBREW_PREFIX`, then standard defaults: `/opt/homebrew`, `/usr/local`, `/home/linuxbrew/.linuxbrew`)
2. Only return `True` when the executable path is **under one of those prefixes**
3. Both Cellar-layout paths (`<prefix>/Cellar/<formula>/<version>/bin/…`) and linked-keg paths (`<prefix>/bin/…`) continue to work

### Changed files
- `topos/cli/installation.py` — rewrote `_is_homebrew_executable()` + added `_homebrew_prefixes()` helper + `_HOMEBREW_DEFAULT_PREFIXES` constant
- `tests/cli/test_helpers.py` — added 3 regression tests

## Verification

```bash
# All existing tests pass + 3 new tests
pytest tests/cli/test_helpers.py -v   # 20 passed
```

**New test cases:**

| Input path | HOMEBREW_PREFIX | Expected |
|---|---|---|
| `/Users/me/projects/Cellar/bin/topos` | unset | ❌ NOT homebrew |
| `/opt/homebrew/Cellar/topos/0.3.12/bin/topos` | unset | ✅ homebrew |
| `<tmp>/linuxbrew/bin/topos` | `<tmp>/linuxbrew` | ✅ homebrew |

## Edge cases considered
- Paths under `/opt/homebrew` but without Cellar (linked kegs in `<prefix>/bin`) → still detected ✅
- Custom `HOMEBREW_PREFIX` on Linuxbrew → still works ✅
- No `HOMEBREW_PREFIX` set, path not under any default prefix → correctly rejected ✅
- Non-resolvable prefix (OSError) → gracefully skipped ✅