### PR TITLE
fix(v0.4.0): review follow-ups — allow grade-cap, timeout panic, inspect parity

### DIFF
--- a/topos/cli/src/commands/inspect.rs
+++ b/topos/cli/src/commands/inspect.rs
@@ -47,8 +47,12 @@ pub fn run(args: InspectArgs) -> Result<(), String> {
     println!("Classification");
     println!("{}", "-".repeat(40));
     if !result.is_parseable {
+        // Match Python's `print(...)` + `sys.exit(1)`: emit the SLOP line to
+        // stdout, then exit non-zero — a parse failure is a CLI failure, so
+        // `topos inspect broken.py` must fail a shell gate. (JSON mode above
+        // returns 0 for an unparseable file, matching Python too.)
         println!("⊥ SLOP — parse failure");
-        return Ok(());
+        std::process::exit(1);
     }
     for dim in ["simple", "composable", "secure"] {
         if let Some(val) = result.dimensions.get(dim) {
@@ -99,12 +103,25 @@ fn print_json(
         .iter()
         .map(|(k, v)| (k.clone(), serde_json::Value::String(v.name().to_string())))
         .collect();
+    let scores: serde_json::Map<String, serde_json::Value> = result
+        .scores
+        .iter()
+        .map(|(k, s)| {
+            // Python emits `round(s * 100.0, 1)` (0–100, one decimal); the
+            // engine stores 0–1, so scale to match for parity/machine consumers.
+            let scaled = (*s * 1000.0).round() / 10.0;
+            let value = serde_json::Number::from_f64(scaled)
+                .map(serde_json::Value::Number)
+                .unwrap_or(serde_json::Value::Null);
+            (k.clone(), value)
+        })
+        .collect();
     let payload = serde_json::json!({
         "file": path.display().to_string(),
         "is_parseable": result.is_parseable,
         "lattice_element": result.lattice_element.name(),
         "dimensions": dimensions,
-        "scores": result.scores,
+        "scores": scores,
         "raw_metrics": result.raw_metrics,
     });
     println!(

--- a/topos/cli/src/commands/inspect.rs
+++ b/topos/cli/src/commands/inspect.rs
@@ -13,6 +13,7 @@ use topos_engine::evaluation::policies::simple::describe_entropy_ratio;
 use topos_engine::functors::probes::ast::entropy::calculate_kolmogorov_proxy;
 
 use super::classify::classify_with_representations;
+use super::composable::resolve_composable_mdg;
 use super::lang::detect_language;
 
 #[derive(Args)]
@@ -28,6 +29,12 @@ pub struct InspectArgs {
     /// parity tests), not primarily human reading.
     #[arg(long)]
     pub json: bool,
+    /// Skip GitNexus detection/generation; inspect SIMPLE/SECURE only.
+    #[arg(long)]
+    pub no_composable: bool,
+    /// Override the `.gitnexus` directory (default: `<cwd>/.gitnexus`).
+    #[arg(long)]
+    pub gitnexus_dir: Option<String>,
 }
 
 pub fn run(args: InspectArgs) -> Result<(), String> {
@@ -35,7 +42,27 @@ pub fn run(args: InspectArgs) -> Result<(), String> {
     let mut morphism = ProgramMorphism::from_file(&args.path, language)
         .map_err(|e| format!("reading {}: {e}", args.path.display()))?;
     let classifier = CharacteristicMorphism;
-    let result = classify_with_representations(&classifier, &mut morphism, None);
+    // Attach the COMPOSABLE MDG the same way `evaluate` does (auto-detect /
+    // generate `<cwd>/.gitnexus`, or `--gitnexus-dir`), so `inspect` reports
+    // COMPOSABLE too. Python's `inspect` fed `--gitnexus-dir` through the same
+    // `classify_file` pipeline as evaluate; `--no-composable` opts out.
+    let mut mdg = if args.no_composable {
+        None
+    } else {
+        match std::env::current_dir() {
+            Ok(project_root) => resolve_composable_mdg(&project_root, args.gitnexus_dir.as_deref()),
+            Err(e) => {
+                eprintln!(
+                    "gitnexus: could not resolve current directory ({e}); inspecting SIMPLE/SECURE only."
+                );
+                None
+            }
+        }
+    };
+    if let Some(g) = mdg.as_mut() {
+        g.target_file = args.path.to_string_lossy().into_owned();
+    }
+    let result = classify_with_representations(&classifier, &mut morphism, mdg.as_ref());
 
     if args.json {
         return print_json(&args.path, &result);

--- a/topos/engine/src/adapters/gitnexus.rs
+++ b/topos/engine/src/adapters/gitnexus.rs
@@ -36,7 +36,7 @@ use blake2::digest::{Update, VariableOutput};
 use blake2::Blake2bVar;
 
 use super::discovery::iter_source_files;
-use super::process::{command_on_path, run_with_timeout, RunError};
+use super::process::{command_on_path, run_with_timeout, timeout_duration, RunError};
 use crate::graphs::ast::languages::{language_file_suffixes, SUPPORTED_LANGUAGES};
 
 pub(crate) const GITNEXUS_CMD: &str = "gitnexus";
@@ -366,7 +366,7 @@ fn run_analyze(
     let start_time = SystemTime::now();
     let source_snapshot = source_fingerprint(target_dir);
     let effective_timeout = resolve_timeout(timeout);
-    let duration_timeout = effective_timeout.map(Duration::from_secs_f64);
+    let duration_timeout = effective_timeout.and_then(timeout_duration);
 
     let mut cmd = Command::new(cmd_name);
     cmd.args(args);

--- a/topos/engine/src/adapters/graphify.rs
+++ b/topos/engine/src/adapters/graphify.rs
@@ -28,9 +28,8 @@
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::time::Duration;
 
-use super::process::{command_on_path, run_with_timeout, RunError};
+use super::process::{command_on_path, run_with_timeout, timeout_duration, RunError};
 
 const GRAPHIFY_CMD: &str = "graphify";
 const INSTALL_HINT: &str = "Graphify not found. Install it with: pip install graphifyy";
@@ -178,7 +177,7 @@ fn run_graphify(
     timeout: Option<f64>,
 ) -> GraphifyGenerationResult {
     let effective_timeout = resolve_timeout(timeout);
-    let duration_timeout = effective_timeout.map(Duration::from_secs_f64);
+    let duration_timeout = effective_timeout.and_then(timeout_duration);
 
     let mut cmd = Command::new(cmd_name);
     cmd.args(args);

--- a/topos/engine/src/adapters/process.rs
+++ b/topos/engine/src/adapters/process.rs
@@ -112,6 +112,22 @@ pub fn run_with_timeout(
     }
 }
 
+/// Convert a timeout expressed in fractional seconds into a [`Duration`],
+/// returning `None` for any value that isn't a usable positive, finite
+/// deadline.
+///
+/// [`Duration::from_secs_f64`] *panics* on non-finite (`inf`, `NaN`) or
+/// out-of-range input, so a misconfigured `TOPOS_*_TIMEOUT` env var (e.g.
+/// `inf`, `1e400`, or an absurdly large finite value) would otherwise abort
+/// the whole run. Mirroring the Python original — where an unbounded or
+/// oversized timeout simply meant "no deadline" rather than a crash — such
+/// inputs disable the deadline (`None`) instead of panicking.
+pub(crate) fn timeout_duration(secs: f64) -> Option<Duration> {
+    Duration::try_from_secs_f64(secs)
+        .ok()
+        .filter(|d| !d.is_zero())
+}
+
 fn spawn_reader<R: Read + Send + 'static>(pipe: Option<R>) -> std::thread::JoinHandle<String> {
     std::thread::spawn(move || {
         let mut buf = String::new();
@@ -156,5 +172,17 @@ mod tests {
         let cmd = Command::new("topos-adapters-nonexistent-binary-xyz");
         let result = run_with_timeout(cmd, None, true, None);
         assert!(matches!(result, Err(RunError::Io(_))));
+    }
+
+    #[test]
+    fn timeout_duration_rejects_unusable_values() {
+        // Non-finite / non-positive / overflowing inputs disable the deadline
+        // instead of panicking inside `Duration::from_secs_f64`.
+        assert_eq!(timeout_duration(f64::INFINITY), None);
+        assert_eq!(timeout_duration(f64::NAN), None);
+        assert_eq!(timeout_duration(-1.0), None);
+        assert_eq!(timeout_duration(0.0), None);
+        assert_eq!(timeout_duration(1e300), None); // overflows Duration
+        assert_eq!(timeout_duration(2.5), Some(Duration::from_secs_f64(2.5)));
     }
 }

--- a/topos/engine/src/graphs/uast/mapper_python.rs
+++ b/topos/engine/src/graphs/uast/mapper_python.rs
@@ -76,8 +76,16 @@ fn is_guard(node: &Node, source: &[u8]) -> bool {
         return false;
     }
     match node.child_by_field_name("condition") {
-        Some(condition) => is_name_equals_main(condition, source),
-        None => false,
+        Some(condition) if is_name_equals_main(condition, source) => {
+            // Only a *bare* guard is pure entrypoint scaffolding. A guard
+            // carrying an `else`/`elif` holds real fallback logic; dropping the
+            // whole `if_statement` would silently discard that branch, so keep
+            // it (matches Python's `_is_guard`). A full fix — dropping only the
+            // `__main__` consequence while keeping the alternative — needs
+            // subtree rewriting the drop-by-id filter can't express.
+            node.child_by_field_name("alternative").is_none()
+        }
+        _ => false,
     }
 }
 
@@ -241,5 +249,22 @@ mod tests {
         let mut kinds = HashSet::new();
         collect_kinds(&uast, &mut kinds);
         assert!(!kinds.contains("if_statement"));
+    }
+
+    #[test]
+    fn keeps_main_guard_carrying_an_else_branch() {
+        // A `__main__` guard with an `else`/`elif` holds real fallback logic;
+        // dropping the whole `if_statement` would silently delete that branch.
+        // Python keeps it (mapper_python.py::_is_guard) — so must the Rust port.
+        let source =
+            "if __name__ == \"__main__\":\n    main()\nelse:\n    configure_as_library()\n";
+        let tree = parse(source);
+        let uast = map_python_tree_to_uast(tree.root_node(), source.as_bytes(), None);
+        let mut kinds = HashSet::new();
+        collect_kinds(&uast, &mut kinds);
+        assert!(
+            kinds.contains("if_statement"),
+            "a __main__ guard with an else branch must be kept, not dropped"
+        );
     }
 }

--- a/topos/mcp/src/diagnostics.rs
+++ b/topos/mcp/src/diagnostics.rs
@@ -1,6 +1,5 @@
 //! Security diagnostic overlay helpers for MCP tools.
 
-use std::collections::HashSet;
 use std::path::Path;
 
 use topos_engine::config::{load_topos_config, merge_cli_allows, ToposConfig};
@@ -77,13 +76,16 @@ fn overlay(
     }
 
     let cpg = morphism.build_cpg().cloned();
-    let allow_set: HashSet<String> = allows.iter().cloned().collect();
-    let findings = security_findings(
-        cpg.as_ref(),
-        20,
-        (!allow_set.is_empty()).then_some(&allow_set),
-        file_path,
-    );
+    // Pass the *raw* findings (full registry — `allow: None`) so that
+    // `apply_allowlist` performs the acknowledged/active partition itself
+    // against the merged config, which already folds in the one-off `allows`
+    // via `config_for`. Filtering the findings here would strip one-off
+    // `--allow` callees *before* the partition, leaving `acknowledged` empty:
+    // that silently drops the mandatory risk disclosure and lets an
+    // acknowledged risk buy an uncapped IDEAL grade (the grade cap in
+    // `apply_allowlist` only fires when `acknowledged` is non-empty). Matches
+    // the Python original's argument-less `security_findings(cpg)`.
+    let findings = security_findings(cpg.as_ref(), 20, None, file_path);
     let core_findings: Vec<_> = findings.iter().map(|f| f.to_core()).collect();
     let verdict = apply_allowlist(result, &core_findings, &config, file_path, cpg.as_ref());
     let active_findings = verdict
@@ -120,4 +122,55 @@ pub fn overlay_for_source(
 ) -> Option<SecurityOverlay> {
     let mut morphism = ProgramMorphism::new(source, language);
     overlay(&mut morphism, result, file_path, allows)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::evaluation::classify_code_string;
+    use topos_engine::evaluation::policies::base::Priority;
+
+    // `eval(...)` is a dangerous call, so SECURE fails and the overlay engages.
+    const EVAL_SRC: &str = "def f(expr):\n    return eval(expr)\n";
+
+    #[test]
+    fn one_off_allow_acknowledges_risk_rather_than_stripping_it() {
+        let result = classify_code_string(EVAL_SRC, "python", Priority::Simple)
+            .expect("classification runs");
+
+        // No allow: the eval finding is active and nothing is acknowledged.
+        let bare = overlay_for_source(EVAL_SRC, "python", &result, None, &[])
+            .expect("a secure-failing file produces an overlay");
+        assert!(
+            bare.acknowledged_risks.is_empty(),
+            "nothing is acknowledged without an allow"
+        );
+        assert!(
+            !bare.active_findings.is_empty(),
+            "the eval finding is active"
+        );
+
+        // Regression guard: a one-off `--allow eval` must move the finding into
+        // `acknowledged` (so the disclosure is emitted and the grade cap can
+        // fire), not silently strip it before the partition.
+        let allow = vec!["eval".to_string()];
+        let allowed = overlay_for_source(EVAL_SRC, "python", &result, None, &allow)
+            .expect("a secure-failing file produces an overlay");
+        assert_eq!(
+            allowed.acknowledged_risks.len(),
+            1,
+            "one-off --allow must acknowledge the eval risk, not strip it"
+        );
+        assert_eq!(
+            allowed.acknowledged_risks[0].callee.as_deref(),
+            Some("eval")
+        );
+        assert!(
+            allowed
+                .active_findings
+                .iter()
+                .all(|f| f.callee.as_deref() != Some("eval")),
+            "the acknowledged eval finding is no longer active"
+        );
+    }
 }


### PR DESCRIPTION
Follow-up fixes for **#159** (Rust v0.4.0 migration), from a review of that PR. Stacks on top of `worktree-rust-migration-v0.4.0` (base) so it can merge into the migration branch before #159 lands. Each fix is a Python-parity regression the migration introduced (or a panic-safety gap), verified against the built binary and unit tests.

## Fixes

### 🔴 `topos_evaluate` one-off `--allow` defeated the anti-gaming grade cap — `topos-mcp`
`overlay()` passed the ephemeral `allow` set **into** `security_findings()`, which strips allowlisted callees **before** `apply_allowlist()` partitions findings into acknowledged vs. active. So `acknowledged` was always empty for one-off `--allow`, which:
- **dropped the mandatory acknowledged-risk disclosure** (regresses Python `test_evaluate_file_supports_one_off_allow`), and
- **defeated the grade cap** — on a file that's independently SIMPLE+COMPOSABLE, an agent could use `--allow eval` to buy an **uncapped IDEAL** medal (the cap only fires when `acknowledged` is non-empty).

Fix: pass the raw findings (`allow: None`) and let `apply_allowlist` partition against the merged config (which already folds in the one-off allows via `config_for`) — matching the Python original. Adds a regression test.

### 🔴 `__main__` guard carrying an `else`/`elif` was silently deleted — `topos-core`
`is_guard` (Python UAST mapper) dropped any `if __name__ == "__main__":` block whose condition matched, ignoring an `alternative`. A guard with an `else`/`elif` holds real fallback logic, so dropping the whole `if_statement` silently deleted that branch from the UAST and skewed SIMPLE node-kind counts. Python's `_is_guard` returns `child_by_field_name("alternative") is None` precisely to keep such guards. Fix adds the same check + a regression test.

### 🟡 Timeout env var could panic the whole run — `topos-core` adapters
`resolve_timeout` accepted any value `> 0.0`, so `TOPOS_DEPGRAPH_TIMEOUT` / `TOPOS_GRAPHIFY_TIMEOUT` set to `inf`, `1e400` (→ f64 infinity), or an oversized finite value (`1e20`) reached `Duration::from_secs_f64`, which **panics** on non-finite/out-of-range input — aborting `topos depgraph generate` / `topos graphify generate` / the MCP tools. Python treated the same input as effectively unbounded.

Fix: a shared `adapters::process::timeout_duration()` converts seconds → `Option<Duration>` via the non-panicking `Duration::try_from_secs_f64`, disabling the deadline (`None`) for any unusable value; both adapter conversion sites route through it. Adds a unit test.

### 🟡 `topos inspect` parity — exit code & JSON score scale — `topos-cli`
- Text mode printed `⊥ SLOP — parse failure` then returned `Ok(())` (exit **0**), so `topos inspect broken.py || fail` never tripped. Python prints the line then `sys.exit(1)`. Now prints to stdout and `process::exit(1)`; `--json` still exits 0 for an unparseable file, matching Python.
- `--json` emitted scores on the engine **0-1** scale while Python emits `round(s*100.0, 1)` (**0-100**). The module doc bills this JSON as being for Python/Rust parity comparison, so every score was off by 100x. Now scaled/rounded to match.

### 🟡 `topos inspect` never scored COMPOSABLE — `topos-cli` (closes #216)
`inspect` hard-coded `mdg=None`, so COMPOSABLE was never attached or shown in text/`--json` — unlike Python `inspect`, which fed `--gitnexus-dir` through the same `classify_file` pipeline as `evaluate`. Now mirrors `evaluate`: resolves the MDG via `resolve_composable_mdg` (auto-detect/generate `<cwd>/.gitnexus`, or `--gitnexus-dir`), sets `target_file`, passes it to `classify_with_representations`; adds `--no-composable` to opt out. Verified against the built binary — `composable:` now appears in both text and `--json`.

## Verification
- `cargo test -p topos-engine timeout` → 6/6 (incl. new `timeout_duration_rejects_unusable_values`)
- `cargo test -p topos-engine mapper_python` → 4/4 (incl. new `keeps_main_guard_carrying_an_else_branch`)
- `cargo test -p topos-mcp one_off_allow` → 1/1 (new regression test)
- `cargo test -p topos` → 6/6
- `topos inspect` checked end-to-end against the built binary: broken→exit 1 + SLOP; broken `--json`→exit 0; good `--json`→`secure: 100.0, simple: 95.0`; with a `.gitnexus` store, `composable:` now shows in text and `--json`.
- `cargo fmt --all --check` clean; `cargo clippy -p topos-engine -p topos-mcp -p topos --all-targets -- -D warnings` clean.

## Deliberately NOT in this PR — needs a maintainer decision, not a patch
- **Python `max_function_complexity` loosening** (`functors/probes/ast/complexity.rs`). The Python original ran a **dual path** — a Python-native counter for `with`/`assert`/ternary/comprehensions/`boolean_operator` plus a UAST path for other languages. This branch **intentionally** collapsed to UAST-only (documented, fixes #153, tests named `works_across_languages_unlike_the_python_original`). Side effect: Python functions whose complexity comes from booleans/ternaries/comprehensions/`assert`/`with` now score far lower and can flip a failing SIMPLE gate to passing — undocumented. Restoring parity means either reverting the multi-language redesign or extending the UAST mappers (boolean-operator counting is blocked on #142). Needs a call: accept + document + re-baseline the gate, or restore.
- **Entropy entrypoint exemption broadened to both sides** (`evaluation/policies/gates.rs`) and **`cfg.cyclomatic` demoted to advisory** (tracked in #193) — both intentional, tested, but silently move SIMPLE verdicts vs Python; need ratification for the "behavior-preserving" claim.

## Other review findings — filed as issues (not in this PR)
#209 (combine_dimensions rollup), #210 (C++ prototype→VarDecl), #211 (branch-scoped fingerprint dir), #212 (LadybugDB File-only loader), #213 (JS `switch`→MatchStmt), #214 (graphify parser edge cases), #215 (symlink containment), #217 (release tag↔Cargo version). #216 (inspect COMPOSABLE) is fixed here.
