### PR TITLE
fix: address #159 review findings (lattice meet, recursion bound, anon-key, git-injection, tool-count docs)

### DIFF
--- a/topos/engine/src/core/characteristic_morphism.rs
+++ b/topos/engine/src/core/characteristic_morphism.rs
@@ -276,9 +276,17 @@ impl CharacteristicMorphism {
             .filter(|dim| results.iter().any(|r| r.dimensions.contains_key(*dim)))
             .map(|dim| {
                 let generator = dimension_generator(dim);
-                let satisfied = results
-                    .iter()
-                    .all(|r| r.is_parseable && r.dimensions.get(dim) == Some(&generator));
+                // A file that never evaluated this dimension at all (key
+                // absent, e.g. no MDG representation for that file) must not
+                // drag the rollup down — only a file that evaluated the
+                // dimension and got the SLOP value counts as a failure.
+                let satisfied = results.iter().all(|r| {
+                    r.is_parseable
+                        && match r.dimensions.get(dim) {
+                            Some(v) => *v == generator,
+                            None => true,
+                        }
+                });
                 let value = if satisfied {
                     generator
                 } else {
@@ -437,6 +445,29 @@ mod tests {
         };
         let combined = classifier.combine_dimensions(&[good, parse_failure]);
         assert_eq!(combined["simple"], EvaluationValue::Slop);
+    }
+
+    #[test]
+    fn combine_dimensions_ignores_files_missing_the_representation() {
+        let classifier = CharacteristicMorphism;
+        let has_repr = ClassificationResult {
+            is_parseable: true,
+            dimensions: HashMap::from([("composable".to_string(), EvaluationValue::Composable)]),
+            scores: HashMap::from([("composable".to_string(), 0.9)]),
+            lattice_element: EvaluationValue::Composable,
+            ..Default::default()
+        };
+        // No MDG representation at all for this file: "composable" key is
+        // absent, not present-and-failing.
+        let missing_repr = ClassificationResult {
+            is_parseable: true,
+            dimensions: HashMap::new(),
+            scores: HashMap::new(),
+            lattice_element: EvaluationValue::Slop,
+            ..Default::default()
+        };
+        let combined = classifier.combine_dimensions(&[has_repr, missing_repr]);
+        assert_eq!(combined["composable"], EvaluationValue::Composable);
     }
 
     #[test]

--- a/topos/engine/src/core/object.rs
+++ b/topos/engine/src/core/object.rs
@@ -135,29 +135,48 @@ impl ProgramObject {
     // (21, exceeding the SIMPLE threshold of 15); the cursor iterator
     // yields nodes directly (no `Option` to unwrap), which removes a
     // branch per recursive call on top of being the idiomatic API.
+    //
+    // All three use an explicit `Vec`-based stack instead of function-call
+    // recursion, matching `graphs::cpg::builder`'s `collect_nodes`/
+    // `ast_edges` and `graphs::uast::mapper_common::map_tree_sitter_to_uast`.
+    // A recursive walk burns one Rust stack frame per AST nesting level;
+    // this file parses untrusted source, and a few thousand nested
+    // parens/brackets is enough to overflow the process stack.
 
-    fn traverse_node<'a>(node: Node<'a>, out: &mut Vec<Node<'a>>) {
-        out.push(node);
-        let mut cursor = node.walk();
-        for child in node.children(&mut cursor) {
-            Self::traverse_node(child, out);
+    fn traverse_node<'a>(root: Node<'a>, out: &mut Vec<Node<'a>>) {
+        let mut stack = vec![root];
+        while let Some(node) = stack.pop() {
+            out.push(node);
+            let mut cursor = node.walk();
+            // Collect then push in reverse so children pop in the same
+            // left-to-right order the recursive version visited them.
+            let children: Vec<Node<'a>> = node.children(&mut cursor).collect();
+            stack.extend(children.into_iter().rev());
         }
     }
 
-    fn count_nodes(node: Node<'_>) -> usize {
-        let mut cursor = node.walk();
-        1 + node
-            .children(&mut cursor)
-            .map(Self::count_nodes)
-            .sum::<usize>()
+    fn count_nodes(root: Node<'_>) -> usize {
+        let mut stack = vec![root];
+        let mut count = 0;
+        while let Some(node) = stack.pop() {
+            count += 1;
+            let mut cursor = node.walk();
+            stack.extend(node.children(&mut cursor));
+        }
+        count
     }
 
-    fn calculate_depth(node: Node<'_>, current: usize) -> usize {
-        let mut cursor = node.walk();
-        node.children(&mut cursor)
-            .map(|child| Self::calculate_depth(child, current + 1))
-            .max()
-            .unwrap_or(current)
+    fn calculate_depth(root: Node<'_>, start: usize) -> usize {
+        let mut stack = vec![(root, start)];
+        let mut max_depth = start;
+        while let Some((node, depth)) = stack.pop() {
+            max_depth = max_depth.max(depth);
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                stack.push((child, depth + 1));
+            }
+        }
+        max_depth
     }
 }
 
@@ -234,5 +253,39 @@ mod tests {
         let c = build("y = 2");
         assert!(a == b);
         assert!(a != c);
+    }
+
+    #[test]
+    fn program_object_survives_deeply_nested_input() {
+        // ponytail: regression test for the stack-overflow-via-untrusted-
+        // input risk in traverse_node/count_nodes/calculate_depth — these
+        // used to recurse one Rust stack frame per AST nesting level, so
+        // a source file with thousands of nested parens/brackets could
+        // blow the process stack. Parses directly via tree-sitter
+        // (bypassing UAST mapping, which owns its own recursively-typed
+        // tree and is out of scope for this fix) so this isolates
+        // exactly the traversal helpers being fixed. O(n) deep nesting,
+        // not the O(2^k) shape used by issue #113's hang regressions
+        // elsewhere in this crate.
+        const DEPTH: usize = 20_000;
+        let source = format!("x = {}1{}", "(".repeat(DEPTH), ")".repeat(DEPTH));
+
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_python::LANGUAGE.into())
+            .expect("python grammar should load");
+        let tree = parser
+            .parse(&source, None)
+            .expect("parse should not be cancelled");
+        let root = tree.root_node();
+        assert!(!root.has_error());
+
+        let mut nodes = Vec::new();
+        ProgramObject::traverse_node(root, &mut nodes);
+        let count = ProgramObject::count_nodes(root);
+        let depth = ProgramObject::calculate_depth(root, 0);
+
+        assert_eq!(nodes.len(), count);
+        assert!(depth >= DEPTH);
     }
 }

--- a/topos/engine/src/graphs/cpg/builder.rs
+++ b/topos/engine/src/graphs/cpg/builder.rs
@@ -27,6 +27,12 @@ use crate::graphs::uast::models::UASTNode;
 /// `graphs::cfg::builder`'s synthetic module-callable wrapper) that
 /// never appear as CFG/PDG statements themselves, so it's effectively
 /// unreachable in real data, same as in Python.
+///
+/// Kept in sync with an identical private helper in
+/// `graphs::pdg::object` (issue #159): DDG/CDG edges built there use
+/// this same `anon::{ptr:x}` format for empty-id statements, so a
+/// dependence edge's endpoint always resolves to the matching key in
+/// this module's node map.
 fn node_key(node: &UASTNode) -> String {
     if node.id.is_empty() {
         format!("anon::{:x}", std::ptr::from_ref(node) as usize)
@@ -98,16 +104,8 @@ fn cfg_edges(cfg: &ControlFlowGraph) -> Vec<CPGEdge> {
         let Some(dst_stmt) = dst_block.statements.first() else {
             continue;
         };
-        let source = if src_stmt.id.is_empty() {
-            "<anon>".to_string()
-        } else {
-            src_stmt.id.clone()
-        };
-        let target = if dst_stmt.id.is_empty() {
-            "<anon>".to_string()
-        } else {
-            dst_stmt.id.clone()
-        };
+        let source = node_key(src_stmt);
+        let target = node_key(dst_stmt);
         edges.push(CPGEdge::new(
             source,
             target,
@@ -141,6 +139,46 @@ fn dependence_edges(pdg: &ProgramDependenceGraph) -> Vec<CPGEdge> {
 mod tests {
     use super::*;
     use crate::graphs::ast::dispatch::parse_source;
+    use crate::graphs::uast::models::{NativeRef, SourceSpan};
+
+    #[test]
+    fn node_key_uses_anon_ptr_convention_for_empty_id_nodes() {
+        // Issue #159: `graphs::pdg::object` builds DDG/CDG edges with an
+        // identical private helper; both must produce the same
+        // `anon::{ptr}` format for an anonymous (empty-id) statement, or
+        // an edge referencing that statement silently fails to resolve
+        // against this module's node map.
+        let anon = UASTNode {
+            kind: "Anonymous".to_string(),
+            lang: "python".to_string(),
+            span: SourceSpan {
+                file: None,
+                start_byte: 0,
+                end_byte: 0,
+                start_line: 0,
+                start_column: 0,
+                end_line: 0,
+                end_column: 0,
+            },
+            native: NativeRef {
+                parser: "test".to_string(),
+                parser_version: "0".to_string(),
+                node_kind: "anon".to_string(),
+            },
+            attributes: HashMap::new(),
+            children: Vec::new(),
+            id: String::new(),
+        };
+        let key = node_key(&anon);
+        assert!(
+            key.starts_with("anon::"),
+            "expected `anon::<ptr>` key for empty-id node, got {key:?}"
+        );
+        assert_ne!(
+            key, "<anon>",
+            "must not use the old literal-string convention"
+        );
+    }
 
     #[test]
     fn build_cpg_includes_all_four_edge_families_when_present() {

--- a/topos/engine/src/graphs/pdg/object.rs
+++ b/topos/engine/src/graphs/pdg/object.rs
@@ -132,6 +132,21 @@ impl Representation for ProgramDependenceGraph {
 
 // --- Internals -----------------------------------------------------------
 
+/// Fallback key for a UAST node with no natural `id` (e.g. hand-built
+/// synthetic nodes) -- matches `graphs::cpg::builder::node_key`'s
+/// `anon::{ptr:x}` convention exactly (issue #159) so a DDG/CDG edge
+/// referencing an anonymous statement resolves to the same key the
+/// CPG's node map inserted it under. Kept as a private duplicate rather
+/// than a cross-module import to avoid a `pdg -> cpg` dependency (the
+/// CPG already depends on this module, not the reverse).
+fn node_key(node: &UASTNode) -> String {
+    if node.id.is_empty() {
+        format!("anon::{:x}", std::ptr::from_ref(node) as usize)
+    } else {
+        node.id.clone()
+    }
+}
+
 /// Approximate reaching-definitions data dependence.
 ///
 /// Walks the statement list in textual order; for each statement records
@@ -148,11 +163,7 @@ fn compute_data_dependence(statements: &[UASTNode], source: &str) -> Vec<Depende
 
     for stmt in statements {
         let (defs, uses) = defs_and_uses(stmt, source);
-        let stmt_id = if stmt.id.is_empty() {
-            "<anon>".to_string()
-        } else {
-            stmt.id.clone()
-        };
+        let stmt_id = node_key(stmt);
         for var in &uses {
             if let Some(definer) = last_def.get(var) {
                 if definer != &stmt_id {
@@ -263,17 +274,9 @@ fn compute_control_dependence(cfg: &ControlFlowGraph) -> Vec<DependenceEdge> {
         let Some(predicate_stmt) = predicate_block.statements.last() else {
             continue;
         };
-        let predicate_id = if predicate_stmt.id.is_empty() {
-            "<anon>".to_string()
-        } else {
-            predicate_stmt.id.clone()
-        };
+        let predicate_id = node_key(predicate_stmt);
         for dep_stmt in &successor_block.statements {
-            let target = if dep_stmt.id.is_empty() {
-                "<anon>".to_string()
-            } else {
-                dep_stmt.id.clone()
-            };
+            let target = node_key(dep_stmt);
             if target == predicate_id {
                 continue;
             }
@@ -372,6 +375,46 @@ fn node_text(node: &UASTNode, source: &str) -> String {
 mod tests {
     use super::*;
     use crate::graphs::ast::dispatch::parse_source;
+    use crate::graphs::uast::models::{NativeRef, SourceSpan};
+
+    #[test]
+    fn node_key_uses_anon_ptr_convention_for_empty_id_nodes() {
+        // Issue #159: `graphs::cpg::builder` builds its node map with an
+        // identical private helper; both must produce the same
+        // `anon::{ptr}` format for an anonymous (empty-id) statement, or
+        // a DDG/CDG edge built here silently fails to resolve against
+        // that node map.
+        let anon = UASTNode {
+            kind: "Anonymous".to_string(),
+            lang: "python".to_string(),
+            span: SourceSpan {
+                file: None,
+                start_byte: 0,
+                end_byte: 0,
+                start_line: 0,
+                start_column: 0,
+                end_line: 0,
+                end_column: 0,
+            },
+            native: NativeRef {
+                parser: "test".to_string(),
+                parser_version: "0".to_string(),
+                node_kind: "anon".to_string(),
+            },
+            attributes: HashMap::new(),
+            children: Vec::new(),
+            id: String::new(),
+        };
+        let key = node_key(&anon);
+        assert!(
+            key.starts_with("anon::"),
+            "expected `anon::<ptr>` key for empty-id node, got {key:?}"
+        );
+        assert_ne!(
+            key, "<anon>",
+            "must not use the old literal-string convention"
+        );
+    }
 
     #[test]
     fn from_uast_computes_control_dependence_for_if() {

--- a/topos/mcp/src/server.rs
+++ b/topos/mcp/src/server.rs
@@ -3,7 +3,7 @@
 //! Server name follows the `{service}_mcp` convention. Transport is stdio
 //! by default; the `topos-mcp` binary (see `main.rs`) launches [`serve`].
 //!
-//! The nine tool modules under [`crate::tools`] each contribute a named
+//! The ten tool modules under [`crate::tools`] each contribute a named
 //! `#[tool_router]` (e.g. `evaluate_router`, `assess_router`); they are
 //! summed here into one [`ToolRouter`]. Resources (`topos://docs/*`) and
 //! the `topos_refactor_until_ideal` prompt are implemented directly in the

--- a/topos/mcp/src/tools/assess.rs
+++ b/topos/mcp/src/tools/assess.rs
@@ -674,13 +674,30 @@ fn assess_edit_in_place(
 // Git helpers
 // ---------------------------------------------------------------------------
 
+/// Whether `git_ref` is safe to interpolate into a `git` argv element.
+///
+/// A ref starting with `-` would otherwise be parsed by git as a CLI option
+/// (e.g. `--output=/some/path`) rather than a revision, since git argv
+/// arguments are never shell-interpreted but are still option-parsed. No
+/// legitimate branch, tag, or commit ref starts with `-`.
+fn is_safe_git_ref(git_ref: &str) -> bool {
+    !git_ref.starts_with('-')
+}
+
 /// Read `<ref>:<rel_path>` from git. Returns `Ok(source)` or
 /// `Err(blocked_by_code)`.
 fn git_show(repo_root: &Path, git_ref: &str, rel_path: &str) -> Result<String, &'static str> {
+    if !is_safe_git_ref(git_ref) {
+        return Err("invalid_baseline_ref");
+    }
     let output = Command::new("git")
         .arg("-C")
         .arg(repo_root)
-        .args(["show", &format!("{git_ref}:{rel_path}")])
+        // `--end-of-options` stops option parsing without git's plain `--`
+        // side effect of reinterpreting the following `ref:path` object as a
+        // bare pathspec (which silently matches nothing instead of showing
+        // the blob). Defense in depth on top of the `-` rejection above.
+        .args(["show", "--end-of-options", &format!("{git_ref}:{rel_path}")])
         .output();
     match output {
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Err("git_unavailable"),
@@ -693,6 +710,9 @@ fn git_show(repo_root: &Path, git_ref: &str, rel_path: &str) -> Result<String, &
 /// Whether `git_ref` resolves to a commit in `repo_root`. Returns `true`
 /// when git cannot run so the caller falls through to per-file handling.
 fn ref_exists(repo_root: &Path, git_ref: &str) -> bool {
+    if !is_safe_git_ref(git_ref) {
+        return false;
+    }
     let output = Command::new("git")
         .arg("-C")
         .arg(repo_root)
@@ -700,6 +720,7 @@ fn ref_exists(repo_root: &Path, git_ref: &str) -> bool {
             "rev-parse",
             "--verify",
             "--quiet",
+            "--end-of-options",
             &format!("{git_ref}^{{commit}}"),
         ])
         .output();
@@ -1635,5 +1656,105 @@ fn changeset_error(
             risk_flags: vec!["changeset_error".to_string()],
         }),
         error: Some(message),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_tmp_dir(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "topos_assess_gitref_test_{label}_{}_{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// Real git repo fixture: one commit on `main`/`master` touching
+    /// `f.txt`, plus a second branch `feature` with its own commit. Returns
+    /// `(repo_root, first_commit_sha)`.
+    fn init_repo(root: &Path) -> String {
+        let run = |args: &[&str]| {
+            let out = Command::new("git")
+                .arg("-C")
+                .arg(root)
+                .args(args)
+                .output()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&out.stderr)
+            );
+        };
+        run(&["init", "-q"]);
+        run(&["config", "user.email", "t@t.t"]);
+        run(&["config", "user.name", "t"]);
+        std::fs::write(root.join("f.txt"), "hello\n").unwrap();
+        run(&["add", "-A"]);
+        run(&["commit", "-q", "-m", "init"]);
+        run(&["branch", "feature"]);
+        let out = Command::new("git")
+            .arg("-C")
+            .arg(root)
+            .args(["rev-parse", "HEAD"])
+            .output()
+            .unwrap();
+        String::from_utf8(out.stdout).unwrap().trim().to_string()
+    }
+
+    #[test]
+    fn git_show_rejects_dash_prefixed_ref() {
+        let tmp = unique_tmp_dir("show_dash");
+        init_repo(&tmp);
+        for malicious in ["-x", "--output=/tmp/topos_pwned_test"] {
+            let result = git_show(&tmp, malicious, "f.txt");
+            assert_eq!(result, Err("invalid_baseline_ref"));
+        }
+        assert!(!Path::new("/tmp/topos_pwned_test").exists());
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn ref_exists_rejects_dash_prefixed_ref() {
+        let tmp = unique_tmp_dir("exists_dash");
+        init_repo(&tmp);
+        assert!(!ref_exists(&tmp, "-x"));
+        assert!(!ref_exists(&tmp, "--output=/tmp/topos_pwned_test2"));
+        assert!(!Path::new("/tmp/topos_pwned_test2").exists());
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn git_show_reads_normal_refs() {
+        let tmp = unique_tmp_dir("show_normal");
+        let sha = init_repo(&tmp);
+
+        assert_eq!(git_show(&tmp, "HEAD", "f.txt").as_deref(), Ok("hello\n"));
+        assert_eq!(git_show(&tmp, "feature", "f.txt").as_deref(), Ok("hello\n"));
+        assert_eq!(git_show(&tmp, &sha, "f.txt").as_deref(), Ok("hello\n"));
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn ref_exists_recognizes_normal_refs() {
+        let tmp = unique_tmp_dir("exists_normal");
+        let sha = init_repo(&tmp);
+
+        assert!(ref_exists(&tmp, "HEAD"));
+        assert!(ref_exists(&tmp, "feature"));
+        assert!(ref_exists(&tmp, &sha));
+        assert!(!ref_exists(&tmp, "no-such-ref-at-all"));
+
+        std::fs::remove_dir_all(&tmp).ok();
     }
 }


### PR DESCRIPTION
Follow-up fixes for the five findings from review of #159 (the Python→Rust migration). Targets `worktree-rust-migration-v0.4.0` so it can land as part of that PR rather than after merge.

## Fixes

1. **`core/characteristic_morphism.rs` — `combine_dimensions` missing-key bug.** A file that never evaluated a dimension (key absent — e.g. no MDG representation for that file) was treated the same as a file that evaluated it and failed, silently dragging the whole-project verdict down for that generator. Now only an explicit SLOP value counts as a failure; a missing key is excluded from that file's contribution to the rollup. Added `combine_dimensions_ignores_files_missing_the_representation` regression test.

2. **`core/object.rs` — unbounded recursion.** `traverse_node`/`count_nodes`/`calculate_depth` walked the tree-sitter tree via plain function recursion — a stack-overflow risk on deeply nested source files. Converted to explicit-stack iteration, matching the pattern already used in `graphs/cpg/builder.rs`. Added a 20,000-deep nested-parens regression test.

3. **`graphs/cpg/builder.rs` + `graphs/pdg/object.rs` — anon-node-key mismatch.** Anonymous tree-sitter nodes got two different key conventions (`anon::{ptr}` vs literal `"<anon>"`), including inconsistently *within* `cpg/builder.rs` itself between `node_key()` and `cfg_edges()`. Any anonymous node reached via a CFG/DDG/CDG edge would fail to resolve in the node map — same failure class as the already-fixed #154. Unified on the pointer-based convention everywhere; added a regression test per file.

4. **`mcp/src/tools/assess.rs` — git argument injection.** `git_show`/`ref_exists` passed a client-supplied `baseline_ref` straight into a `git` argv with no leading-dash guard. A ref like `--output=/some/path` is parsed by git as an option, not a revision — verified live that `git show "--output=/tmp/pwned:file.txt"` writes blob content to that path. Fixed with (a) rejecting refs starting with `-` up front, and (b) `--end-of-options` as defense in depth (a bare `--` breaks the `ref:path` object syntax here, so it's not the right separator for this git subcommand). Added tests for both the injection attempt and normal ref resolution (`HEAD`, branch name, SHA).

5. **`mcp/src/server.rs` — stale tool-count doc comment.** Said "nine tool modules"; `tools/mod.rs` lists ten. Also confirmed the actual MCP tool count is 18, not the 17 stated in #159's description — `topos_assess_changeset` is a genuinely new tool that wasn't accounted for in that summary. This PR only corrects the doc comment; no tool-surface change.

## Verification

- `cargo test --workspace`: 335 passed, 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo fmt --all --check`: clean
