### PR TITLE
fix(cli): restore topos depgraph generate subcommand (#206)

### DIFF
--- a/topos/cli/src/commands/depgraph.rs
+++ b/topos/cli/src/commands/depgraph.rs
@@ -1,0 +1,38 @@
+//! `topos depgraph` — GitNexus dependency-graph generation for COMPOSABLE.
+//!
+//! Thin CLI wrapper over the same `generate_depgraph` / `depgraph_status`
+//! paths the MCP `topos_generate_depgraph` tool uses. Restores the
+//! `topos depgraph generate` entry point referenced by README, the VS Code
+//! extension, and agent docs (issue #206).
+
+mod generate;
+
+use clap::{Args, Subcommand};
+
+use generate::{run_generate, GenerateArgs};
+
+#[derive(Args)]
+pub struct DepgraphArgs {
+    #[command(subcommand)]
+    pub action: DepgraphAction,
+}
+
+#[derive(Subcommand)]
+pub enum DepgraphAction {
+    /// Build or refresh `.gitnexus/` via `gitnexus analyze --skip-agents-md`.
+    Generate(GenerateArgs),
+}
+
+pub fn run(args: DepgraphArgs) -> Result<(), String> {
+    match args.action {
+        DepgraphAction::Generate(args) => run_generate(args),
+    }
+}
+
+pub(super) fn print_json(value: &serde_json::Value) -> Result<(), String> {
+    println!(
+        "{}",
+        serde_json::to_string_pretty(value).map_err(|e| e.to_string())?
+    );
+    Ok(())
+}

--- a/topos/cli/src/commands/depgraph/generate.rs
+++ b/topos/cli/src/commands/depgraph/generate.rs
@@ -1,0 +1,83 @@
+//! `topos depgraph generate` — ensure `.gitnexus/` is present and fresh.
+
+use std::path::PathBuf;
+
+use clap::Args;
+use topos_engine::adapters::gitnexus::generate_depgraph;
+use topos_mcp::evaluation::depgraph_status;
+
+use super::print_json;
+
+#[derive(Args)]
+pub struct GenerateArgs {
+    /// Project directory to analyze (default: current directory).
+    pub path: Option<PathBuf>,
+    /// Regenerate even when the graph is already current.
+    #[arg(long)]
+    pub force: bool,
+    /// Output the result as a single JSON object.
+    #[arg(long)]
+    pub json: bool,
+}
+
+pub fn run_generate(args: GenerateArgs) -> Result<(), String> {
+    let target_dir = match args.path {
+        Some(path) => path,
+        None => std::env::current_dir().map_err(|e| format!("current directory: {e}"))?,
+    };
+    if !target_dir.is_dir() {
+        return Err(format!("Not a directory: {}", target_dir.display()));
+    }
+
+    let target_file = target_dir.to_string_lossy().to_string();
+
+    if !args.force {
+        let status = depgraph_status(None, &target_dir, &target_file);
+        if status.state == "present" {
+            let message = "Dependency graph already current.".to_string();
+            if args.json {
+                print_json(&serde_json::json!({
+                    "ok": true,
+                    "generated": false,
+                    "gitnexus_dir": status.gitnexus_dir,
+                    "message": message,
+                }))?;
+            } else {
+                println!("{message}");
+                if let Some(dir) = status.gitnexus_dir {
+                    println!("  .gitnexus: {dir}");
+                }
+            }
+            return Ok(());
+        }
+        if status.state == "schema_mismatch" {
+            let message = status
+                .detail
+                .unwrap_or_else(|| "GitNexus store schema mismatch.".to_string());
+            return Err(message);
+        }
+    }
+
+    let result = generate_depgraph(&target_dir, args.json, None);
+    if args.json {
+        print_json(&serde_json::json!({
+            "ok": result.ok,
+            "returncode": result.returncode,
+            "generated": result.ok,
+            "gitnexus_dir": result.gitnexus_path.as_ref().map(|p| p.display().to_string()),
+            "message": result.message,
+        }))?;
+    }
+
+    if result.ok {
+        if !args.json {
+            println!("{}", result.message);
+            if let Some(dir) = result.gitnexus_path {
+                println!("  .gitnexus: {}", dir.display());
+            }
+        }
+        Ok(())
+    } else {
+        Err(result.message)
+    }
+}

--- a/topos/cli/src/commands/mod.rs
+++ b/topos/cli/src/commands/mod.rs
@@ -4,6 +4,7 @@ mod classify;
 pub mod compare;
 mod composable;
 pub mod coverage;
+pub mod depgraph;
 pub mod evaluate;
 pub mod graphify;
 pub mod inspect;

--- a/topos/cli/src/main.rs
+++ b/topos/cli/src/main.rs
@@ -20,7 +20,7 @@ mod commands;
 
 use clap::{Parser, Subcommand};
 
-use commands::{compare, coverage, evaluate, graphify, inspect, mcp};
+use commands::{compare, coverage, depgraph, evaluate, graphify, inspect, mcp};
 
 #[derive(Parser)]
 #[command(
@@ -45,6 +45,8 @@ enum Command {
     Coverage(coverage::CoverageArgs),
     /// Graphify knowledge-graph generation and orphan detection (issue #150).
     Graphify(graphify::GraphifyArgs),
+    /// GitNexus dependency-graph generation for COMPOSABLE scoring.
+    Depgraph(depgraph::DepgraphArgs),
     /// Launch the Topos MCP server over stdio.
     Mcp(mcp::McpArgs),
 }
@@ -57,6 +59,7 @@ fn main() {
         Command::Compare(args) => compare::run(args),
         Command::Coverage(args) => coverage::run(args),
         Command::Graphify(args) => graphify::run(args),
+        Command::Depgraph(args) => depgraph::run(args),
         Command::Mcp(args) => mcp::run(args),
     };
     if let Err(message) = result {


### PR DESCRIPTION
## Summary

Restores the `topos depgraph generate` CLI subcommand removed during the v0.4.0 Rust migration. The command is a thin wrapper over the same `depgraph_status` / `generate_depgraph` paths the MCP `topos_generate_depgraph` tool uses.

Fixes #206 — unblocks the VS Code **Topos: Generate Dependency Graph** command (`cliArgs: ["depgraph", "generate"]`) and aligns the shipped binary with README, skill, and error-message references.

## Changes

- Add `topos depgraph generate [--force] [--json] [path]`
- No-op with message when `.gitnexus/` is already current
- Block on `schema_mismatch` (same policy as MCP)
- Stream GitNexus output to inherited stdio (human CLI path)

## Test plan

- [x] `cargo build -p topos --release`
- [ ] `topos depgraph generate` on a repo with GitNexus on PATH
- [ ] `topos depgraph generate` when graph already current → no-op message
- [ ] VS Code **Generate Dependency Graph** command succeeds
- [ ] `topos depgraph generate --json` emits structured result