### PR TITLE
fix(packaging): preserve macOS OpenSSL bundling in Homebrew template

### DIFF
--- a/packaging/homebrew/topos.rb.template
+++ b/packaging/homebrew/topos.rb.template
@@ -16,6 +16,7 @@ class Topos < Formula
 
   on_macos do
     depends_on arch: :arm64
+    depends_on "openssl@3"
   end
 
   on_linux do
@@ -33,6 +34,7 @@ class Topos < Formula
     binary = Dir["topos-*"].first
     bin.install binary => "topos"
     (bin/"topos").chmod 0755
+    bundle_openssl_on_macos if OS.mac?
 
     # Homebrew formulae are non-interactive: warn only (no y/N). Formula-level
     # conflict declarations only cover other formulae, not curl/install.sh.
@@ -79,6 +81,44 @@ class Topos < Formula
     candidates.select do |path|
       File.exist?(path) && !path.start_with?("#{HOMEBREW_PREFIX}/")
     end
+  end
+
+  def bundle_openssl_on_macos
+    # Release binaries are Developer ID signed but link Homebrew OpenSSL paths
+    # from the build runner. macOS rejects that Team ID mix at runtime, so ship
+    # matching dylibs in libexec, rewrite load paths, and re-sign ad hoc.
+    openssl_lib = formula_opt_lib("openssl@3")
+    dylibs = %w[libssl.3.dylib libcrypto.3.dylib]
+
+    libexec.mkpath
+    dylibs.each do |lib|
+      cp openssl_lib/lib, libexec/lib
+      (libexec/lib).chmod 0644
+    end
+
+    rewrite_openssl_links(bin/"topos", loader_base: "@loader_path/../libexec")
+
+    dylibs.each do |lib|
+      dylib = libexec/lib
+      rewrite_openssl_links(dylib, loader_base: "@loader_path")
+      macho = MachO.open(dylib)
+      macho.change_dylib_id("@loader_path/#{lib}")
+      macho.write!
+    end
+
+    targets = [bin/"topos", *dylibs.map { |lib| libexec/lib }]
+    system "codesign", "--force", "--sign", "-", *targets
+  end
+
+  def rewrite_openssl_links(target, loader_base:)
+    macho = MachO.open(target)
+    macho.linked_dylibs.each do |dep|
+      next unless dep.include?("openssl")
+
+      lib_name = dep.include?("libssl") ? "libssl.3.dylib" : "libcrypto.3.dylib"
+      macho.change_install_name(dep, "#{loader_base}/#{lib_name}")
+    end
+    macho.write!
   end
 
   test do

--- a/tests/packaging/test_install_sh_preflight.py
+++ b/tests/packaging/test_install_sh_preflight.py
@@ -171,6 +171,10 @@ def test_homebrew_formula_template_has_foreign_detection() -> None:
     assert "~/.local/bin/topos" in template
     assert "opoo" in template
     assert "brew upgrade topos" in template
+    assert 'depends_on "openssl@3"' in template
+    assert "bundle_openssl_on_macos if OS.mac?" in template
+    assert "def bundle_openssl_on_macos" in template
+    assert "def rewrite_openssl_links" in template
     # Prefer a behavioral smoke beyond --version alone.
     assert 'assert_match "evaluate"' in template
     # Cross-channel only: no formula-to-formula conflicts_with stanza.


### PR DESCRIPTION
## Summary
- Add macOS OpenSSL bundling (`depends_on "openssl@3"`, `bundle_openssl_on_macos`, `rewrite_openssl_links`) to `packaging/homebrew/topos.rb.template`
- Extend packaging tests so release automation cannot drop these hooks again

## Context
The `publish-homebrew` release job fully overwrites `Formula/topos.rb` in `Krv-Labs/homebrew-tap` from this template. PR #3 in the tap added macOS OpenSSL runtime bundling manually, but the 0.4.1 bot bump regenerated the formula without it and macOS `brew test-bot` failed on broken dylib links.

## Test plan
- [x] `pytest tests/packaging/test_install_sh_preflight.py::test_homebrew_formula_template_has_foreign_detection`
- [ ] After merge: re-run or update `Krv-Labs/homebrew-tap` PR #4 so the bot branch picks up the fixed template


Made with [Cursor](https://cursor.com)