### PR TITLE
fix: secure score/pillar drift under overlay adjustment (#232) + bump 0.4.1

### DIFF
--- a/.mcp/server.json
+++ b/.mcp/server.json
@@ -17,13 +17,13 @@
     "url": "https://github.com/Krv-Labs/topos",
     "source": "github"
   },
-  "version": "0.4.0",
+  "version": "0.4.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "topos-mcp",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "transport": {
         "type": "stdio"
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2026-07-25
+
+### Fixed
+
+- **Project-row SECURE score now matches its pillar score under an active security overlay** — `evaluate_project`'s per-file `scores.secure` and `pillars.secure.score` could disagree when an allowlisted/acknowledged risk was in effect, because the overlay-adjusted classification used for `pillars` hard-coded the score to 1.0/0.0 instead of keeping it raw. `pillars.secure.achieved` and `lattice_element` still reflect the overlay-adjusted verdict; only the score is now always raw, matching the existing single-file `evaluate` behavior. (Closes [#232](https://github.com/Krv-Labs/topos/issues/232))
+
 ## [0.4.0] - 2026-07-25
 
 Baseline: **`topos-mcp==0.3.12`** (last Python release on PyPI). v0.4.0 is a Rust rewrite aimed at drop-in parity for scoring semantics and agent workflows on the same inputs, with documented exceptions called out below. Items not listed under **Intentional changes** are intended to match 0.3.12 behavior; where the Rust port regressed during migration, **Fixed** entries restore Python semantics.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1580,7 +1580,7 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "topos"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "clap",
  "serde_json",
@@ -1591,7 +1591,7 @@ dependencies = [
 
 [[package]]
 name = "topos-engine"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "blake2",
  "flate2",
@@ -1610,7 +1610,7 @@ dependencies = [
 
 [[package]]
 name = "topos-mcp"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["topos/engine", "topos/cli", "topos/mcp"]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "BSD-3-Clause"
 repository = "https://github.com/Krv-Labs/topos"

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "topos-vscode",
   "displayName": "Topos: Code Quality Targets for Agents",
   "description": "Structural code-quality targets your coding agents can optimize toward, delivered as MCP tools for agent mode.",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "publisher": "KrvLabs",
   "icon": "icon.png",
   "license": "SEE LICENSE IN LICENSE",

--- a/skills/topos/SKILL.md
+++ b/skills/topos/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: topos
 description: Structural code quality metrics, lattice verification, and refactor loops for agent-written code.
-version: "0.4.0"
+version: "0.4.1"
 homepage: https://docs.krv.ai/topos/
 metadata:
   openclaw:

--- a/topos/mcp/src/tools/evaluate.rs
+++ b/topos/mcp/src/tools/evaluate.rs
@@ -406,7 +406,6 @@ fn adjusted_result(
         return result.clone();
     };
     let mut dimensions = result.dimensions.clone();
-    let mut scores = result.scores.clone();
     let pass = overlay.verdict.adjusted_secure_pass;
     dimensions.insert(
         "secure".to_string(),
@@ -416,11 +415,10 @@ fn adjusted_result(
             EvaluationValue::Slop
         },
     );
-    scores.insert("secure".to_string(), if pass { 1.0 } else { 0.0 });
     ClassificationResult {
         is_parseable: result.is_parseable,
         dimensions,
-        scores,
+        scores: result.scores.clone(),
         lattice_element: overlay.verdict.adjusted_element,
         priority: result.priority,
         raw_metrics: result.raw_metrics.clone(),
@@ -1210,6 +1208,45 @@ mod tests {
         assert!(
             verbose.raw_metrics.contains_key("cfg.cyclomatic"),
             "verbose=true must restore the previous row shape"
+        );
+    }
+
+    /// #232: an active security overlay must only flip `achieved`/lattice,
+    /// never the numeric score — `entry.scores` and `entry.pillars` are
+    /// two different channels for the same raw classification.
+    #[test]
+    fn project_row_scores_and_pillars_agree_under_security_overlay() {
+        let path = write_temp_source("overlay_secure", "def f(expr):\n    return eval(expr)\n");
+        let dir = path.parent().expect("parent");
+        let (_, entry, ..) = evaluate_single_file(
+            &path,
+            dir,
+            Priority::Simple,
+            None,
+            /* include_security_findings = */ false,
+            /* verbose = */ false,
+            &["eval".to_string()],
+        )
+        .expect("classify temp file");
+
+        let raw_score = entry
+            .scores
+            .get("secure")
+            .copied()
+            .expect("secure score present");
+        let pillar = entry.pillars.get("secure").expect("secure pillar present");
+
+        assert_eq!(
+            raw_score, pillar.score,
+            "entry.scores and pillars must report the same (raw) secure score"
+        );
+        assert!(
+            raw_score > 0.0 && raw_score < 100.0,
+            "fixture must produce a non-trivial raw score, not 0/100 by coincidence: {raw_score}"
+        );
+        assert!(
+            pillar.achieved,
+            "the allowlisted eval call must still achieve SECURE via the overlay verdict"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Fixes #232: `ProjectFileEntry.scores.secure` and `pillars.secure.score` could disagree on project rows whenever a security overlay (allowlist / `.topos.toml` acknowledgment) was active, because `adjusted_result()` hard-coded the overlay-adjusted score to exactly 1.0/0.0 while `entry.scores` stayed raw. The overlay now only adjusts `dimensions`/`lattice_element` (driving `pillars.*.achieved`); the numeric score is always raw, matching the existing single-file `evaluate` path. Added a regression test that fails pre-fix and passes post-fix.
- Bumps the version to 0.4.1 across `Cargo.toml`/`Cargo.lock`, the VS Code extension, `.mcp/server.json`, `skills/topos/SKILL.md`, and `CHANGELOG.md`. v0.4.0 was already published to the VS Code Marketplace, PyPI, and GitHub Releases by mistake (with a Homebrew tap PR opened), so this bump is needed before a corrected release goes out. 