### PR TITLE
Fix: `uvx` PyPI resolution for MCP registry install

### DIFF
--- a/.mcp/server.json
+++ b/.mcp/server.json
@@ -19,9 +19,17 @@
   "packages": [
     {
       "registryType": "pypi",
-      "registryBaseUrl": "https://pypi.org/simple",
+      "registryBaseUrl": "https://pypi.org",
       "identifier": "topos-mcp",
       "version": "0.4.2",
+      "runtimeHint": "uvx",
+      "runtimeArguments": [
+        {
+          "type": "named",
+          "name": "--index-url",
+          "value": "https://pypi.org/simple"
+        }
+      ],
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
### Background
Installing `topos-mcp` via VS Code's `@mcp` extension failed to resolve the package, even though it's live on PyPI. Root cause: VS Code's uvx-invocation generator passes `registryBaseUrl` straight through as `uvx --index-url <value>`, and `https://pypi.org` (the PyPI HTML frontend) is not a valid index — it needs the Simple API (`https://pypi.org/simple`).

### False start (reverted)
First attempt set `registryBaseUrl: "https://pypi.org/simple"` directly. This broke `mcp-publisher publish`:

~~~
registry validation failed for package 0 (topos-mcp): registry type and
base URL do not match: 'https://pypi.org/simple' is not valid for
registry type 'pypi'. Expected: https://pypi.org
~~~

`registryBaseUrl` is registry-validated metadata, not a runtime index override — confirmed against the official `server.json` spec, where every `pypi` example uses the bare root.

### Final fix
Kept `registryBaseUrl` at the required `https://pypi.org`, and added the actual index override via `runtimeArguments` (flags passed to `uvx` itself, ahead of the package identifier):

~~~json
"runtimeHint": "uvx",
"runtimeArguments": [
  { "type": "named", "name": "--index-url", "value": "https://pypi.org/simple" }
]
~~~

Produces `uvx --index-url https://pypi.org/simple topos-mcp@0.4.2` regardless of how VS Code's translation layer behaves.

### Root cause (upstream, unfixed)
VS Code's registry→uvx config generation has a known-buggy translation layer — see `microsoft/vscode#283572` (VS Code team confirmed, separate but related uvx invocation bug: `==` vs `@` version separator). Ours is the same class of bug. Not something fixable from our `server.json` alone without the `runtimeArguments` workaround above.

### Verification
- `mcp-publisher publish .mcp/server.json` — passes.
- `uvx --index-url https://pypi.org/simple topos-mcp@0.4.2` — resolves and runs directly.
- [ ] Confirm VS Code `@mcp` install picks up `runtimeArguments` correctly (untested against live extension as of this PR — flag if it doesn't).

> [!IMPORTANT]
> In the process of validating this PR, `v0.4.2` + this single file change was _accidentally_ published to the MCP registry... if that published version has issues, I will take down this PR.
>
> As such, **ensure v0.4.2 is live and dogfood the `@mcp` VSCode extension to validate this PR**

### Follow-up
File issue against `microsoft/vscode` referencing #283572 for the underlying installer bug.