### PR TITLE
release: v0.4.3

### DIFF
--- a/.mcp/server.json
+++ b/.mcp/server.json
@@ -15,13 +15,13 @@
     "url": "https://github.com/Krv-Labs/topos",
     "source": "github"
   },
-  "version": "0.4.2",
+  "version": "0.4.3",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "topos-mcp",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "runtimeHint": "uvx",
       "runtimeArguments": [
         {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.3] - 2026-07-28
+
+### Added
+
+- **First-class CLI terminal UX restored** ([#251](https://github.com/Krv-Labs/topos/pull/251)) — `topos evaluate` prints one stable pillar summary instead of streaming every file; TTY progress stays on stderr. `--info` adds a bounded weak-file drill-down; `--failures <pillar>` lists failing paths. New `topos config` interactively sets evaluation priority and writes `.topos.toml`.
+- **Unified `--priority` flag** ([#255](https://github.com/Krv-Labs/topos/pull/255)) — `topos evaluate` and `topos config set` accept either a single pillar or a full comma-separated ranking; on-disk schema collapses to one `priority` key (legacy `preferences` still loads for one release).
+
+### Changed
+
+- **`topos inspect` and supporting CLI commands** — actionable single-file detail, medal tier in the evaluate footer, clearer composable-unavailable and diagnostic-score guidance; Rust CLI docs refreshed and Python-era references removed.
+
 ## [0.4.2] - 2026-07-26
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1580,7 +1580,7 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "topos"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "clap",
  "console",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "topos-engine"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "blake2",
  "flate2",
@@ -1613,7 +1613,7 @@ dependencies = [
 
 [[package]]
 name = "topos-mcp"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["topos/engine", "topos/cli", "topos/mcp"]
 
 [workspace.package]
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 license = "BSD-3-Clause"
 repository = "https://github.com/Krv-Labs/topos"

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "topos-vscode",
   "displayName": "Topos: Code Quality Targets for Agents",
   "description": "Structural code-quality targets your coding agents can optimize toward, delivered as MCP tools for agent mode.",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "publisher": "KrvLabs",
   "icon": "icon.png",
   "license": "SEE LICENSE IN LICENSE",

--- a/skills/topos/SKILL.md
+++ b/skills/topos/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: topos
 description: Structural code quality metrics, lattice verification, and refactor loops for agent-written code.
-version: "0.4.2"
+version: "0.4.3"
 homepage: https://docs.krv.ai/topos/
 metadata:
   openclaw:


### PR DESCRIPTION
## Summary

- Bump version to **0.4.3** across Cargo, VS Code extension, MCP manifest, and skill card
- Ship the restored CLI terminal UX from PR [#251](https://github.com/Krv-Labs/topos/pull/251) and the unified `--priority` flag from PR [#255](https://github.com/Krv-Labs/topos/pull/255)

## CLI highlights (PR #251)

- **`topos evaluate`** — quiet cumulative summary with TTY progress on stderr; `--info` for bounded weak-file drill-down; `--failures <pillar>` to list failing paths
- **`topos inspect`** — actionable single-file detail; medal tier in the evaluate footer
- **`topos config`** — interactive pillar-priority selector that writes `.topos.toml`
- **`--priority`** — single flag accepts one pillar or a full ranking (replaces separate `--preferences`)
- **Docs** — Rust CLI workflows refreshed; stale Python-era references removed

## Test plan

- [x] `python3 scripts/check_versions.py`
- [x] `python3 scripts/check_skill.py`
- [ ] Merge → tag `v0.4.3` → verify release CI
- [ ] `uvx --index-url https://pypi.org/simple topos-mcp@0.4.3 --version`
- [ ] `topos evaluate <dir> -r` shows compact pillar summary in a TTY
- [ ] Republish MCP registry: `mcp-publisher publish .mcp/server.json`


Made with [Cursor](https://cursor.com)