### PR TITLE
fix(ci): pin external lbug prebuilt for macOS release builds (#239)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+# Pin the LadybugDB prebuilt band used by topos-engine (lbug = "=0.17.1").
+# Run `./scripts/setup-lbug-prebuilt.sh` and export the printed vars before
+# building if liblbug is not already on the default search path.
+[env]
+LBUG_VERSION = "0.17.1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
       - name: Cache lbug prebuilt
         uses: actions/cache@v4
         with:
@@ -66,9 +69,6 @@ jobs:
 
       - name: Setup lbug prebuilt
         run: ./scripts/setup-lbug-prebuilt.sh
-
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,15 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache lbug prebuilt
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/lbug-prebuilt
+          key: lbug-prebuilt-0.17.1-static-${{ runner.os }}-${{ runner.arch }}
+
+      - name: Setup lbug prebuilt
+        run: ./scripts/setup-lbug-prebuilt.sh
+
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,20 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache lbug prebuilt
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/lbug-prebuilt
+          key: lbug-prebuilt-0.17.1-static-${{ runner.os }}-${{ runner.arch }}
+
+      - name: Setup lbug prebuilt
+        run: ./scripts/setup-lbug-prebuilt.sh
+
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-${{ matrix.target }}-lbug-prebuilt
+          cache-on-failure: false
 
       - name: Build release binary
         run: cargo build --release -p topos
@@ -363,6 +375,17 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache lbug prebuilt
+        if: runner.os == 'macOS'
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/lbug-prebuilt
+          key: lbug-prebuilt-0.17.1-static-${{ runner.os }}-${{ runner.arch }}
+
+      - name: Setup lbug prebuilt
+        if: runner.os == 'macOS'
+        run: ./scripts/setup-lbug-prebuilt.sh
 
       # lbug links OpenSSL; macOS source builds also need cmake and a
       # deployment target new enough for C++ `to_chars` (macOS 13.3+).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,12 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: release-${{ matrix.target }}-lbug-prebuilt
+          cache-on-failure: false
+
       - name: Cache lbug prebuilt
         uses: actions/cache@v4
         with:
@@ -49,12 +55,6 @@ jobs:
 
       - name: Setup lbug prebuilt
         run: ./scripts/setup-lbug-prebuilt.sh
-
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: release-${{ matrix.target }}-lbug-prebuilt
-          cache-on-failure: false
 
       - name: Build release binary
         run: cargo build --release -p topos

--- a/scripts/setup-lbug-prebuilt.sh
+++ b/scripts/setup-lbug-prebuilt.sh
@@ -5,6 +5,13 @@
 # the in-crate downloader and the cmake source fallback (issue #239).
 set -euo pipefail
 
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  if [[ -n "${LBUG_BUILD_FROM_SOURCE:-}" || -n "${LBUG_RUST_BUILD_FROM_SOURCE:-}" ]]; then
+    echo "Refusing lbug source build on macOS (issue #239)" >&2
+    exit 1
+  fi
+fi
+
 LBUG_VERSION="${LBUG_VERSION:-0.17.1}"
 LIB_KIND="${LBUG_LIB_KIND:-static}"
 CACHE_ROOT="${LBUG_PREBUILT_ROOT:-${CARGO_HOME:-$HOME/.cargo}/lbug-prebuilt}"
@@ -61,12 +68,4 @@ emit_env() {
 emit_env "LBUG_LIBRARY_DIR" "${LIB_DIR}"
 emit_env "LBUG_INCLUDE_DIR" "${LIB_DIR}"
 emit_env "LBUG_VERSION" "${LBUG_VERSION}"
-
-if [[ "$(uname -s)" == "Darwin" ]]; then
-  if [[ -n "${LBUG_BUILD_FROM_SOURCE:-}" || -n "${LBUG_RUST_BUILD_FROM_SOURCE:-}" ]]; then
-    echo "Refusing lbug source build on macOS (issue #239)" >&2
-    exit 1
-  fi
-fi
-
 echo "lbug prebuilt: ${LIB_DIR}/${LIB_FILE}" >&2

--- a/scripts/setup-lbug-prebuilt.sh
+++ b/scripts/setup-lbug-prebuilt.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Pin and cache LadybugDB prebuilt liblbug for deterministic CI/local builds.
+#
+# Uses lbug's LBUG_LIBRARY_DIR / LBUG_INCLUDE_DIR path so build.rs skips both
+# the in-crate downloader and the cmake source fallback (issue #239).
+set -euo pipefail
+
+LBUG_VERSION="${LBUG_VERSION:-0.17.1}"
+LIB_KIND="${LBUG_LIB_KIND:-static}"
+CACHE_ROOT="${LBUG_PREBUILT_ROOT:-${CARGO_HOME:-$HOME/.cargo}/lbug-prebuilt}"
+LIB_DIR="${CACHE_ROOT}/${LBUG_VERSION}/${LIB_KIND}/lib"
+
+lib_name() {
+  case "$LIB_KIND" in
+    static) echo "liblbug.a" ;;
+    shared)
+      case "$(uname -s)" in
+        Darwin) echo "liblbug.dylib" ;;
+        Linux) echo "liblbug.so" ;;
+        *) echo "liblbug.so" ;;
+      esac
+      ;;
+    *) echo "unsupported LBUG_LIB_KIND: $LIB_KIND" >&2; exit 1 ;;
+  esac
+}
+
+LIB_FILE="$(lib_name)"
+
+if [[ ! -f "${LIB_DIR}/${LIB_FILE}" ]]; then
+  mkdir -p "${LIB_DIR}"
+  if ! cargo fetch --locked >/dev/null 2>&1; then
+    cargo fetch
+  fi
+  LBUG_CRATE="$(find "${CARGO_HOME:-$HOME/.cargo}/registry/src" -maxdepth 2 -type d -name "lbug-${LBUG_VERSION}" 2>/dev/null | head -1)"
+  if [[ -z "${LBUG_CRATE}" ]]; then
+    echo "lbug-${LBUG_VERSION} crate not found under \$CARGO_HOME/registry/src after cargo fetch" >&2
+    exit 1
+  fi
+  LBUG_VERSION="${LBUG_VERSION}" LBUG_LIB_KIND="${LIB_KIND}" \
+    LBUG_TARGET_DIR="${LIB_DIR}" \
+    sh "${LBUG_CRATE}/scripts/download_lbug.sh"
+fi
+
+if [[ ! -f "${LIB_DIR}/${LIB_FILE}" ]]; then
+  echo "Expected prebuilt ${LIB_FILE} missing under ${LIB_DIR}" >&2
+  exit 1
+fi
+
+emit_env() {
+  local key="$1"
+  local value="$2"
+  if [[ -n "${GITHUB_ENV:-}" ]]; then
+    {
+      echo "${key}=${value}"
+    } >>"${GITHUB_ENV}"
+  else
+    printf 'export %s=%q\n' "${key}" "${value}"
+  fi
+}
+
+emit_env "LBUG_LIBRARY_DIR" "${LIB_DIR}"
+emit_env "LBUG_INCLUDE_DIR" "${LIB_DIR}"
+emit_env "LBUG_VERSION" "${LBUG_VERSION}"
+
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  if [[ -n "${LBUG_BUILD_FROM_SOURCE:-}" || -n "${LBUG_RUST_BUILD_FROM_SOURCE:-}" ]]; then
+    echo "Refusing lbug source build on macOS (issue #239)" >&2
+    exit 1
+  fi
+fi
+
+echo "lbug prebuilt: ${LIB_DIR}/${LIB_FILE}" >&2


### PR DESCRIPTION
## Summary
- Adds `scripts/setup-lbug-prebuilt.sh` to download/cache `liblbug.a` v0.17.1 and set `LBUG_LIBRARY_DIR` / `LBUG_INCLUDE_DIR` so `lbug`'s build.rs uses the external prebuilt path instead of cmake source fallback.
- Wires the script into `release.yml` native `build` (all platforms), `release.yml` macOS PyPI wheels, and `ci.yml` composable job.
- Pins `LBUG_VERSION=0.17.1` in `.cargo/config.toml`; hardens release rust-cache (`cache-on-failure: false`, shared key includes lbug prebuilt).

Fixes #239 by ensuring macOS never links monolithic `liblbug.a` together with separately-built antlr4/parquet archives.

## Test plan
- [ ] Merge and confirm PR `release.yml` macOS `build (macos-latest, macos-arm64)` completes without `duplicate symbol` link errors
- [ ] Confirm `build-pypi-wheels (macos-latest)` succeeds
- [ ] Local: `eval "$(./scripts/setup-lbug-prebuilt.sh)" && cargo build --release -p topos`


Made with [Cursor](https://cursor.com)