### PR TITLE
ci(release): validate git tag against Cargo/wheel version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,32 @@ permissions:
   contents: write
 
 jobs:
+  # Fail fast when a release tag (or workflow_dispatch version) does not match
+  # Cargo.toml — maturin/PyPI take the workspace version, while GitHub Release
+  # + Homebrew take the git tag. See #217.
+  verify-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Check published metadata vs Cargo.toml
+        run: python3 scripts/check_versions.py
+
+      - name: Check release tag matches Cargo.toml
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            RAW="${{ github.event.inputs.version }}"
+          else
+            RAW="${GITHUB_REF#refs/tags/}"
+          fi
+          python3 scripts/check_versions.py --tag "$RAW"
+
   # ---- Native `topos` binary (includes `topos mcp`) per platform -----------
   build:
     if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.pypi_only) }}
+    needs:
+      - verify-version
     strategy:
       fail-fast: false
       matrix:
@@ -244,6 +267,7 @@ jobs:
   release:
     if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && !(github.event_name == 'workflow_dispatch' && inputs.pypi_only) }}
     needs:
+      - verify-version
       - build
       - package-vscode
     runs-on: ubuntu-latest
@@ -289,6 +313,7 @@ jobs:
   publish-homebrew:
     if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && !(github.event_name == 'workflow_dispatch' && inputs.pypi_only) }}
     needs:
+      - verify-version
       - release
     runs-on: ubuntu-latest
     steps:
@@ -468,6 +493,8 @@ jobs:
 
   # ---- PyPI: thin `bin` wheels wrapping the topos-mcp server binary --------
   build-pypi-wheels:
+    needs:
+      - verify-version
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -762,3 +789,7 @@ jobs:
             echo "Twine also logs \`Skipping <file> because it appears to already exist\` inside the Publish step when a duplicate is hit."
           } >> "$GITHUB_STEP_SUMMARY"
           echo "::notice title=PyPI publish finished::topos-mcp==${VERSION}: ${PRE_UPLOAD} attempted upload(s), ${PRE_ALREADY} pre-existing skip(s)"
+
+
+
+

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import argparse
 import json
 import sys
 import tomllib
@@ -16,9 +17,33 @@ def cargo_version() -> str:
         return tomllib.load(f)["workspace"]["package"]["version"]
 
 
-def main() -> int:
+def normalize_tag(tag: str) -> str:
+    """Strip a leading ``v`` so ``v0.4.4`` and ``0.4.4`` compare equal."""
+    return tag[1:] if tag.startswith("v") else tag
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--tag",
+        help=(
+            "Release git tag (with or without leading v). When set, must equal "
+            "the Cargo.toml workspace version so GitHub/Homebrew tags cannot "
+            "drift from the maturin/PyPI wheel version."
+        ),
+    )
+    args = parser.parse_args(argv)
+
     expected = cargo_version()
     errors: list[str] = []
+
+    if args.tag is not None:
+        tag_version = normalize_tag(args.tag)
+        if tag_version != expected:
+            errors.append(
+                f"release tag {args.tag!r} normalizes to {tag_version!r}, "
+                f"expected Cargo.toml workspace version {expected!r}"
+            )
 
     package_json = json.loads(
         (ROOT / "extensions/vscode/package.json").read_text(encoding="utf-8")
@@ -48,7 +73,10 @@ def main() -> int:
             print(message, file=sys.stderr)
         return 1
 
-    print(f"version check passed ({expected})")
+    if args.tag is not None:
+        print(f"version check passed ({expected}; tag {args.tag})")
+    else:
+        print(f"version check passed ({expected})")
     return 0
 
 


### PR DESCRIPTION
## Summary
- Adds `--tag` to `scripts/check_versions.py` (accepts `v0.4.3` or `0.4.3`).
- Adds a `verify-version` job in `release.yml` that fails before binary/wheel builds and publishes when the release tag does not match `Cargo.toml`.
- Stacked on #266 (`release/044-213-js-switch-delta`).
- Closes #217.

## Test plan
- [x] `python3 scripts/check_versions.py` passes
- [x] `python3 scripts/check_versions.py --tag v0.4.3` passes (current Cargo)
- [x] `python3 scripts/check_versions.py --tag v0.4.4` fails with clear mismatch message
- [ ] Confirm `verify-version` appears in the release workflow graph on this PR


Made with [Cursor](https://cursor.com)