### PR TITLE
fix: avoid Intel Homebrew false positives

### DIFF
--- a/tests/cli/test_helpers.py
+++ b/tests/cli/test_helpers.py
@@ -334,6 +334,49 @@ def test_detect_install_method_binary_in_usr_local_bin(monkeypatch):
         assert info.provenance == provenance
 
 
+def test_detect_install_method_binary_in_usr_local_bin_with_homebrew_prefix(
+    monkeypatch,
+):
+    def raise_not_found(name: str):
+        raise PackageNotFoundError
+
+    provenance = {
+        "install_method": "binary-installer",
+        "install_path": "/usr/local/bin/topos",
+    }
+
+    with monkeypatch.context() as m:
+        m.setattr("importlib.metadata.distribution", raise_not_found)
+        m.setattr("topos.cli.installation.load_provenance", lambda: provenance)
+        m.setattr(
+            "topos.cli.installation.active_executable",
+            lambda: Path("/usr/local/bin/topos"),
+        )
+        m.setenv("HOMEBREW_PREFIX", "/usr/local")
+
+        info = detect_install_info()
+        assert info.method == "binary-installer"
+        assert info.provenance == provenance
+
+
+def test_detect_install_method_homebrew_intel_cellar_with_homebrew_prefix(
+    monkeypatch,
+):
+    def raise_not_found(name: str):
+        raise PackageNotFoundError
+
+    with monkeypatch.context() as m:
+        m.setattr("importlib.metadata.distribution", raise_not_found)
+        m.setattr("topos.cli.installation.load_provenance", lambda: None)
+        m.setattr(
+            "topos.cli.installation.active_executable",
+            lambda: Path("/usr/local/Cellar/topos/0.3.12/bin/topos"),
+        )
+        m.setenv("HOMEBREW_PREFIX", "/usr/local")
+
+        assert detect_install_info().method == "homebrew"
+
+
 def test_detect_install_method_ignores_malformed_homebrew_prefix(monkeypatch):
     def raise_not_found(name: str):
         raise PackageNotFoundError

--- a/topos/cli/installation.py
+++ b/topos/cli/installation.py
@@ -141,7 +141,8 @@ def _is_homebrew_executable(path: Path) -> bool:
             prefix_path = Path(configured_prefix).expanduser()
             if prefix_path.is_absolute():
                 prefix = prefix_path.resolve()
-                if resolved_path.is_relative_to(prefix):
+                shared_prefix = _SHARED_HOMEBREW_PREFIX.resolve()
+                if prefix != shared_prefix and resolved_path.is_relative_to(prefix):
                     return True
         except (OSError, RuntimeError):
             pass


### PR DESCRIPTION
## Summary
- avoid treating every executable under `/usr/local` as Homebrew when `HOMEBREW_PREFIX=/usr/local`
- keep genuine Intel Homebrew Cellar installs detected as Homebrew
- add regression coverage for binary-installer provenance under `/usr/local/bin/topos` with the Intel Homebrew prefix exported

Fixes #220.

## Testing
- `uv run pytest tests/cli/test_helpers.py -q`
- `uv run pytest tests/cli -q`
- `uv run ruff check topos/cli/installation.py tests/cli/test_helpers.py`
- `git diff --check`
