### PR TITLE
chore(release): prep crates.io publish manifests (#149)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Tests
         run: cargo test --workspace
 
+      - name: Crates.io publish dry-run (dependency order)
+        run: bash scripts/cargo_publish_dry_run.sh
+
       - name: Smoke-test the MCP server over stdio
         run: |
           cargo build -p topos-mcp --bin topos-mcp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,10 @@ version = "0.4.0"
 edition = "2021"
 license = "BSD-3-Clause"
 repository = "https://github.com/Krv-Labs/topos"
+authors = ["Krv Labs <team@krv.ai>"]
+
+# Internal path deps with crates.io version pins (keep version in sync with
+# [workspace.package].version — required for `cargo publish`).
+[workspace.dependencies]
+topos-engine = { path = "topos/engine", version = "0.4.0" }
+topos-mcp = { path = "topos/mcp", version = "0.4.0" }

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 <p align="center">
   <a href="https://github.com/mcp/Krv-Labs/topos"><img src="https://img.shields.io/badge/VS_Code-Install_MCP-007ACC?logo=visualstudiocode&logoColor=white" alt="Install Topos MCP in VS Code"></a>
-  <a href="https://pypi.org/project/topos-mcp/"><img src="https://img.shields.io/pypi/v/topos-mcp.svg" alt="PyPI"></a>
+  <a href="https://pypi.org/project/topos-mcp/"><img src="https://img.shields.io/pypi/v/topos-mcp?color=3776AB&logo=python&logoColor=ffd43b" alt="PyPI"></a>
   <a href="https://crates.io/crates/topos"><img src="https://img.shields.io/crates/v/topos?color=dea584&logo=rust&logoColor=000000" alt="crates.io"></a>
   <a href="https://github.com/Krv-Labs/topos/blob/main/LICENSE"><img src="https://img.shields.io/github/license/Krv-Labs/topos" alt="License"></a>
   <a href="https://glama.ai/mcp/servers/Krv-Labs/topos"><img src="https://glama.ai/mcp/servers/Krv-Labs/topos/badges/score.svg" alt="Topos MCP server"></a>

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 <p align="center">
   <a href="https://github.com/mcp/Krv-Labs/topos"><img src="https://img.shields.io/badge/VS_Code-Install_MCP-007ACC?logo=visualstudiocode&logoColor=white" alt="Install Topos MCP in VS Code"></a>
   <a href="https://pypi.org/project/topos-mcp/"><img src="https://img.shields.io/pypi/v/topos-mcp.svg" alt="PyPI"></a>
-  <a href="https://crates.io/crates/topos"><img src="https://img.shields.io/crates/v/topos.svg" alt="crates.io"></a>
+  <a href="https://crates.io/crates/topos"><img src="https://img.shields.io/crates/v/topos?color=dea584&logo=rust&logoColor=000000" alt="crates.io"></a>
   <a href="https://github.com/Krv-Labs/topos/blob/main/LICENSE"><img src="https://img.shields.io/github/license/Krv-Labs/topos" alt="License"></a>
   <a href="https://glama.ai/mcp/servers/Krv-Labs/topos"><img src="https://glama.ai/mcp/servers/Krv-Labs/topos/badges/score.svg" alt="Topos MCP server"></a>
   <a href="https://clawhub.ai/krv-labs/skills/topos"><img src="https://img.shields.io/badge/%F0%9F%A6%9E_ClawHub-topos-F97316" alt="ClawHub"></a>

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 <p align="center">
   <a href="https://github.com/mcp/Krv-Labs/topos"><img src="https://img.shields.io/badge/VS_Code-Install_MCP-007ACC?logo=visualstudiocode&logoColor=white" alt="Install Topos MCP in VS Code"></a>
   <a href="https://pypi.org/project/topos-mcp/"><img src="https://img.shields.io/pypi/v/topos-mcp.svg" alt="PyPI"></a>
+  <a href="https://crates.io/crates/topos"><img src="https://img.shields.io/crates/v/topos.svg" alt="crates.io"></a>
   <a href="https://github.com/Krv-Labs/topos/blob/main/LICENSE"><img src="https://img.shields.io/github/license/Krv-Labs/topos" alt="License"></a>
   <a href="https://glama.ai/mcp/servers/Krv-Labs/topos"><img src="https://glama.ai/mcp/servers/Krv-Labs/topos/badges/score.svg" alt="Topos MCP server"></a>
   <a href="https://clawhub.ai/krv-labs/skills/topos"><img src="https://img.shields.io/badge/%F0%9F%A6%9E_ClawHub-topos-F97316" alt="ClawHub"></a>

--- a/scripts/cargo_publish_dry_run.sh
+++ b/scripts/cargo_publish_dry_run.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Verify workspace crates are ready for `cargo publish` (dependency order).
+# topos-mcp and topos stay skipped until sighthound is on crates.io — git-only
+# deps cannot ship on crates.io (#149).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+echo "==> topos-engine"
+cargo publish -p topos-engine --dry-run "$@"
+
+if cargo search sighthound --limit 1 2>/dev/null | grep -q '^sighthound = '; then
+  echo "==> topos-mcp"
+  cargo publish -p topos-mcp --dry-run "$@"
+  echo "==> topos"
+  cargo publish -p topos --dry-run "$@"
+else
+  echo "SKIP: topos-mcp and topos dry-run until sighthound is published to crates.io" >&2
+fi

--- a/topos/cli/Cargo.toml
+++ b/topos/cli/Cargo.toml
@@ -4,18 +4,22 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+authors.workspace = true
+readme = "../../README.md"
 description = "Rust CLI for Topos structural code quality evaluation (binary name: topos)."
+keywords = ["code-quality", "static-analysis", "topos", "cli"]
+categories = ["command-line-utilities", "development-tools"]
 
 [[bin]]
 name = "topos"
 path = "src/main.rs"
 
 [dependencies]
-topos-engine = { path = "../engine" }
+topos-engine = { workspace = true }
 # The `topos mcp` subcommand launches the in-process Rust MCP server, so the
 # `topos` binary bundles the same server the standalone `topos-mcp` binary
 # exposes (the VS Code extension invokes `topos mcp`).
-topos-mcp = { path = "../mcp" }
+topos-mcp = { workspace = true }
 tokio = { version = "1", features = ["rt-multi-thread"] }
 clap = { version = "4", features = ["derive"] }
 # Already a topos-engine dependency; used here for --json output.

--- a/topos/engine/Cargo.toml
+++ b/topos/engine/Cargo.toml
@@ -4,7 +4,11 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+authors.workspace = true
+readme = "../../README.md"
 description = "Structural code quality engine for Topos: category-theoretic evaluation (SIMPLE/COMPOSABLE/SECURE), tree-sitter-driven graph representations, and refactoring probes. Pure Rust, no Python bindings — see topos-mcp and topos."
+keywords = ["code-quality", "static-analysis", "topos"]
+categories = ["algorithms", "development-tools"]
 
 [dependencies]
 tree-sitter = "0.26"

--- a/topos/mcp/Cargo.toml
+++ b/topos/mcp/Cargo.toml
@@ -4,10 +4,14 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+authors.workspace = true
+readme = "../../README.md"
 description = "Topos MCP server: SIMPLE/COMPOSABLE/SECURE structural code-quality tools over the Model Context Protocol (stdio)."
+keywords = ["code-quality", "static-analysis", "topos", "mcp"]
+categories = ["development-tools"]
 
 [dependencies]
-topos-engine = { path = "../engine" }
+topos-engine = { workspace = true }
 rmcp = { version = "2.2", features = ["server", "transport-io", "macros"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-std"] }
 serde = { version = "1.0", features = ["derive"] }
@@ -22,4 +26,4 @@ tempfile = "3"
 similar = "2"
 # Embedded SAST engine (MIT) — replaces the former external `sighthound`
 # CLI dependency; pinned for reproducible builds.
-sighthound = { git = "https://github.com/Corgea/Sighthound", rev = "36dd5da663f826d81f1a444c474935b6acbf285c" }
+sighthound = { git = "https://github.com/Corgea/Sighthound", rev = "36dd5da663f826d81f1a444c474935b6acbf285c", version = "0.1.1" }


### PR DESCRIPTION
## Summary

Prepares the v0.4.0 Rust workspace for crates.io publish ([#149](https://github.com/Krv-Labs/topos/issues/149)) on top of [#159](https://github.com/Krv-Labs/topos/pull/159):

- **`[workspace.dependencies]`** — dual `path` + `version` pins for `topos-engine` and `topos-mcp` (keep in sync with `[workspace.package].version`).
- **Publish metadata** on all three crates (`readme`, `authors`, `keywords`, `categories`).
- **`scripts/cargo_publish_dry_run.sh`** — runs `cargo publish --dry-run` in dependency order; wired into CI `rust` job.
- **`sighthound` git dep** — adds required `version = "0.1.1"` field for manifest validation.

## Blocker discovered

`topos-mcp` (and therefore `topos` CLI) **cannot publish to crates.io yet** because `sighthound` is a git-only dependency and is not on crates.io. The dry-run script publishes `topos-engine` today and automatically includes `topos-mcp` + `topos` once `cargo search sighthound` finds a crates.io release.

Follow-up options for #149 phase 2:
1. Coordinate publishing [Sighthound](https://github.com/Corgea/Sighthound) to crates.io, or
2. Vendor/publish a fork under a crates.io name.

## Test plan

- [x] `bash scripts/cargo_publish_dry_run.sh --allow-dirty` — `topos-engine` packages and verifies; mcp/cli skipped with message
- [ ] CI `rust` job green on this PR (dry-run step)

Made with [Cursor](https://cursor.com)