### PR TITLE
feat: treat --gitnexus-dir / gitnexus_dir as COMPOSABLE project root

### DIFF
--- a/docs/source/agents.rst
+++ b/docs/source/agents.rst
@@ -404,9 +404,11 @@ Dependency Graph
    (falling back to file mtimes for graphs built before that marker existed), so
    a regenerate reliably clears ``stale``. Never shells out.
 
-``topos_generate_depgraph({"directory": ..., "force": ...})``
-   Runs ``gitnexus analyze`` and writes ``.gitnexus/``. Side-effecting and
-   approval-gated. Requires the ``gitnexus`` CLI (``pnpm add -g gitnexus  # or: npm install -g gitnexus``).
+``topos_generate_depgraph({"directory": ..., "gitnexus_dir": ..., "force": ...})``
+   Runs ``gitnexus analyze`` and writes ``.gitnexus/``. When ``directory`` is
+   omitted, the analyze root is derived from ``gitnexus_dir`` the same way
+   ``topos_depgraph_status`` does. Side-effecting and approval-gated. Requires
+   the ``gitnexus`` CLI (``pnpm add -g gitnexus  # or: npm install -g gitnexus``).
 
 Structure & Coverage
 ~~~~~~~~~~~~~~~~~~~~

--- a/skills/topos/SKILL.md
+++ b/skills/topos/SKILL.md
@@ -96,7 +96,7 @@ Mitigation: Stop when MCP returns `SUSPICIOUS_NO_STRUCTURAL_CHANGE`; require `IM
 
 ## Agent Loop
 
-1. **Measure** — `topos evaluate <path> -r` (CLI) or `topos_evaluate_file` / `topos_evaluate_project` (MCP). COMPOSABLE is included by default; run the CLI from the repo root (MCP: set file root to that repo). Pass `gitnexus_dir` only to select a non-default store under that root.
+1. **Measure** — `topos evaluate <path> -r` (CLI) or `topos_evaluate_file` / `topos_evaluate_project` (MCP). COMPOSABLE is included by default. Pass `--gitnexus-dir` / `gitnexus_dir` to select a store; its parent becomes the COMPOSABLE project root (so you can evaluate from `$HOME` against `~/repo/.gitnexus`).
 2. **Inspect** — `topos inspect <file>` or `topos_inspect_code` for per-function complexity and metric detail.
 3. **Edit** — one focused structural change (extract helper, simplify branch, decouple import).
 4. **Verify** — re-run evaluate, or use `topos_assess_worktree_change` (baseline `HEAD`) for MCP loops. For untracked baselines: `topos_begin_refactor` → edit → `topos_assess_snapshot`.
@@ -119,9 +119,7 @@ Stop when the target medal is reached, the priority pillar passes, or further it
 | `topos graphify generate\|orphans` | Advisory orphan / fragile-edge hints (does not affect evaluate) |
 | `topos mcp` | Start the MCP server for tool-based agent loops |
 
-Run CLI `evaluate` / `inspect` / `depgraph` from the **repo root that owns `.gitnexus`**. COMPOSABLE freshness and `gitnexus analyze` always use process **cwd** as the project root; `--gitnexus-dir` only selects a store path under that cwd (default `<cwd>/.gitnexus`) — it does not retarget the root. Pass `--no-composable` to score SIMPLE/SECURE only. The CLI accepts a one-run `--priority` override (a single pillar or a full comma-separated ranking) and `topos config` persists project defaults; MCP additionally returns the induced preference walk. Advisory `cycles`/`dependencies`/`process` hints are MCP-only, via `topos_refactor`.
-
-For MCP, the same rule uses the server **file root** (`TOPOS_MCP_FILE_ROOT`, else server cwd): set the file root to the repo, and use `gitnexus_dir` only for a non-default store under that root.
+Without `--gitnexus-dir`, COMPOSABLE uses process **cwd** (CLI) or the MCP **file root** (`TOPOS_MCP_FILE_ROOT`, else server cwd), with store at `<root>/.gitnexus`. With `--gitnexus-dir` / `gitnexus_dir`, the store's parent is the COMPOSABLE project root for freshness and `gitnexus analyze` (CLI allows absolute paths outside cwd; MCP still requires the store under the file root). Pass `--no-composable` to score SIMPLE/SECURE only. The CLI accepts a one-run `--priority` override (a single pillar or a full comma-separated ranking) and `topos config` persists project defaults; MCP additionally returns the induced preference walk. Advisory `cycles`/`dependencies`/`process` hints are MCP-only, via `topos_refactor`.
 
 ## MCP Tool Reference
 
@@ -148,7 +146,7 @@ MCP tool arguments are **flat objects** — `{"filepath": "..."}`, not `{"params
 ## Pitfalls
 
 - **No GitNexus → no COMPOSABLE.** The graph is generated automatically, but only if `gitnexus` is installed. If it isn't, `coupling_available` is `false` and GOLD is unreachable — check `warnings`.
-- **Wrong cwd / file root → slow or hung COMPOSABLE setup.** Freshness fingerprints the whole project root (CLI cwd / MCP file root). Running from `$HOME` with `--gitnexus-dir ~/…/repo/.gitnexus` still walks home and can appear stuck on “indexing”; `cd` into the repo (or point MCP `TOPOS_MCP_FILE_ROOT` at it) instead.
+- **Missing `--gitnexus-dir` from a parent directory → slow COMPOSABLE setup.** Without the override, freshness fingerprints CLI cwd / MCP file root. Prefer `--gitnexus-dir <repo>/.gitnexus` (or `cd` into the repo / set `TOPOS_MCP_FILE_ROOT`) so only that repo is walked.
 - **Cosmetic edits don't count.** Whitespace and rename-only changes won't move the lattice; MCP returns `SUSPICIOUS_NO_STRUCTURAL_CHANGE`.
 - **SECURE is structural, not full SAST.** Pair with dedicated security tooling for high-stakes code.
 - **`topos refactor` is advisory.** It does not replace `topos evaluate` for scoring.

--- a/topos/cli/src/commands/composable.rs
+++ b/topos/cli/src/commands/composable.rs
@@ -135,7 +135,7 @@ mod tests {
             .join(" ");
         assert!(
             src.contains("resolve_composable_mdg(")
-                && src.contains("args.gitnexus_dir.as_deref(), true,")
+                && src.contains("resolved_override.as_deref(), true,")
                 && src.contains("&mut on_phase"),
             "inspect must capture GitNexus output so it cannot corrupt the CLI renderer"
         );

--- a/topos/cli/src/commands/composable.rs
+++ b/topos/cli/src/commands/composable.rs
@@ -10,7 +10,7 @@ use topos_engine::adapters::gitnexus::{
     current_git_branch, gitnexus_compat_warning, resolve_lbug_store,
 };
 use topos_engine::graphs::mdg::object::ModuleDependencyGraph;
-use topos_mcp::evaluation::ensure_gitnexus_dir;
+use topos_mcp::evaluation::ensure_gitnexus_dir_with_progress;
 
 /// Ensure a fresh `.gitnexus` build exists for `project_root` and load its
 /// `ModuleDependencyGraph`, or return `None` (with an explanatory `stderr`
@@ -28,16 +28,21 @@ use topos_mcp::evaluation::ensure_gitnexus_dir;
 /// `quiet` captures GitNexus output. Machine-readable callers require this to
 /// keep stdout valid; interactive callers can also capture it while presenting
 /// their own stable progress indicator.
+///
+/// `progress` receives phase labels (`Checking dependency graph freshness`,
+/// `Running gitnexus analyze`) for spinner updates.
 pub(crate) fn resolve_composable_mdg(
     project_root: &Path,
     gitnexus_dir_override: Option<&str>,
     quiet: bool,
+    progress: &mut dyn FnMut(&'static str),
 ) -> Option<ModuleDependencyGraph> {
-    let outcome = ensure_gitnexus_dir(
+    let outcome = ensure_gitnexus_dir_with_progress(
         gitnexus_dir_override,
         project_root,
         /* skip = */ false,
         /* capture = */ quiet,
+        progress,
     );
     if let Some(note) = &outcome.generation_note {
         eprintln!("gitnexus: {note}");
@@ -107,7 +112,12 @@ mod tests {
         let project_root = temp_dir("root");
         let outside = temp_dir("outside");
 
-        let result = resolve_composable_mdg(&project_root, Some(&outside.to_string_lossy()), false);
+        let result = resolve_composable_mdg(
+            &project_root,
+            Some(&outside.to_string_lossy()),
+            false,
+            &mut |_| {},
+        );
         assert!(result.is_none());
 
         std::fs::remove_dir_all(&project_root).ok();
@@ -124,9 +134,9 @@ mod tests {
             .collect::<Vec<_>>()
             .join(" ");
         assert!(
-            src.contains(
-                "resolve_composable_mdg(&project_root, args.gitnexus_dir.as_deref(), true)"
-            ),
+            src.contains("resolve_composable_mdg(")
+                && src.contains("args.gitnexus_dir.as_deref(), true,")
+                && src.contains("&mut on_phase"),
             "inspect must capture GitNexus output so it cannot corrupt the CLI renderer"
         );
     }

--- a/topos/cli/src/commands/evaluate/mod.rs
+++ b/topos/cli/src/commands/evaluate/mod.rs
@@ -132,12 +132,21 @@ pub fn run(args: EvaluateArgs) -> Result<(), String> {
                     args.gitnexus_dir.as_deref(),
                     &cwd,
                 );
+                // Resolved to an absolute path against `cwd` — must be used
+                // here instead of `args.gitnexus_dir`, since `project_root`
+                // above already absorbed a relative override's subdirectory;
+                // rejoining the original relative string against it a second
+                // time would double that subdirectory.
+                let resolved_override = topos_mcp::evaluation::resolve_override_for_root(
+                    args.gitnexus_dir.as_deref(),
+                    &cwd,
+                );
                 let mut on_phase = |msg: &'static str| {
                     spinner.set_message(msg);
                 };
                 let graph = resolve_composable_mdg(
                     &project_root,
-                    args.gitnexus_dir.as_deref(),
+                    resolved_override.as_deref(),
                     true,
                     &mut on_phase,
                 );

--- a/topos/cli/src/commands/evaluate/mod.rs
+++ b/topos/cli/src/commands/evaluate/mod.rs
@@ -9,18 +9,18 @@
 //!
 //! Unless `--no-composable` is passed, this command also attempts to
 //! attach a [`ModuleDependencyGraph`] (COMPOSABLE generator): it checks
-//! whether `<cwd>/.gitnexus` (or `--gitnexus-dir`) is present and fresh,
-//! and if it's missing or stale, generates it by shelling out to
-//! `gitnexus analyze --skip-agents-md` behind a stable spinner. That
-//! resolve-or-generate decision is
-//! shared with the MCP evaluate tools via
-//! `topos_mcp::evaluation::ensure_gitnexus_dir`, so the CLI and MCP
-//! server standardize on one policy. Any failure here — GitNexus not
-//! installed, generation failing, a schema mismatch — degrades
-//! gracefully to SIMPLE/SECURE only with a one-line `stderr` notice; it
-//! never fails the whole evaluate run, matching how the MCP tools treat
-//! COMPOSABLE as "not measured" rather than "failed" when coupling data
-//! is unavailable.
+//! whether the COMPOSABLE project root's `.gitnexus` (default
+//! `<cwd>/.gitnexus`, or `--gitnexus-dir` whose parent becomes the project
+//! root) is present and fresh, and if it's missing or stale, generates it
+//! by shelling out to `gitnexus analyze --skip-agents-md` behind a stable
+//! spinner. That resolve-or-generate decision is shared with the MCP
+//! evaluate tools via `topos_mcp::evaluation::ensure_gitnexus_dir`, so the
+//! CLI and MCP server standardize on one policy. Any failure here —
+//! GitNexus not installed, generation failing, a schema mismatch —
+//! degrades gracefully to SIMPLE/SECURE only with a one-line `stderr`
+//! notice; it never fails the whole evaluate run, matching how the MCP
+//! tools treat COMPOSABLE as "not measured" rather than "failed" when
+//! coupling data is unavailable.
 //!
 //! [`ModuleDependencyGraph`]: topos_engine::graphs::mdg::object::ModuleDependencyGraph
 //! [`ProgramDependenceGraph`]: topos_engine::graphs::pdg::object::ProgramDependenceGraph
@@ -63,10 +63,10 @@ pub struct EvaluateArgs {
     /// Skip GitNexus detection/generation; score SIMPLE/SECURE only.
     #[arg(long)]
     pub no_composable: bool,
-    /// `.gitnexus` store under the process cwd (default: `<cwd>/.gitnexus`).
-    /// COMPOSABLE freshness/regeneration always use cwd as the project root —
-    /// run from the repo that owns the graph. This flag only selects the store
-    /// path; it does not change the root.
+    /// `.gitnexus` store path (default: `<cwd>/.gitnexus`). When set, COMPOSABLE
+    /// freshness and `gitnexus analyze` use the store's parent directory as the
+    /// project root — so `topos evaluate … --gitnexus-dir ~/repo/.gitnexus` from
+    /// `$HOME` fingerprints `~/repo`, not `$HOME`.
     #[arg(long)]
     pub gitnexus_dir: Option<String>,
     /// Show the full per-file classification and raw metrics.
@@ -125,11 +125,22 @@ pub fn run(args: EvaluateArgs) -> Result<(), String> {
     let mut mdg = if args.no_composable {
         None
     } else {
-        let spinner = spinner(args.json, "Checking dependency graph");
+        let spinner = spinner(args.json, "Checking dependency graph freshness");
         match std::env::current_dir() {
-            Ok(project_root) => {
-                let graph =
-                    resolve_composable_mdg(&project_root, args.gitnexus_dir.as_deref(), true);
+            Ok(cwd) => {
+                let project_root = topos_mcp::evaluation::resolve_composable_project_root(
+                    args.gitnexus_dir.as_deref(),
+                    &cwd,
+                );
+                let mut on_phase = |msg: &'static str| {
+                    spinner.set_message(msg);
+                };
+                let graph = resolve_composable_mdg(
+                    &project_root,
+                    args.gitnexus_dir.as_deref(),
+                    true,
+                    &mut on_phase,
+                );
                 spinner.finish_and_clear();
                 graph
             }

--- a/topos/cli/src/commands/inspect/mod.rs
+++ b/topos/cli/src/commands/inspect/mod.rs
@@ -59,12 +59,20 @@ pub fn run(args: InspectArgs) -> Result<(), String> {
                     args.gitnexus_dir.as_deref(),
                     &cwd,
                 );
+                // See the matching comment in evaluate/mod.rs: must use the
+                // resolved override, not `args.gitnexus_dir`, since a
+                // relative override's subdirectory is already baked into
+                // `project_root` above.
+                let resolved_override = topos_mcp::evaluation::resolve_override_for_root(
+                    args.gitnexus_dir.as_deref(),
+                    &cwd,
+                );
                 let mut on_phase = |msg: &'static str| {
                     progress.set_message(msg);
                 };
                 let graph = resolve_composable_mdg(
                     &project_root,
-                    args.gitnexus_dir.as_deref(),
+                    resolved_override.as_deref(),
                     true,
                     &mut on_phase,
                 );

--- a/topos/cli/src/commands/inspect/mod.rs
+++ b/topos/cli/src/commands/inspect/mod.rs
@@ -33,10 +33,8 @@ pub struct InspectArgs {
     /// Skip GitNexus detection/generation; inspect SIMPLE/SECURE only.
     #[arg(long)]
     pub no_composable: bool,
-    /// `.gitnexus` store under the process cwd (default: `<cwd>/.gitnexus`).
-    /// COMPOSABLE freshness/regeneration always use cwd as the project root —
-    /// run from the repo that owns the graph. This flag only selects the store
-    /// path; it does not change the root.
+    /// `.gitnexus` store path (default: `<cwd>/.gitnexus`). When set, COMPOSABLE
+    /// freshness and `gitnexus analyze` use the store's parent as the project root.
     #[arg(long)]
     pub gitnexus_dir: Option<String>,
 }
@@ -49,17 +47,27 @@ pub fn run(args: InspectArgs) -> Result<(), String> {
         .map_err(|e| format!("reading {}: {e}", args.path.display()))?;
     let classifier = CharacteristicMorphism;
     // Attach the COMPOSABLE MDG the same way `evaluate` does (auto-detect /
-    // generate `<cwd>/.gitnexus`, or `--gitnexus-dir`), so `inspect` reports
-    // COMPOSABLE too. Python's `inspect` fed `--gitnexus-dir` through the same
-    // `classify_file` pipeline as evaluate; `--no-composable` opts out.
+    // generate, or `--gitnexus-dir` deriving the project root), so `inspect`
+    // reports COMPOSABLE too. `--no-composable` opts out.
     let mut mdg = if args.no_composable {
         None
     } else {
-        let progress = spinner(args.json, "Checking dependency graph");
+        let progress = spinner(args.json, "Checking dependency graph freshness");
         match std::env::current_dir() {
-            Ok(project_root) => {
-                let graph =
-                    resolve_composable_mdg(&project_root, args.gitnexus_dir.as_deref(), true);
+            Ok(cwd) => {
+                let project_root = topos_mcp::evaluation::resolve_composable_project_root(
+                    args.gitnexus_dir.as_deref(),
+                    &cwd,
+                );
+                let mut on_phase = |msg: &'static str| {
+                    progress.set_message(msg);
+                };
+                let graph = resolve_composable_mdg(
+                    &project_root,
+                    args.gitnexus_dir.as_deref(),
+                    true,
+                    &mut on_phase,
+                );
                 progress.finish_and_clear();
                 graph
             }

--- a/topos/mcp/docs/content/agent-contract.md
+++ b/topos/mcp/docs/content/agent-contract.md
@@ -121,19 +121,18 @@ which never affects medals. See `topos://docs/workflows` § Advisory refactoring
 
 - COMPOSABLE is scored automatically — `topos_evaluate_file`/
   `topos_evaluate_project` detect and generate/refresh `.gitnexus` by
-  default (`gitnexus_dir` to point at a specific store under the project
-  root, `no_composable: true` to skip detection/generation). The project
-  root is the MCP **file root** (`TOPOS_MCP_FILE_ROOT`, else the server
-  cwd) — freshness fingerprints that whole tree, and regeneration runs
-  `gitnexus analyze` there. `gitnexus_dir` only selects the store path
-  inside that root; it does not retarget the root. For the CLI, the same
-  rule applies with **process cwd** as the root: run `topos evaluate` /
-  `inspect` from the repo that owns `.gitnexus`, not from `$HOME` or a
-  parent directory (a nested `--gitnexus-dir` still walks cwd and can
-  hang). If GitNexus isn't installed or generation fails, any verdict
-  containing COMPOSABLE, including `IDEAL`, is unreachable — check
-  `warnings` for why. `topos_depgraph_status` gives a read-only diagnosis
-  without triggering generation; force an explicit refresh with
+  default (`no_composable: true` to skip). When `gitnexus_dir` /
+  `--gitnexus-dir` is unset, the project root is the MCP **file root**
+  (`TOPOS_MCP_FILE_ROOT`, else server cwd) or the CLI **process cwd**.
+  When the override is set, the COMPOSABLE project root is the **parent
+  of that store path** (typically the parent of `.gitnexus`): freshness
+  and `gitnexus analyze` target that derived root, not cwd/file-root.
+  MCP still requires the store (and derived root) to stay inside the
+  file root; the CLI allows absolute overrides outside cwd. If GitNexus
+  isn't installed or generation fails, any verdict containing
+  COMPOSABLE, including `IDEAL`, is unreachable — check `warnings` for
+  why. `topos_depgraph_status` gives a read-only diagnosis without
+  triggering generation; force an explicit refresh with
   `topos_generate_depgraph` rather than shelling out yourself.
 - Use `allow` only for intentional dangerous calls. Acknowledged risks stay
   disclosed and can cap the grade.

--- a/topos/mcp/src/evaluation/mod.rs
+++ b/topos/mcp/src/evaluation/mod.rs
@@ -23,6 +23,8 @@ use std::path::{Path, PathBuf};
 
 use topos_engine::adapters::gitnexus::{generate_depgraph, gitnexus_available};
 
+use crate::security::resolve_existing_prefix;
+
 /// Stable prefixes shared by the producer (this module) and the
 /// agent-contract consumer (`formatting::composable_contract_signals`) so an
 /// invalid/denied override is matched on a single marker.
@@ -36,46 +38,39 @@ pub const BRANCH_NOT_INDEXED_MARKER: &str = "no gitnexus store indexed for branc
 /// Stable prefix for staleness warnings.
 pub const STALE_GITNEXUS_MARKER: &str = "gitnexus index may be stale";
 
-/// Resolve symlinks incrementally, one path component at a time, so a
-/// missing tail doesn't hide a symlink earlier in the path.
+/// Resolve `override_dir` (if any) into an absolute path: joining a relative
+/// override against `default_root` first, then following symlinks on the
+/// existing prefix (see [`crate::security::resolve_existing_prefix`]) so a
+/// not-yet-generated store path still resolves through any real symlink
+/// ahead of the missing tail. `None` when no override is given.
 ///
-/// A plain `canonicalize().unwrap_or_else(lexical_normalize)` is unsafe:
-/// when the full path doesn't exist yet (the common case for an
-/// as-yet-ungenerated `.gitnexus` store), lexical normalize never follows
-/// symlinks on the existing prefix, so `--gitnexus-dir linkdir/.gitnexus`
-/// with `linkdir` a symlink out of the trusted root would derive a project
-/// root that lexically looks contained but really isn't. Walking forwards
-/// and canonicalizing each existing segment as we go — falling back to
-/// lexical join/pop only once a segment is found missing — keeps this in
-/// sync with the equivalent fix in `topos_mcp::security::resolve_within_root`
-/// (topos/mcp/src/security.rs).
-fn resolve_existing_prefix(path: &Path) -> PathBuf {
-    use std::path::Component;
-    let mut resolved = PathBuf::new();
-    let mut past_missing = false;
-    for component in path.components() {
-        match component {
-            Component::CurDir => {}
-            Component::ParentDir => {
-                resolved.pop();
-            }
-            Component::Prefix(_) | Component::RootDir => resolved.push(component),
-            Component::Normal(name) => {
-                if past_missing {
-                    resolved.push(name);
-                    continue;
-                }
-                match resolved.join(name).canonicalize() {
-                    Ok(real) => resolved = real,
-                    Err(_) => {
-                        past_missing = true;
-                        resolved.push(name);
-                    }
-                }
-            }
-        }
-    }
-    resolved
+/// Downstream resolvers ([`resolve_gitnexus_dir`], [`check_override_warning`],
+/// [`depgraph_status`]) join a *relative* override against whatever project
+/// root they're handed. Once an override has been used to derive a
+/// non-default project root (see [`resolve_composable_project_root`]), that
+/// root has already absorbed the override's relative path — rejoining the
+/// original, still-relative string against it a second time would double it
+/// (`--gitnexus-dir repo/.gitnexus` from `$HOME` deriving root `$HOME/repo`,
+/// then rejoining `repo/.gitnexus` against that root, landing on
+/// `$HOME/repo/repo/.gitnexus`). Pass this function's result — already
+/// absolute — as the override for anything called alongside a project root
+/// derived from the same override, so it's used as-is instead of rejoined.
+pub fn resolve_override_for_root(
+    override_dir: Option<&str>,
+    default_root: &Path,
+) -> Option<String> {
+    let raw = override_dir?;
+    let path = PathBuf::from(raw);
+    let joined = if path.is_absolute() {
+        path
+    } else {
+        default_root.join(path)
+    };
+    Some(
+        resolve_existing_prefix(&joined)
+            .to_string_lossy()
+            .into_owned(),
+    )
 }
 
 /// Derive the COMPOSABLE **project root** used for freshness fingerprinting
@@ -85,24 +80,12 @@ fn resolve_existing_prefix(path: &Path) -> PathBuf {
 ///   project root is the parent of that store path (typically the parent of
 ///   `.gitnexus`). Relative overrides resolve against `default_root` first.
 /// - When unset, returns `default_root` (CLI cwd / MCP file root).
-pub fn resolve_composable_project_root(
-    override_dir: Option<&str>,
-    default_root: &Path,
-) -> PathBuf {
-    let Some(raw) = override_dir else {
+pub fn resolve_composable_project_root(override_dir: Option<&str>, default_root: &Path) -> PathBuf {
+    let Some(resolved) = resolve_override_for_root(override_dir, default_root) else {
         return default_root.to_path_buf();
     };
-    let path = PathBuf::from(raw);
-    let joined = if path.is_absolute() {
-        path
-    } else {
-        default_root.join(path)
-    };
-    let resolved = resolve_existing_prefix(&joined);
-    resolved
-        .parent()
-        .map(Path::to_path_buf)
-        .unwrap_or(resolved)
+    let resolved = PathBuf::from(resolved);
+    resolved.parent().map(Path::to_path_buf).unwrap_or(resolved)
 }
 
 /// MCP helper: same as [`resolve_composable_project_root`], but if a
@@ -189,8 +172,7 @@ pub fn ensure_gitnexus_dir_with_progress(
     skip: bool,
     capture: bool,
     progress: &mut dyn FnMut(&'static str),
-) -> GitnexusEnsureOutcome
-{
+) -> GitnexusEnsureOutcome {
     let resolve = || resolve_gitnexus_dir(override_dir, project_root);
     if skip {
         return GitnexusEnsureOutcome {
@@ -430,13 +412,53 @@ mod tests {
     }
 
     #[test]
+    fn resolve_gitnexus_dir_double_joins_a_relative_override_against_the_derived_root() {
+        // Documents the hazard resolve_override_for_root exists to route
+        // around: a *relative* override with a subdirectory component
+        // (e.g. `repo/.gitnexus` run from $HOME) re-joined against the
+        // project root resolve_composable_project_root already derived from
+        // it lands on `repo/repo/.gitnexus`, not the real store. Callers
+        // must use resolve_override_for_root's result (see the next test),
+        // never the original raw string, once a root has been derived.
+        let home = temp_dir("relative_override_double_join_home");
+        let repo = home.join("repo");
+        std::fs::create_dir_all(repo.join(".gitnexus")).unwrap();
+        let raw_override = "repo/.gitnexus";
+
+        let project_root = resolve_composable_project_root(Some(raw_override), &home);
+        assert_eq!(
+            resolve_gitnexus_dir(Some(raw_override), &project_root),
+            None,
+            "re-joining the raw relative override must miss the real store"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn resolve_override_for_root_avoids_the_double_join() {
+        let home = temp_dir("relative_override_fixed_home");
+        let repo = home.join("repo");
+        let store = repo.join(".gitnexus");
+        std::fs::create_dir_all(&store).unwrap();
+        let raw_override = "repo/.gitnexus";
+
+        let project_root = resolve_composable_project_root(Some(raw_override), &home);
+        let resolved_override = resolve_override_for_root(Some(raw_override), &home).unwrap();
+        assert_eq!(
+            resolve_gitnexus_dir(Some(&resolved_override), &project_root),
+            Some(store.canonicalize().unwrap()),
+            "the resolved (absolute) override must find the real store"
+        );
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
     fn resolve_mcp_composable_project_root_falls_back_when_override_escapes_file_root() {
         let file_root = temp_dir("mcp_file_root");
         let outside = temp_dir("mcp_outside_repo");
         let store = outside.join(".gitnexus");
         std::fs::create_dir_all(&store).unwrap();
-        let root =
-            resolve_mcp_composable_project_root(Some(store.to_str().unwrap()), &file_root);
+        let root = resolve_mcp_composable_project_root(Some(store.to_str().unwrap()), &file_root);
         assert_eq!(root, file_root);
         std::fs::remove_dir_all(&file_root).ok();
         std::fs::remove_dir_all(&outside).ok();
@@ -464,10 +486,8 @@ mod tests {
         std::os::unix::fs::symlink(&outside, &link).unwrap();
 
         let override_dir = link.join(".gitnexus");
-        let root = resolve_mcp_composable_project_root(
-            Some(override_dir.to_str().unwrap()),
-            &file_root,
-        );
+        let root =
+            resolve_mcp_composable_project_root(Some(override_dir.to_str().unwrap()), &file_root);
         assert_eq!(root, file_root);
         std::fs::remove_dir_all(&file_root).ok();
         std::fs::remove_dir_all(&outside).ok();

--- a/topos/mcp/src/evaluation/mod.rs
+++ b/topos/mcp/src/evaluation/mod.rs
@@ -36,6 +36,67 @@ pub const BRANCH_NOT_INDEXED_MARKER: &str = "no gitnexus store indexed for branc
 /// Stable prefix for staleness warnings.
 pub const STALE_GITNEXUS_MARKER: &str = "gitnexus index may be stale";
 
+/// Lexically normalize `..` / `.` without touching the filesystem.
+fn normalize_path(path: &Path) -> PathBuf {
+    use std::path::Component;
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::ParentDir => {
+                out.pop();
+            }
+            Component::CurDir => {}
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+/// Derive the COMPOSABLE **project root** used for freshness fingerprinting
+/// and `gitnexus analyze`.
+///
+/// - When `override_dir` (`--gitnexus-dir` / MCP `gitnexus_dir`) is set, the
+///   project root is the parent of that store path (typically the parent of
+///   `.gitnexus`). Relative overrides resolve against `default_root` first.
+/// - When unset, returns `default_root` (CLI cwd / MCP file root).
+pub fn resolve_composable_project_root(
+    override_dir: Option<&str>,
+    default_root: &Path,
+) -> PathBuf {
+    let Some(raw) = override_dir else {
+        return default_root.to_path_buf();
+    };
+    let path = PathBuf::from(raw);
+    let joined = if path.is_absolute() {
+        path
+    } else {
+        default_root.join(path)
+    };
+    let resolved = joined
+        .canonicalize()
+        .unwrap_or_else(|_| normalize_path(&joined));
+    resolved
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or(resolved)
+}
+
+/// MCP helper: same as [`resolve_composable_project_root`], but if a
+/// `gitnexus_dir` override would place the project root outside the trusted
+/// file root, fall back to `file_root` so existing invalid-override checks
+/// reject the store without fingerprinting an escaped tree.
+pub fn resolve_mcp_composable_project_root(
+    override_dir: Option<&str>,
+    file_root: &Path,
+) -> PathBuf {
+    let derived = resolve_composable_project_root(override_dir, file_root);
+    if override_dir.is_some() && !derived.starts_with(file_root) {
+        file_root.to_path_buf()
+    } else {
+        derived
+    }
+}
+
 /// Return the gitnexus dir to use, or None if not available.
 ///
 /// Preference: explicit override > `<project_root>/.gitnexus` if it exists.
@@ -92,6 +153,20 @@ pub fn ensure_gitnexus_dir(
     skip: bool,
     capture: bool,
 ) -> GitnexusEnsureOutcome {
+    ensure_gitnexus_dir_with_progress(override_dir, project_root, skip, capture, &mut |_| {})
+}
+
+/// Same as [`ensure_gitnexus_dir`], invoking `progress` with stable phase
+/// labels so CLI spinners can distinguish freshness checks from
+/// `gitnexus analyze`.
+pub fn ensure_gitnexus_dir_with_progress(
+    override_dir: Option<&str>,
+    project_root: &Path,
+    skip: bool,
+    capture: bool,
+    progress: &mut dyn FnMut(&'static str),
+) -> GitnexusEnsureOutcome
+{
     let resolve = || resolve_gitnexus_dir(override_dir, project_root);
     if skip {
         return GitnexusEnsureOutcome {
@@ -100,6 +175,7 @@ pub fn ensure_gitnexus_dir(
         };
     }
 
+    progress("Checking dependency graph freshness");
     let status = depgraph_status(override_dir, project_root, &project_root.to_string_lossy());
     if !matches!(status.state, "missing" | "stale") {
         // present, or a problem generating won't fix (invalid_dir,
@@ -122,6 +198,7 @@ pub fn ensure_gitnexus_dir(
         };
     }
 
+    progress("Running gitnexus analyze");
     let result = generate_depgraph(project_root, capture, None);
     let generation_note = (!result.ok).then(|| generation_failure_note(&result.message));
     GitnexusEnsureOutcome {
@@ -304,6 +381,41 @@ mod tests {
         ));
         std::fs::create_dir_all(&dir).unwrap();
         dir
+    }
+
+    #[test]
+    fn resolve_composable_project_root_uses_default_without_override() {
+        let home = temp_dir("home_default");
+        let root = resolve_composable_project_root(None, &home);
+        assert_eq!(root, home);
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn resolve_composable_project_root_derives_parent_of_gitnexus_dir() {
+        // From $HOME with --gitnexus-dir <repo>/.gitnexus, fingerprint/analyze
+        // must target <repo>, not $HOME.
+        let home = temp_dir("home_parent");
+        let repo = home.join("phil");
+        let store = repo.join(".gitnexus");
+        std::fs::create_dir_all(&store).unwrap();
+        let root = resolve_composable_project_root(Some(store.to_str().unwrap()), &home);
+        assert_eq!(root, repo.canonicalize().unwrap());
+        assert_ne!(root, home.canonicalize().unwrap());
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    #[test]
+    fn resolve_mcp_composable_project_root_falls_back_when_override_escapes_file_root() {
+        let file_root = temp_dir("mcp_file_root");
+        let outside = temp_dir("mcp_outside_repo");
+        let store = outside.join(".gitnexus");
+        std::fs::create_dir_all(&store).unwrap();
+        let root =
+            resolve_mcp_composable_project_root(Some(store.to_str().unwrap()), &file_root);
+        assert_eq!(root, file_root);
+        std::fs::remove_dir_all(&file_root).ok();
+        std::fs::remove_dir_all(&outside).ok();
     }
 
     #[test]

--- a/topos/mcp/src/evaluation/mod.rs
+++ b/topos/mcp/src/evaluation/mod.rs
@@ -36,20 +36,46 @@ pub const BRANCH_NOT_INDEXED_MARKER: &str = "no gitnexus store indexed for branc
 /// Stable prefix for staleness warnings.
 pub const STALE_GITNEXUS_MARKER: &str = "gitnexus index may be stale";
 
-/// Lexically normalize `..` / `.` without touching the filesystem.
-fn normalize_path(path: &Path) -> PathBuf {
+/// Resolve symlinks incrementally, one path component at a time, so a
+/// missing tail doesn't hide a symlink earlier in the path.
+///
+/// A plain `canonicalize().unwrap_or_else(lexical_normalize)` is unsafe:
+/// when the full path doesn't exist yet (the common case for an
+/// as-yet-ungenerated `.gitnexus` store), lexical normalize never follows
+/// symlinks on the existing prefix, so `--gitnexus-dir linkdir/.gitnexus`
+/// with `linkdir` a symlink out of the trusted root would derive a project
+/// root that lexically looks contained but really isn't. Walking forwards
+/// and canonicalizing each existing segment as we go — falling back to
+/// lexical join/pop only once a segment is found missing — keeps this in
+/// sync with the equivalent fix in `topos_mcp::security::resolve_within_root`
+/// (topos/mcp/src/security.rs).
+fn resolve_existing_prefix(path: &Path) -> PathBuf {
     use std::path::Component;
-    let mut out = PathBuf::new();
+    let mut resolved = PathBuf::new();
+    let mut past_missing = false;
     for component in path.components() {
         match component {
-            Component::ParentDir => {
-                out.pop();
-            }
             Component::CurDir => {}
-            other => out.push(other),
+            Component::ParentDir => {
+                resolved.pop();
+            }
+            Component::Prefix(_) | Component::RootDir => resolved.push(component),
+            Component::Normal(name) => {
+                if past_missing {
+                    resolved.push(name);
+                    continue;
+                }
+                match resolved.join(name).canonicalize() {
+                    Ok(real) => resolved = real,
+                    Err(_) => {
+                        past_missing = true;
+                        resolved.push(name);
+                    }
+                }
+            }
         }
     }
-    out
+    resolved
 }
 
 /// Derive the COMPOSABLE **project root** used for freshness fingerprinting
@@ -72,9 +98,7 @@ pub fn resolve_composable_project_root(
     } else {
         default_root.join(path)
     };
-    let resolved = joined
-        .canonicalize()
-        .unwrap_or_else(|_| normalize_path(&joined));
+    let resolved = resolve_existing_prefix(&joined);
     resolved
         .parent()
         .map(Path::to_path_buf)
@@ -413,6 +437,37 @@ mod tests {
         std::fs::create_dir_all(&store).unwrap();
         let root =
             resolve_mcp_composable_project_root(Some(store.to_str().unwrap()), &file_root);
+        assert_eq!(root, file_root);
+        std::fs::remove_dir_all(&file_root).ok();
+        std::fs::remove_dir_all(&outside).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_mcp_composable_project_root_falls_back_when_override_escapes_via_symlink() {
+        // Regression: a gitnexus_dir override through a symlinked directory
+        // whose store doesn't exist yet used to canonicalize-fail on the
+        // whole path and fall back to lexical normalize, which never
+        // follows the symlink — so `linkdir/.gitnexus` (linkdir -> outside)
+        // derived a project root that lexically looked contained under
+        // file_root but really resolved outside it.
+        // Callers always pass an already-canonical file_root (resolve_file_root()
+        // canonicalizes), so canonicalize it here too — on macOS /tmp itself is
+        // a symlink (/var -> /private/var), and comparing a raw temp_dir()
+        // path against a canonicalized derived path would spuriously "escape"
+        // on that alone, masking the real symlink-escape behavior under test.
+        let file_root = temp_dir("mcp_symlink_file_root").canonicalize().unwrap();
+        let outside = temp_dir("mcp_symlink_outside_secret")
+            .canonicalize()
+            .unwrap();
+        let link = file_root.join("linkdir");
+        std::os::unix::fs::symlink(&outside, &link).unwrap();
+
+        let override_dir = link.join(".gitnexus");
+        let root = resolve_mcp_composable_project_root(
+            Some(override_dir.to_str().unwrap()),
+            &file_root,
+        );
         assert_eq!(root, file_root);
         std::fs::remove_dir_all(&file_root).ok();
         std::fs::remove_dir_all(&outside).ok();

--- a/topos/mcp/src/schemas.rs
+++ b/topos/mcp/src/schemas.rs
@@ -562,9 +562,15 @@ pub struct DepgraphStatusInput {
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct GenerateDepgraphInput {
-    /// Repo root (default: MCP file root).
+    /// Repo root to analyze (default: derived from `gitnexus_dir` when set,
+    /// otherwise the MCP file root). Explicit `directory` wins over derivation.
     #[serde(default)]
     pub directory: Option<String>,
+    /// `.gitnexus` store under the MCP file root. When `directory` is omitted,
+    /// the analyze root is the parent of this path — same derivation
+    /// `topos_depgraph_status` uses — so status → generate stay aligned.
+    #[serde(default)]
+    pub gitnexus_dir: Option<String>,
     /// Regenerate even when current.
     #[serde(default)]
     pub force: bool,
@@ -1383,6 +1389,34 @@ mod tests {
                 "`{field}` missing from the published InspectCodeInput schema"
             );
         }
+    }
+
+    #[test]
+    fn generate_depgraph_accepts_and_advertises_gitnexus_dir() {
+        let defaulted: GenerateDepgraphInput =
+            serde_json::from_str(r#"{}"#).expect("deserialize");
+        assert!(defaulted.gitnexus_dir.is_none());
+        assert!(defaulted.directory.is_none());
+        assert!(!defaulted.force);
+
+        let explicit: GenerateDepgraphInput = serde_json::from_str(
+            r#"{"directory": "nested", "gitnexus_dir": "nested/.gitnexus", "force": true}"#,
+        )
+        .expect("deserialize");
+        assert_eq!(explicit.directory.as_deref(), Some("nested"));
+        assert_eq!(explicit.gitnexus_dir.as_deref(), Some("nested/.gitnexus"));
+        assert!(explicit.force);
+
+        let schema = serde_json::to_value(schemars::schema_for!(GenerateDepgraphInput))
+            .expect("schema serializes");
+        let properties = schema
+            .get("properties")
+            .and_then(|p| p.as_object())
+            .expect("object schema with properties");
+        assert!(
+            properties.contains_key("gitnexus_dir"),
+            "`gitnexus_dir` missing from GenerateDepgraphInput schema"
+        );
     }
 
     /// The empty-field policy, asserted as a property rather than per

--- a/topos/mcp/src/security.rs
+++ b/topos/mcp/src/security.rs
@@ -71,7 +71,7 @@ pub fn resolve_file_root() -> Result<PathBuf, String> {
 /// found not to exist, nothing after it can be a symlink either, so the
 /// remaining components (including any `..`) are safe to apply lexically
 /// against the already-resolved real prefix.
-fn resolve_existing_prefix(path: &Path) -> PathBuf {
+pub(crate) fn resolve_existing_prefix(path: &Path) -> PathBuf {
     let mut resolved = PathBuf::new();
     let mut past_missing = false;
     for component in path.components() {
@@ -169,10 +169,8 @@ mod tests {
 
     #[test]
     fn missing_in_root_leaf_is_allowed() {
-        let dir = std::env::temp_dir().join(format!(
-            "topos-security-missing-{}",
-            std::process::id()
-        ));
+        let dir =
+            std::env::temp_dir().join(format!("topos-security-missing-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         let root = dir.canonicalize().unwrap();
@@ -185,10 +183,8 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn symlink_escape_via_missing_leaf_is_denied() {
-        let dir = std::env::temp_dir().join(format!(
-            "topos-security-symlink-{}",
-            std::process::id()
-        ));
+        let dir =
+            std::env::temp_dir().join(format!("topos-security-symlink-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         let root_path = dir.join("proj");
         std::fs::create_dir_all(&root_path).unwrap();

--- a/topos/mcp/src/security.rs
+++ b/topos/mcp/src/security.rs
@@ -68,18 +68,59 @@ fn normalize(path: &Path) -> PathBuf {
     out
 }
 
-/// Resolve a path (absolute or root-relative) and check it's inside the
-/// root, without reading it. Symlinks are resolved when the path exists.
-pub fn resolve_within_root(filepath: &str) -> Result<PathBuf, String> {
-    let root = resolve_file_root()?;
+/// Resolve symlinks on the longest existing prefix, then re-append any
+/// missing tail — matching Python `Path.resolve(strict=False)`.
+///
+/// A plain `canonicalize().unwrap_or_else(normalize)` is unsafe: when the
+/// leaf is missing, lexical normalize does not follow symlinks on the
+/// existing prefix, so `/proj/link/newfile` with `link → /etc` would be
+/// accepted under root `/proj`.
+fn resolve_existing_prefix(path: &Path) -> PathBuf {
+    let mut existing = path.to_path_buf();
+    let mut missing: Vec<std::ffi::OsString> = Vec::new();
+    while !existing.as_os_str().is_empty() && !existing.exists() {
+        match existing.file_name() {
+            Some(name) => {
+                missing.push(name.to_os_string());
+                if !existing.pop() {
+                    break;
+                }
+            }
+            None => break,
+        }
+    }
+
+    let mut resolved = if existing.as_os_str().is_empty() || !existing.exists() {
+        normalize(path)
+    } else {
+        existing
+            .canonicalize()
+            .unwrap_or_else(|_| normalize(&existing))
+    };
+
+    for part in missing.into_iter().rev() {
+        if part == "." {
+            continue;
+        }
+        if part == ".." {
+            resolved.pop();
+            continue;
+        }
+        resolved.push(part);
+    }
+    resolved
+}
+
+/// Resolve `filepath` against `root` and reject paths that escape it.
+pub(crate) fn resolve_path_within(filepath: &str, root: &Path) -> Result<PathBuf, String> {
     let path = Path::new(filepath);
     let joined = if path.is_absolute() {
         path.to_path_buf()
     } else {
         root.join(path)
     };
-    let resolved = joined.canonicalize().unwrap_or_else(|_| normalize(&joined));
-    if resolved.starts_with(&root) {
+    let resolved = resolve_existing_prefix(&joined);
+    if resolved.starts_with(root) {
         Ok(resolved)
     } else {
         Err(format!(
@@ -88,6 +129,14 @@ pub fn resolve_within_root(filepath: &str) -> Result<PathBuf, String> {
             resolved.display()
         ))
     }
+}
+
+/// Resolve a path (absolute or root-relative) and check it's inside the
+/// root, without reading it. Symlinks on an existing prefix are resolved
+/// even when the final component is missing.
+pub fn resolve_within_root(filepath: &str) -> Result<PathBuf, String> {
+    let root = resolve_file_root()?;
+    resolve_path_within(filepath, &root)
 }
 
 /// Read a UTF-8 file if it is within the configured root.
@@ -136,5 +185,40 @@ mod tests {
         // sufficiently deep ../ chain always escapes it.
         let err = resolve_within_root("../../../../../../../../etc/passwd").unwrap_err();
         assert!(err.contains("Access denied"), "{err}");
+    }
+
+    #[test]
+    fn missing_in_root_leaf_is_allowed() {
+        let dir = std::env::temp_dir().join(format!(
+            "topos-security-missing-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let root = dir.canonicalize().unwrap();
+        let missing = root.join("does-not-exist-yet.rs");
+        let resolved = resolve_path_within(missing.to_str().unwrap(), &root).unwrap();
+        assert_eq!(resolved, missing);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_escape_via_missing_leaf_is_denied() {
+        let dir = std::env::temp_dir().join(format!(
+            "topos-security-symlink-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        let root_path = dir.join("proj");
+        std::fs::create_dir_all(&root_path).unwrap();
+        let root = root_path.canonicalize().unwrap();
+        let link = root.join("link");
+        std::os::unix::fs::symlink("/etc", &link).unwrap();
+        let request = link.join("newfile");
+        let err = resolve_path_within(request.to_str().unwrap(), &root).unwrap_err();
+        assert!(err.contains("Access denied"), "{err}");
+        assert!(err.contains("/etc"), "{err}");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/topos/mcp/src/security.rs
+++ b/topos/mcp/src/security.rs
@@ -52,61 +52,49 @@ pub fn resolve_file_root() -> Result<PathBuf, String> {
     FILE_ROOT.get_or_init(compute_file_root).clone()
 }
 
-/// Lexically normalize `..` / `.` components without touching the
-/// filesystem, so a non-existent path can still be checked against the root.
-fn normalize(path: &Path) -> PathBuf {
-    let mut out = PathBuf::new();
-    for component in path.components() {
-        match component {
-            Component::ParentDir => {
-                out.pop();
-            }
-            Component::CurDir => {}
-            other => out.push(other),
-        }
-    }
-    out
-}
-
-/// Resolve symlinks on the longest existing prefix, then re-append any
-/// missing tail — matching Python `Path.resolve(strict=False)`.
+/// Resolve symlinks incrementally, one path component at a time, matching
+/// Python `Path.resolve(strict=False)`.
 ///
 /// A plain `canonicalize().unwrap_or_else(normalize)` is unsafe: when the
 /// leaf is missing, lexical normalize does not follow symlinks on the
 /// existing prefix, so `/proj/link/newfile` with `link → /etc` would be
 /// accepted under root `/proj`.
+///
+/// The previous fix for that walked the path *backwards* from the leaf,
+/// popping components until it found one that existed. That breaks as soon
+/// as a `..` component is involved: `Path::file_name()` returns `None` when
+/// the last component is `..`, so the walk bailed out to the same unsafe
+/// whole-path lexical normalize it was meant to replace — e.g.
+/// `/proj/link/subdir/../newfile` (an existing `link` symlink, missing
+/// `subdir`) was silently accepted even though it really resolves outside
+/// `/proj`. Walking *forwards* instead avoids that: once a component is
+/// found not to exist, nothing after it can be a symlink either, so the
+/// remaining components (including any `..`) are safe to apply lexically
+/// against the already-resolved real prefix.
 fn resolve_existing_prefix(path: &Path) -> PathBuf {
-    let mut existing = path.to_path_buf();
-    let mut missing: Vec<std::ffi::OsString> = Vec::new();
-    while !existing.as_os_str().is_empty() && !existing.exists() {
-        match existing.file_name() {
-            Some(name) => {
-                missing.push(name.to_os_string());
-                if !existing.pop() {
-                    break;
+    let mut resolved = PathBuf::new();
+    let mut past_missing = false;
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                resolved.pop();
+            }
+            Component::Prefix(_) | Component::RootDir => resolved.push(component),
+            Component::Normal(name) => {
+                if past_missing {
+                    resolved.push(name);
+                    continue;
+                }
+                match resolved.join(name).canonicalize() {
+                    Ok(real) => resolved = real,
+                    Err(_) => {
+                        past_missing = true;
+                        resolved.push(name);
+                    }
                 }
             }
-            None => break,
         }
-    }
-
-    let mut resolved = if existing.as_os_str().is_empty() || !existing.exists() {
-        normalize(path)
-    } else {
-        existing
-            .canonicalize()
-            .unwrap_or_else(|_| normalize(&existing))
-    };
-
-    for part in missing.into_iter().rev() {
-        if part == "." {
-            continue;
-        }
-        if part == ".." {
-            resolved.pop();
-            continue;
-        }
-        resolved.push(part);
     }
     resolved
 }
@@ -172,14 +160,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn normalize_collapses_parent_components() {
-        assert_eq!(
-            normalize(Path::new("/a/b/../c/./d")),
-            PathBuf::from("/a/c/d")
-        );
-    }
-
-    #[test]
     fn escape_via_dotdot_is_denied() {
         // The root is this repo (auto-detected or env-provided); a
         // sufficiently deep ../ chain always escapes it.
@@ -219,6 +199,38 @@ mod tests {
         let err = resolve_path_within(request.to_str().unwrap(), &root).unwrap_err();
         assert!(err.contains("Access denied"), "{err}");
         assert!(err.contains("/etc"), "{err}");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_escape_via_dotdot_and_missing_intermediate_is_denied() {
+        // Regression: the backward-walk implementation bailed to whole-path
+        // lexical normalize as soon as it hit a `..` component, silently
+        // accepting escapes like `link/subdir/../newfile` where `subdir`
+        // doesn't exist under the symlink target.
+        let dir = std::env::temp_dir().join(format!(
+            "topos-security-dotdot-symlink-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        let root_path = dir.join("proj");
+        std::fs::create_dir_all(&root_path).unwrap();
+        let root = root_path.canonicalize().unwrap();
+        let outside = dir.join("outside");
+        std::fs::create_dir_all(&outside).unwrap();
+        let outside = outside.canonicalize().unwrap();
+        let link = root.join("link");
+        std::os::unix::fs::symlink(&outside, &link).unwrap();
+
+        let request = format!("{}/subdir/../newfile", link.display());
+        let err = resolve_path_within(&request, &root).unwrap_err();
+        assert!(err.contains("Access denied"), "{err}");
+        assert!(
+            err.contains(&outside.display().to_string()),
+            "expected resolved path under {}, got: {err}",
+            outside.display()
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/topos/mcp/src/tools/assess.rs
+++ b/topos/mcp/src/tools/assess.rs
@@ -22,6 +22,7 @@ use topos_engine::functors::profunctors::ast::compare::calculate_ast_distance;
 use crate::diagnostics::{overlay_for_source, SecurityOverlay};
 use crate::evaluation::{
     classify_morphism, detect_language, gitnexus_warnings, load_dep_graph, resolve_gitnexus_dir,
+    resolve_override_for_root,
 };
 use crate::formatting::{
     composable_contract_signals, to_evaluation_result, to_tool_result, EvalResultOptions,
@@ -584,11 +585,18 @@ fn load_baseline(params: &AssessImprovementInput) -> Result<Baseline, String> {
             params.gitnexus_dir.as_deref(),
             &file_root,
         );
-        let gitnexus_dir = resolve_gitnexus_dir(params.gitnexus_dir.as_deref(), &project_root);
+        // Resolved to an absolute path against `file_root` — must be used
+        // below instead of `params.gitnexus_dir`, since `project_root` above
+        // already absorbed a relative override's subdirectory; rejoining the
+        // original relative string against it a second time would double
+        // that subdirectory.
+        let resolved_override =
+            resolve_override_for_root(params.gitnexus_dir.as_deref(), &file_root);
+        let gitnexus_dir = resolve_gitnexus_dir(resolved_override.as_deref(), &project_root);
         let (dep_graph, load_error) =
             load_dep_graph(gitnexus_dir.as_deref(), &resolved.to_string_lossy());
         let warnings = gitnexus_warnings(
-            params.gitnexus_dir.as_deref(),
+            resolved_override.as_deref(),
             &project_root,
             gitnexus_dir.as_deref(),
             dep_graph.is_some(),
@@ -643,19 +651,24 @@ fn assess_edit_in_place(
         Ok(src) => src,
         Err(err) => return err_assessment(priority, priority_source, err, "file_not_found"),
     };
-    let project_root = match resolve_file_root() {
-        Ok(root) => crate::evaluation::resolve_mcp_composable_project_root(
-            gitnexus_dir_override,
-            &root,
-        ),
+    let file_root = match resolve_file_root() {
+        Ok(root) => root,
         Err(err) => return err_assessment(priority, priority_source, err, "assessment_error"),
     };
-    let gitnexus_dir = resolve_gitnexus_dir(gitnexus_dir_override, &project_root);
+    let project_root =
+        crate::evaluation::resolve_mcp_composable_project_root(gitnexus_dir_override, &file_root);
+    // Resolved to an absolute path against `file_root` — must be used below
+    // instead of `gitnexus_dir_override`, since `project_root` above already
+    // absorbed a relative override's subdirectory; rejoining the original
+    // relative string against it a second time would double that
+    // subdirectory.
+    let resolved_override = resolve_override_for_root(gitnexus_dir_override, &file_root);
+    let gitnexus_dir = resolve_gitnexus_dir(resolved_override.as_deref(), &project_root);
     let (dep_graph, load_error) =
         load_dep_graph(gitnexus_dir.as_deref(), &resolved_path.to_string_lossy());
     let mut warnings = extra_warnings;
     warnings.extend(gitnexus_warnings(
-        gitnexus_dir_override,
+        resolved_override.as_deref(),
         &project_root,
         gitnexus_dir.as_deref(),
         dep_graph.is_some(),
@@ -1360,17 +1373,25 @@ impl ToposServer {
             .preferences
             .as_ref()
             .and_then(|p| p.to_preferences().ok());
-        let project_root = match resolve_file_root() {
-            Ok(root) => crate::evaluation::resolve_mcp_composable_project_root(
-                params.gitnexus_dir.as_deref(),
-                &root,
-            ),
+        let file_root = match resolve_file_root() {
+            Ok(root) => root,
             Err(err) => {
                 let model = changeset_error(priority, priority_source, &params.baseline_ref, err);
                 return to_tool_result(&model, render_changeset_md(&model));
             }
         };
-        let gitnexus_dir = resolve_gitnexus_dir(params.gitnexus_dir.as_deref(), &project_root);
+        let project_root = crate::evaluation::resolve_mcp_composable_project_root(
+            params.gitnexus_dir.as_deref(),
+            &file_root,
+        );
+        // Resolved to an absolute path against `file_root` — must be used
+        // below instead of `params.gitnexus_dir`, since `project_root` above
+        // already absorbed a relative override's subdirectory; rejoining the
+        // original relative string against it a second time would double
+        // that subdirectory.
+        let resolved_override =
+            resolve_override_for_root(params.gitnexus_dir.as_deref(), &file_root);
+        let gitnexus_dir = resolve_gitnexus_dir(resolved_override.as_deref(), &project_root);
 
         let mut entries: Vec<ChangesetFileEntry> = Vec::new();
         let mut before_evals: Vec<EvaluationResult> = Vec::new();
@@ -1407,7 +1428,7 @@ impl ToposServer {
 
         let load_error_placeholder = None;
         let warnings = gitnexus_warnings(
-            params.gitnexus_dir.as_deref(),
+            resolved_override.as_deref(),
             &project_root,
             gitnexus_dir.as_deref(),
             any_coupling,

--- a/topos/mcp/src/tools/assess.rs
+++ b/topos/mcp/src/tools/assess.rs
@@ -579,7 +579,11 @@ fn load_baseline(params: &AssessImprovementInput) -> Result<Baseline, String> {
             return Err(format!("Path is not a file: {}", resolved.display()));
         }
         let current_src = read_safe_utf8_file(filepath)?;
-        let project_root = resolve_file_root()?;
+        let file_root = resolve_file_root()?;
+        let project_root = crate::evaluation::resolve_mcp_composable_project_root(
+            params.gitnexus_dir.as_deref(),
+            &file_root,
+        );
         let gitnexus_dir = resolve_gitnexus_dir(params.gitnexus_dir.as_deref(), &project_root);
         let (dep_graph, load_error) =
             load_dep_graph(gitnexus_dir.as_deref(), &resolved.to_string_lossy());
@@ -640,7 +644,10 @@ fn assess_edit_in_place(
         Err(err) => return err_assessment(priority, priority_source, err, "file_not_found"),
     };
     let project_root = match resolve_file_root() {
-        Ok(root) => root,
+        Ok(root) => crate::evaluation::resolve_mcp_composable_project_root(
+            gitnexus_dir_override,
+            &root,
+        ),
         Err(err) => return err_assessment(priority, priority_source, err, "assessment_error"),
     };
     let gitnexus_dir = resolve_gitnexus_dir(gitnexus_dir_override, &project_root);
@@ -1354,7 +1361,10 @@ impl ToposServer {
             .as_ref()
             .and_then(|p| p.to_preferences().ok());
         let project_root = match resolve_file_root() {
-            Ok(root) => root,
+            Ok(root) => crate::evaluation::resolve_mcp_composable_project_root(
+                params.gitnexus_dir.as_deref(),
+                &root,
+            ),
             Err(err) => {
                 let model = changeset_error(priority, priority_source, &params.baseline_ref, err);
                 return to_tool_result(&model, render_changeset_md(&model));

--- a/topos/mcp/src/tools/depgraph.rs
+++ b/topos/mcp/src/tools/depgraph.rs
@@ -38,6 +38,26 @@ fn resolve_generate_project_root(
     }
 }
 
+/// Choose the `gitnexus_dir` override to pass to [`depgraph_status`]
+/// alongside the root [`resolve_generate_project_root`] just derived.
+///
+/// Only when that root was itself derived from `gitnexus_dir` (no explicit
+/// `directory`) has it already absorbed a relative override's subdirectory
+/// — rejoining the raw override against it would then double that
+/// subdirectory, so resolve it to an absolute path first in that case. An
+/// explicit `directory` is independent of `gitnexus_dir`, so the raw
+/// (still relative-to-`directory`) override is correct as-is there.
+fn resolve_generate_status_override(
+    directory: Option<&Path>,
+    gitnexus_dir: Option<&str>,
+    file_root: &Path,
+) -> Option<String> {
+    match directory {
+        Some(_) => gitnexus_dir.map(str::to_string),
+        None => resolve_override_for_root(gitnexus_dir, file_root),
+    }
+}
+
 fn parse_state(state: &str) -> DepgraphState {
     match state {
         "missing" => DepgraphState::Missing,
@@ -387,18 +407,11 @@ impl ToposServer {
             params.gitnexus_dir.as_deref(),
             &file_root,
         );
-        // Only when `target_dir` was itself derived from `gitnexus_dir`
-        // (no explicit `directory`) does it already absorb a relative
-        // override's subdirectory — rejoining the raw override against it
-        // would then double that subdirectory, so resolve it first in that
-        // case. An explicit `directory` is independent of `gitnexus_dir`,
-        // so the raw (still relative-to-`target_dir`) override is correct
-        // as-is there.
-        let status_override = if resolved_directory.is_none() {
-            resolve_override_for_root(params.gitnexus_dir.as_deref(), &file_root)
-        } else {
-            params.gitnexus_dir.clone()
-        };
+        let status_override = resolve_generate_status_override(
+            resolved_directory.as_deref(),
+            params.gitnexus_dir.as_deref(),
+            &file_root,
+        );
 
         let mut state_before = None;
         if !params.force {
@@ -624,6 +637,44 @@ mod tests {
             &file_root,
         );
         assert_eq!(explicit, file_root);
+
+        std::fs::remove_dir_all(&file_root).ok();
+    }
+
+    #[test]
+    fn resolve_generate_status_override_matches_the_root_it_pairs_with() {
+        // Regression: `depgraph_status` re-joins a *relative* override
+        // against whatever root it's given. When `directory` is omitted,
+        // `resolve_generate_project_root` derives a root from a relative
+        // `gitnexus_dir` with a subdirectory (e.g. `repo/.gitnexus`) — so
+        // the override paired with it must already be resolved to an
+        // absolute path, or the subdirectory doubles
+        // (`repo/.gitnexus` -> `repo/repo/.gitnexus`).
+        let file_root = std::env::temp_dir().join(format!(
+            "topos_generate_status_override_{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(file_root.join("repo/.gitnexus")).unwrap();
+        let file_root = file_root.canonicalize().unwrap();
+        let raw_override = "repo/.gitnexus";
+
+        let derived_override =
+            resolve_generate_status_override(None, Some(raw_override), &file_root);
+        assert_eq!(
+            derived_override.as_deref(),
+            file_root.join("repo/.gitnexus").to_str(),
+            "must resolve to the real store, not double the subdirectory"
+        );
+
+        // An explicit `directory` is independent of `gitnexus_dir` — pass
+        // the raw override through unresolved, still relative to that
+        // directory.
+        let explicit_override = resolve_generate_status_override(
+            Some(file_root.as_path()),
+            Some(raw_override),
+            &file_root,
+        );
+        assert_eq!(explicit_override.as_deref(), Some(raw_override));
 
         std::fs::remove_dir_all(&file_root).ok();
     }

--- a/topos/mcp/src/tools/depgraph.rs
+++ b/topos/mcp/src/tools/depgraph.rs
@@ -278,7 +278,10 @@ impl ToposServer {
         Parameters(params): Parameters<DepgraphStatusInput>,
     ) -> CallToolResult {
         let project_root = match resolve_file_root() {
-            Ok(root) => root,
+            Ok(root) => crate::evaluation::resolve_mcp_composable_project_root(
+                params.gitnexus_dir.as_deref(),
+                &root,
+            ),
             Err(err) => {
                 let model = status_error(err);
                 let md = render_status_md(&model);

--- a/topos/mcp/src/tools/depgraph.rs
+++ b/topos/mcp/src/tools/depgraph.rs
@@ -10,7 +10,9 @@ use rmcp::model::CallToolResult;
 use rmcp::{tool, tool_router};
 use topos_engine::adapters::gitnexus::generate_depgraph;
 
-use crate::evaluation::{cap_generation_detail, depgraph_status, DepgraphStatus};
+use crate::evaluation::{
+    cap_generation_detail, depgraph_status, resolve_mcp_composable_project_root, DepgraphStatus,
+};
 use crate::formatting::to_tool_result;
 use crate::schemas::{
     AgentContract, DepgraphState, DepgraphStatusInput, DepgraphStatusResult, GenerateDepgraphInput,
@@ -18,6 +20,22 @@ use crate::schemas::{
 };
 use crate::security::{resolve_file_root, resolve_within_root};
 use crate::server::ToposServer;
+use std::path::{Path, PathBuf};
+
+/// Choose the analyze root for `topos_generate_depgraph`.
+///
+/// Explicit `directory` wins. When omitted, derive from `gitnexus_dir` the
+/// same way `topos_depgraph_status` does so status → generate stay aligned.
+fn resolve_generate_project_root(
+    directory: Option<&Path>,
+    gitnexus_dir: Option<&str>,
+    file_root: &Path,
+) -> PathBuf {
+    match directory {
+        Some(dir) => dir.to_path_buf(),
+        None => resolve_mcp_composable_project_root(gitnexus_dir, file_root),
+    }
+}
 
 fn parse_state(state: &str) -> DepgraphState {
     match state {
@@ -324,7 +342,7 @@ impl ToposServer {
         &self,
         Parameters(params): Parameters<GenerateDepgraphInput>,
     ) -> CallToolResult {
-        let project_root = match resolve_file_root() {
+        let file_root = match resolve_file_root() {
             Ok(root) => root,
             Err(err) => {
                 let model = generate_error(err);
@@ -332,9 +350,16 @@ impl ToposServer {
                 return to_tool_result(&model, md);
             }
         };
-        let target_dir = match &params.directory {
+        if let Some(dir) = &params.gitnexus_dir {
+            if let Err(err) = resolve_within_root(dir) {
+                let model = generate_error(err);
+                let md = render_generate_md(&model);
+                return to_tool_result(&model, md);
+            }
+        }
+        let resolved_directory = match &params.directory {
             Some(dir) => match resolve_within_root(dir) {
-                Ok(resolved) if resolved.is_dir() => resolved,
+                Ok(resolved) if resolved.is_dir() => Some(resolved),
                 Ok(resolved) => {
                     let model = generate_error(format!("Not a directory: {}", resolved.display()));
                     let md = render_generate_md(&model);
@@ -346,12 +371,21 @@ impl ToposServer {
                     return to_tool_result(&model, md);
                 }
             },
-            None => project_root.clone(),
+            None => None,
         };
+        let target_dir = resolve_generate_project_root(
+            resolved_directory.as_deref(),
+            params.gitnexus_dir.as_deref(),
+            &file_root,
+        );
 
         let mut state_before = None;
         if !params.force {
-            let status = depgraph_status(None, &target_dir, &target_dir.to_string_lossy());
+            let status = depgraph_status(
+                params.gitnexus_dir.as_deref(),
+                &target_dir,
+                &target_dir.to_string_lossy(),
+            );
             let state = parse_state(status.state);
             state_before = Some(state);
             if state == DepgraphState::Present {
@@ -545,5 +579,34 @@ mod tests {
             let (_, _, blocked) = state_guidance(state);
             assert_eq!(blocked, code, "{state:?}");
         }
+    }
+
+    #[test]
+    fn resolve_generate_project_root_derives_from_gitnexus_dir_like_status() {
+        // Callers pass a canonical file_root (resolve_file_root does); do the
+        // same here so macOS /tmp -> /private/tmp does not fake an escape.
+        let file_root = std::env::temp_dir()
+            .join(format!("topos_generate_root_{}", std::process::id()));
+        std::fs::create_dir_all(&file_root).unwrap();
+        let file_root = file_root.canonicalize().unwrap();
+        let nested = file_root.join("nested");
+        std::fs::create_dir_all(nested.join(".gitnexus")).unwrap();
+        let store = nested.join(".gitnexus");
+
+        let derived = resolve_generate_project_root(
+            None,
+            Some(store.to_str().unwrap()),
+            &file_root,
+        );
+        assert_eq!(derived, nested.canonicalize().unwrap());
+
+        let explicit = resolve_generate_project_root(
+            Some(file_root.as_path()),
+            Some(store.to_str().unwrap()),
+            &file_root,
+        );
+        assert_eq!(explicit, file_root);
+
+        std::fs::remove_dir_all(&file_root).ok();
     }
 }

--- a/topos/mcp/src/tools/depgraph.rs
+++ b/topos/mcp/src/tools/depgraph.rs
@@ -11,7 +11,8 @@ use rmcp::{tool, tool_router};
 use topos_engine::adapters::gitnexus::generate_depgraph;
 
 use crate::evaluation::{
-    cap_generation_detail, depgraph_status, resolve_mcp_composable_project_root, DepgraphStatus,
+    cap_generation_detail, depgraph_status, resolve_mcp_composable_project_root,
+    resolve_override_for_root, DepgraphStatus,
 };
 use crate::formatting::to_tool_result;
 use crate::schemas::{
@@ -295,17 +296,18 @@ impl ToposServer {
         &self,
         Parameters(params): Parameters<DepgraphStatusInput>,
     ) -> CallToolResult {
-        let project_root = match resolve_file_root() {
-            Ok(root) => crate::evaluation::resolve_mcp_composable_project_root(
-                params.gitnexus_dir.as_deref(),
-                &root,
-            ),
+        let file_root = match resolve_file_root() {
+            Ok(root) => root,
             Err(err) => {
                 let model = status_error(err);
                 let md = render_status_md(&model);
                 return to_tool_result(&model, md);
             }
         };
+        let project_root = crate::evaluation::resolve_mcp_composable_project_root(
+            params.gitnexus_dir.as_deref(),
+            &file_root,
+        );
         if let Some(dir) = &params.gitnexus_dir {
             if let Err(err) = resolve_within_root(dir) {
                 let model = status_error(err);
@@ -313,8 +315,15 @@ impl ToposServer {
                 return to_tool_result(&model, md);
             }
         }
+        // Resolved to an absolute path against `file_root` — must be used
+        // below instead of `params.gitnexus_dir`, since `project_root` above
+        // already absorbed a relative override's subdirectory; rejoining the
+        // original relative string against it a second time would double
+        // that subdirectory.
+        let resolved_override =
+            resolve_override_for_root(params.gitnexus_dir.as_deref(), &file_root);
         let status = depgraph_status(
-            params.gitnexus_dir.as_deref(),
+            resolved_override.as_deref(),
             &project_root,
             &project_root.to_string_lossy(),
         );
@@ -378,11 +387,23 @@ impl ToposServer {
             params.gitnexus_dir.as_deref(),
             &file_root,
         );
+        // Only when `target_dir` was itself derived from `gitnexus_dir`
+        // (no explicit `directory`) does it already absorb a relative
+        // override's subdirectory — rejoining the raw override against it
+        // would then double that subdirectory, so resolve it first in that
+        // case. An explicit `directory` is independent of `gitnexus_dir`,
+        // so the raw (still relative-to-`target_dir`) override is correct
+        // as-is there.
+        let status_override = if resolved_directory.is_none() {
+            resolve_override_for_root(params.gitnexus_dir.as_deref(), &file_root)
+        } else {
+            params.gitnexus_dir.clone()
+        };
 
         let mut state_before = None;
         if !params.force {
             let status = depgraph_status(
-                params.gitnexus_dir.as_deref(),
+                status_override.as_deref(),
                 &target_dir,
                 &target_dir.to_string_lossy(),
             );
@@ -585,19 +606,16 @@ mod tests {
     fn resolve_generate_project_root_derives_from_gitnexus_dir_like_status() {
         // Callers pass a canonical file_root (resolve_file_root does); do the
         // same here so macOS /tmp -> /private/tmp does not fake an escape.
-        let file_root = std::env::temp_dir()
-            .join(format!("topos_generate_root_{}", std::process::id()));
+        let file_root =
+            std::env::temp_dir().join(format!("topos_generate_root_{}", std::process::id()));
         std::fs::create_dir_all(&file_root).unwrap();
         let file_root = file_root.canonicalize().unwrap();
         let nested = file_root.join("nested");
         std::fs::create_dir_all(nested.join(".gitnexus")).unwrap();
         let store = nested.join(".gitnexus");
 
-        let derived = resolve_generate_project_root(
-            None,
-            Some(store.to_str().unwrap()),
-            &file_root,
-        );
+        let derived =
+            resolve_generate_project_root(None, Some(store.to_str().unwrap()), &file_root);
         assert_eq!(derived, nested.canonicalize().unwrap());
 
         let explicit = resolve_generate_project_root(

--- a/topos/mcp/src/tools/evaluate.rs
+++ b/topos/mcp/src/tools/evaluate.rs
@@ -14,7 +14,7 @@ use topos_engine::evaluation::weakest_score;
 use crate::diagnostics::{overlay_for_file, overlay_for_source, SecurityOverlay};
 use crate::evaluation::{
     all_source_suffixes, classify_code_string, classify_file, detect_language, ensure_gitnexus_dir,
-    gitnexus_warnings, resolve_mcp_composable_project_root,
+    gitnexus_warnings, resolve_mcp_composable_project_root, resolve_override_for_root,
 };
 use crate::formatting::{
     build_pillars, composable_contract_signals, error_md, render_evaluation_md,
@@ -208,8 +208,8 @@ fn evaluate_file_sync(params: EvaluateFileInput) -> CallToolResult {
         );
     }
 
-    let project_root = match resolve_file_root() {
-        Ok(root) => resolve_mcp_composable_project_root(params.gitnexus_dir.as_deref(), &root),
+    let file_root = match resolve_file_root() {
+        Ok(root) => root,
         Err(err) => {
             return err_eval(
                 "Access denied / path error",
@@ -219,8 +219,16 @@ fn evaluate_file_sync(params: EvaluateFileInput) -> CallToolResult {
             )
         }
     };
+    let project_root =
+        resolve_mcp_composable_project_root(params.gitnexus_dir.as_deref(), &file_root);
+    // Resolved to an absolute path against `file_root` — must be used below
+    // instead of `params.gitnexus_dir`, since `project_root` above already
+    // absorbed a relative override's subdirectory; rejoining the original
+    // relative string against it a second time would double that
+    // subdirectory.
+    let resolved_override = resolve_override_for_root(params.gitnexus_dir.as_deref(), &file_root);
     let gitnexus_outcome = ensure_gitnexus_dir(
-        params.gitnexus_dir.as_deref(),
+        resolved_override.as_deref(),
         &project_root,
         params.no_composable,
         /* capture = */ true,
@@ -243,7 +251,7 @@ fn evaluate_file_sync(params: EvaluateFileInput) -> CallToolResult {
         None => None,
     };
     let mut warnings = gitnexus_warnings(
-        params.gitnexus_dir.as_deref(),
+        resolved_override.as_deref(),
         &project_root,
         gitnexus_dir.as_deref(),
         dep_graph.is_some(),
@@ -310,16 +318,22 @@ fn evaluate_project_sync(params: EvaluateProjectInput) -> CallToolResult {
         }
     };
 
-    let project_root = match resolve_file_root() {
-        Ok(root) => resolve_mcp_composable_project_root(params.gitnexus_dir.as_deref(), &root),
+    let file_root = match resolve_file_root() {
+        Ok(root) => root,
         Err(err) => {
             let model = empty_project_result(&params, priority, priority_source, Some(err));
             let md = render_project_md(&model);
             return to_tool_result(&model, md);
         }
     };
+    let project_root =
+        resolve_mcp_composable_project_root(params.gitnexus_dir.as_deref(), &file_root);
+    // See the matching comment in evaluate_file_sync: must use the resolved
+    // override below, not `params.gitnexus_dir`, since a relative override's
+    // subdirectory is already baked into `project_root` above.
+    let resolved_override = resolve_override_for_root(params.gitnexus_dir.as_deref(), &file_root);
     let gitnexus_outcome = ensure_gitnexus_dir(
-        params.gitnexus_dir.as_deref(),
+        resolved_override.as_deref(),
         &project_root,
         params.no_composable,
         /* capture = */ true,
@@ -392,6 +406,7 @@ fn evaluate_project_sync(params: EvaluateProjectInput) -> CallToolResult {
         priority_source,
         coupling_available,
         project_root: &project_root,
+        resolved_gitnexus_override: resolved_override.as_deref(),
         gitnexus_dir: gitnexus_dir.as_deref(),
         generation_note: gitnexus_outcome.generation_note,
     });
@@ -615,6 +630,11 @@ struct BuildProjectArgs<'a> {
     priority_source: PrioritySource,
     coupling_available: bool,
     project_root: &'a Path,
+    /// The `gitnexus_dir` override resolved to an absolute path against the
+    /// MCP file root (see [`resolve_override_for_root`]) — pass this to
+    /// [`gitnexus_warnings`] instead of `params.gitnexus_dir`, which
+    /// `project_root` above has already derived a non-default root from.
+    resolved_gitnexus_override: Option<&'a str>,
     gitnexus_dir: Option<&'a Path>,
     generation_note: Option<String>,
 }
@@ -653,7 +673,7 @@ fn build_project_result(args: BuildProjectArgs<'_>) -> ProjectEvaluationResult {
     let next_offset = has_more.then_some(args.params.offset + page.len());
 
     let mut project_warnings = gitnexus_warnings(
-        args.params.gitnexus_dir.as_deref(),
+        args.resolved_gitnexus_override,
         args.project_root,
         args.gitnexus_dir,
         args.any_dep_graph_loaded,
@@ -1088,6 +1108,7 @@ mod tests {
             priority_source: PrioritySource::Default,
             coupling_available: false,
             project_root: root,
+            resolved_gitnexus_override: None,
             gitnexus_dir: None,
             generation_note: None,
         })

--- a/topos/mcp/src/tools/evaluate.rs
+++ b/topos/mcp/src/tools/evaluate.rs
@@ -14,7 +14,7 @@ use topos_engine::evaluation::weakest_score;
 use crate::diagnostics::{overlay_for_file, overlay_for_source, SecurityOverlay};
 use crate::evaluation::{
     all_source_suffixes, classify_code_string, classify_file, detect_language, ensure_gitnexus_dir,
-    gitnexus_warnings,
+    gitnexus_warnings, resolve_mcp_composable_project_root,
 };
 use crate::formatting::{
     build_pillars, composable_contract_signals, error_md, render_evaluation_md,
@@ -209,7 +209,7 @@ fn evaluate_file_sync(params: EvaluateFileInput) -> CallToolResult {
     }
 
     let project_root = match resolve_file_root() {
-        Ok(root) => root,
+        Ok(root) => resolve_mcp_composable_project_root(params.gitnexus_dir.as_deref(), &root),
         Err(err) => {
             return err_eval(
                 "Access denied / path error",
@@ -311,7 +311,7 @@ fn evaluate_project_sync(params: EvaluateProjectInput) -> CallToolResult {
     };
 
     let project_root = match resolve_file_root() {
-        Ok(root) => root,
+        Ok(root) => resolve_mcp_composable_project_root(params.gitnexus_dir.as_deref(), &root),
         Err(err) => {
             let model = empty_project_result(&params, priority, priority_source, Some(err));
             let md = render_project_md(&model);

--- a/topos/mcp/src/tools/inspect.rs
+++ b/topos/mcp/src/tools/inspect.rs
@@ -17,7 +17,7 @@ use topos_engine::functors::probes::ast::entropy::calculate_kolmogorov_proxy;
 use crate::diagnostics::overlay_for_source;
 use crate::evaluation::{
     classify_code_string, classify_file, detect_language, ensure_gitnexus_dir, gitnexus_warnings,
-    resolve_mcp_composable_project_root,
+    resolve_mcp_composable_project_root, resolve_override_for_root,
 };
 use crate::formatting::{
     render_evaluation_md, to_evaluation_result, to_tool_result, EvalResultOptions,
@@ -72,22 +72,23 @@ struct InspectClassification {
 /// (issue #216: inspect used to skip the MDG entirely and read one medal
 /// lower).
 fn classify_inspected_file(
-    params: &InspectCodeInput,
+    resolved_gitnexus_override: Option<&str>,
+    no_composable: bool,
     project_root: &Path,
     path: &Path,
     priority: Priority,
 ) -> Result<InspectClassification, String> {
     let outcome = ensure_gitnexus_dir(
-        params.gitnexus_dir.as_deref(),
+        resolved_gitnexus_override,
         project_root,
-        params.no_composable,
+        no_composable,
         /* capture = */ true,
     );
     let gitnexus_dir = outcome.gitnexus_dir;
 
     let (result, dep_graph, load_error) = classify_file(path, priority, gitnexus_dir.as_deref())?;
     let mut warnings = gitnexus_warnings(
-        params.gitnexus_dir.as_deref(),
+        resolved_gitnexus_override,
         project_root,
         gitnexus_dir.as_deref(),
         dep_graph.is_some(),
@@ -125,7 +126,19 @@ fn classify_inspection(
     let file_root = resolve_file_root()?;
     let project_root =
         resolve_mcp_composable_project_root(params.gitnexus_dir.as_deref(), &file_root);
-    classify_inspected_file(params, &project_root, path, priority)
+    // Resolved to an absolute path against `file_root` — must be used
+    // below instead of `params.gitnexus_dir`, since `project_root` above
+    // already absorbed a relative override's subdirectory; rejoining the
+    // original relative string against it a second time would double that
+    // subdirectory.
+    let resolved_override = resolve_override_for_root(params.gitnexus_dir.as_deref(), &file_root);
+    classify_inspected_file(
+        resolved_override.as_deref(),
+        params.no_composable,
+        &project_root,
+        path,
+        priority,
+    )
 }
 
 fn inspection_language(params: &InspectCodeInput, file_path: Option<&PathBuf>) -> String {
@@ -395,8 +408,14 @@ mod tests {
             "filepath": "sample.py",
             "no_composable": true,
         }));
-        let classified =
-            classify_inspected_file(&params, &project_root, &file, Priority::Simple).expect("runs");
+        let classified = classify_inspected_file(
+            params.gitnexus_dir.as_deref(),
+            params.no_composable,
+            &project_root,
+            &file,
+            Priority::Simple,
+        )
+        .expect("runs");
 
         assert!(!classified.coupling_available);
         assert!(

--- a/topos/mcp/src/tools/inspect.rs
+++ b/topos/mcp/src/tools/inspect.rs
@@ -17,6 +17,7 @@ use topos_engine::functors::probes::ast::entropy::calculate_kolmogorov_proxy;
 use crate::diagnostics::overlay_for_source;
 use crate::evaluation::{
     classify_code_string, classify_file, detect_language, ensure_gitnexus_dir, gitnexus_warnings,
+    resolve_mcp_composable_project_root,
 };
 use crate::formatting::{
     render_evaluation_md, to_evaluation_result, to_tool_result, EvalResultOptions,
@@ -121,7 +122,9 @@ fn classify_inspection(
             warnings: Vec::new(),
         });
     };
-    let project_root = resolve_file_root()?;
+    let file_root = resolve_file_root()?;
+    let project_root =
+        resolve_mcp_composable_project_root(params.gitnexus_dir.as_deref(), &file_root);
     classify_inspected_file(params, &project_root, path, priority)
 }
 


### PR DESCRIPTION
## Summary
- When `--gitnexus-dir` / `gitnexus_dir` is set, COMPOSABLE project root is the store's parent (not CLI cwd / MCP file root).
- CLI allows absolute overrides outside cwd; MCP still requires the derived root under `TOPOS_MCP_FILE_ROOT`.
- Spinner phases distinguish freshness vs `gitnexus analyze`.
- Docs: agent contract + skill updated.
- Stacked on #269 (`release/044-215-symlink-containment`).
- Closes #258.

## Test plan
- [x] `cargo test -p topos-mcp --lib evaluation::` (includes root-derivation tests)
- [x] `cargo test -p topos composable`
- [ ] Dogfood: from `$HOME`, `topos evaluate <repo>/… -r --gitnexus-dir <repo>/.gitnexus` fingerprints only `<repo>`


Made with [Cursor](https://cursor.com)