### PR TITLE
release: v0.4.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -451,16 +451,13 @@ jobs:
         if: runner.os == 'macOS'
         run: ./scripts/setup-lbug-prebuilt.sh
 
-      # lbug 0.17.1 statically links mbedtls and needs no OpenSSL; the stale
-      # claim that it does is what produced the -lssl/-lcrypto linkage that
-      # broke the v0.4.1 macOS binary. cmake and a deployment target new enough
-      # for C++ `to_chars` (macOS 13.3+) are still needed for source fallbacks.
-      # openssl@3 is kept only because the maturin wheel path is not verified
-      # here; it has no known remaining consumer and can likely be dropped.
+      # lbug 0.17.1 statically links mbedtls and needs no OpenSSL. cmake and a
+      # deployment target new enough for C++ `to_chars` (macOS 13.3+) are still
+      # needed for source fallbacks.
       - name: Install macOS build deps (lbug)
         if: runner.os == 'macOS'
         run: |
-          brew install openssl@3 cmake
+          brew install cmake
           echo "MACOSX_DEPLOYMENT_TARGET=13.3" >> "$GITHUB_ENV"
 
       - name: Build bin wheel
@@ -468,28 +465,19 @@ jobs:
         with:
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux }}
-          # manylinux images are AlmaLinux-based; openssl must be installed
-          # inside the container (host apt packages are invisible).
+          # Install cmake inside the manylinux container (host packages are invisible).
           before-script-linux: |
             if command -v dnf >/dev/null 2>&1; then
-              # openssl-devel/cmake live in base/AppStream; skip EPEL to avoid mirror flakes.
-              dnf install -y --disablerepo='epel*' openssl-devel cmake pkgconfig
+              dnf install -y --disablerepo='epel*' cmake pkgconfig
             elif command -v yum >/dev/null 2>&1; then
-              yum install -y --disablerepo='epel*' openssl-devel cmake pkgconfig
+              yum install -y --disablerepo='epel*' cmake pkgconfig
             elif command -v apt-get >/dev/null 2>&1; then
               apt-get update
               DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-                libssl-dev cmake pkg-config
+                cmake pkg-config
             else
               echo "No supported package manager in manylinux container" >&2
               exit 1
-            fi
-            # Sanity: lbug prebuilts need OpenSSL 3 symbols.
-            if ! ldconfig -p 2>/dev/null | grep -q 'libssl\.so\.3'; then
-              if [ ! -e /usr/lib64/libssl.so.3 ] && [ ! -e /usr/lib/libssl.so.3 ]; then
-                echo "OpenSSL 3 not found in manylinux image; lbug link will fail" >&2
-                exit 1
-              fi
             fi
           args: >-
             --release --bindings bin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -423,8 +423,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # 2_34 (AlmaLinux 9) ships OpenSSL 3 — required by the lbug
-          # prebuilt (SSL_get1_peer_certificate). 2_28 only has OpenSSL 1.1.
+          # manylinux 2_34 (AlmaLinux 9) for a modern glibc/toolchain. lbug
+          # 0.17.1 statically links mbedtls and needs no OpenSSL at link time.
           - os: ubuntu-latest
             target: x86_64
             manylinux: "2_34"
@@ -484,11 +484,9 @@ jobs:
             --manifest-path topos/mcp/Cargo.toml
             --out dist
 
-      # The v0.4.1 macOS wheel shipped a topos-mcp that linked Homebrew's
-      # openssl@3 by absolute path, so it fails with "Library not loaded" for
-      # anyone without that formula. Linux wheels are covered by auditwheel
-      # (manylinux tags reject a non-allowlisted libssl); macOS has no
-      # equivalent here, so check it explicitly.
+      # Guard against non-portable dylib paths in the wheel binary. v0.4.1
+      # wheels linked Homebrew openssl@3 and failed on machines without it.
+      # Linux wheels are covered by auditwheel; macOS has no equivalent.
       - name: Verify macOS wheel binary has no non-system linkage
         if: runner.os == 'macOS'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -524,6 +524,44 @@ jobs:
             exit 1
           fi
 
+      # auditwheel only rejects a non-allowlisted libssl if it runs; nothing
+      # here proves it did. Check the DT_NEEDED entries directly so removing
+      # openssl-devel from this job is actually demonstrated, not assumed.
+      - name: Verify Linux wheel binary has no unexpected linkage
+        if: runner.os == 'Linux'
+        run: |
+          set -euo pipefail
+          workdir="$(mktemp -d)"
+          shopt -s nullglob
+          wheels=(dist/*.whl)
+          if [ "${#wheels[@]}" -eq 0 ]; then
+            echo "::error title=No wheel built::dist/ contains no .whl"
+            exit 1
+          fi
+          for whl in "${wheels[@]}"; do
+            unzip -qo "${whl}" -d "${workdir}"
+          done
+          find "${workdir}" -type f -path '*.data/scripts/*' > "${workdir}/bins.txt"
+          found=0
+          while IFS= read -r bin; do
+            [ -n "${bin}" ] || continue
+            found=1
+            echo "checking ${bin}"
+            bad="$(readelf -d "${bin}" \
+              | grep 'NEEDED' \
+              | grep -vE 'lib(c|m|dl|pthread|rt|gcc_s|stdc\+\+)\.so|ld-linux-[a-z0-9_-]*\.so' || true)"
+            if [ -n "${bad}" ]; then
+              echo "::error title=Non-portable Linux wheel::${bin} has unexpected DT_NEEDED entries"
+              echo "${bad}"
+              exit 1
+            fi
+            readelf -d "${bin}" | grep 'NEEDED'
+          done < "${workdir}/bins.txt"
+          if [ "${found}" -eq 0 ]; then
+            echo "::error title=Wheel check found no binary::expected a *.data/scripts/ entry"
+            exit 1
+          fi
+
       - name: Upload wheels
         uses: actions/upload-artifact@v7
         with:

--- a/.mcp/server.json
+++ b/.mcp/server.json
@@ -15,13 +15,13 @@
     "url": "https://github.com/Krv-Labs/topos",
     "source": "github"
   },
-  "version": "0.4.1",
+  "version": "0.4.2",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org/simple",
       "identifier": "topos-mcp",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "transport": {
         "type": "stdio"
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2] - 2026-07-26
+
+### Fixed
+
+- **Rebuild release artifacts without spurious OpenSSL linkage** — v0.4.1 macOS CLI and PyPI wheels linked Homebrew `openssl@3` paths and aborted under library validation; source fixes landed in PR [#246](https://github.com/Krv-Labs/topos/pull/246) but users still received the broken v0.4.1 binaries until this release.
+
+### Changed
+
+- **Drop stale OpenSSL from PyPI wheel and Glama Docker builds** — remove unused `openssl@3` / `libssl-dev` install steps from the maturin wheel job; CI already rejects macOS wheels with non-system dylib linkage.
+
 ## [0.4.1] - 2026-07-25
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1580,7 +1580,7 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "topos"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "clap",
  "serde_json",
@@ -1591,7 +1591,7 @@ dependencies = [
 
 [[package]]
 name = "topos-engine"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "blake2",
  "flate2",
@@ -1610,7 +1610,7 @@ dependencies = [
 
 [[package]]
 name = "topos-mcp"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["topos/engine", "topos/cli", "topos/mcp"]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 license = "BSD-3-Clause"
 repository = "https://github.com/Krv-Labs/topos"

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ENV PIP_NO_CACHE_DIR=1 \
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        build-essential curl cmake libssl-dev pkg-config \
+        build-essential curl cmake pkg-config \
     && rm -rf /var/lib/apt/lists/* \
     && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
         | sh -s -- -y --profile minimal --default-toolchain stable \

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "topos-vscode",
   "displayName": "Topos: Code Quality Targets for Agents",
   "description": "Structural code-quality targets your coding agents can optimize toward, delivered as MCP tools for agent mode.",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "publisher": "KrvLabs",
   "icon": "icon.png",
   "license": "SEE LICENSE IN LICENSE",

--- a/skills/topos/SKILL.md
+++ b/skills/topos/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: topos
 description: Structural code quality metrics, lattice verification, and refactor loops for agent-written code.
-version: "0.4.1"
+version: "0.4.2"
 homepage: https://docs.krv.ai/topos/
 metadata:
   openclaw:


### PR DESCRIPTION
## Summary
- Bump version to **0.4.2** across Cargo, VS Code extension, MCP manifest, and skill card
- Remove stale `openssl@3` / `libssl-dev` from the **PyPI wheel** maturin job and Glama `Dockerfile` (lbug statically links mbedtls; nothing consumes OpenSSL)
- **Homebrew tap template unchanged** — PR #244 OpenSSL bundling stays; this release only rebuilds artifacts so curl/uv get clean binaries

## Context
PR #246 fixed the source (deleted spurious `build.rs`, install.sh parse error, MCP `/simple` URL) but v0.4.1 release artifacts still link Homebrew OpenSSL and abort under library validation. This PR is the version bump + wheel-build cleanup needed before tagging `v0.4.2`.

## Test plan
- [x] `python3 scripts/check_versions.py`
- [x] `pytest tests/packaging/test_install_sh_preflight.py` (16 passed)
- [ ] Merge → tag `v0.4.2` → verify release CI builds wheels with only `/usr/lib` dylibs on macOS
- [ ] `uvx --index-url https://pypi.org/simple topos-mcp@0.4.2 --version`
- [ ] `curl -fsSL https://docs.krv.ai/topos/install.sh | bash` installs a runnable binary
- [ ] Republish MCP registry: `mcp-publisher publish .mcp/server.json`


Made with [Cursor](https://cursor.com)