### PR TITLE
draft: plan topos install / uninstall (#256)

### DIFF
--- a/docs/decisions/cli-harness-install.md
+++ b/docs/decisions/cli-harness-install.md
@@ -1,12 +1,19 @@
 # CLI harness install / uninstall (`topos install`)
 
-Status: **PLANNED** (v0.4.4) — implementation owned by @sgathrid.  
+Status: **DRAFT IMPLEMENTATION** (v0.4.4) — owned by @sgathrid; needs a
+review pass on the schema assumptions called out in `integrations.rs`
+before it ships.
 Issue: [#256](https://github.com/Krv-Labs/topos/issues/256).
 
-This document is the implementation plan. No install/uninstall code ships
-in this PR; merge the plan into `release/v0.4.4` so work can proceed in
-follow-up commits on this branch (or a successor PR stacked on the
-release train).
+A first implementation lands in `topos/cli/src/commands/install/`,
+following the harness-installer pattern from
+[sgathrid/brian](https://github.com/sgathrid/brian)
+(`wikicli/lifecycle/{integrations,install,uninstall}.py`): a flat
+per-harness dispatch, marker-based idempotent edits, atomic writes with
+`.topos.backup` snapshots, and an install-state file so uninstall only
+ever touches what a previous `topos install` created. The sections below
+are updated to describe what actually shipped; see "Changes from the
+original plan" at the end for what moved and why.
 
 ## Goal
 
@@ -26,101 +33,116 @@ Inspired by skills.sh-style TTY selection and the existing
 
 | Command | Behavior |
 | --- | --- |
-| `topos install` | TTY: multi-select harnesses (↑↓, space, `a`, enter). Non-TTY: require explicit harness names or `--yes --all-detected`. |
-| `topos uninstall` | Default to dry-run preview of every file change; require `--apply` or confirmation to mutate. |
-| `topos install status` | Per-harness ✓/○ with paths; summary `N/M active`. Prefer `--json` for agents. |
+| `topos install` | TTY, no args: interactive multi-select (↑↓/`j`/`k` move, space toggle, `a` toggle-all, enter confirm, esc cancel). Non-TTY: requires explicit harness names or `--all`. |
+| `topos uninstall` | Always previews first (dry-run); `--apply` performs the removal, or (in a TTY) a `[y/N]` prompt after the preview does. |
+| `topos install status` | Per-harness ✓ active / ▲ stale / ○ absent; summary `N/M active`. `--json` for agents. |
 
 ## Module layout
 
 ```text
 topos/cli/src/commands/install/
-  mod.rs           # clap + dispatch
-  registry.rs      # HarnessId, detection, paths
-  interactive.rs   # multi-select TUI (reuse console patterns from config.rs)
-  plan.rs          # InstallPlan / UninstallPlan (dry-run preview)
-  apply.rs         # Idempotent apply/remove
-  adapters/
-    claude_code.rs
-    claude_desktop.rs
-    codex.rs
-    gemini.rs
-    copilot.rs
-    cursor_vscode.rs
-    antigravity.rs
+  mod.rs           # clap args, target resolution (explicit/--all/interactive), dispatch
+  integrations.rs  # per-harness paths, State (Active/Stale/Absent), atomic write+backup,
+                    # ownership-tracking state file — the brian-derived core
+  menu.rs          # multi-select TTY checkbox list
+  configure.rs     # topos install: one function per harness
+  uninstall.rs     # topos uninstall: one function per harness, mirrors configure.rs
+  status.rs        # topos install status
 ```
 
-Wire into [`topos/cli/src/main.rs`](../../topos/cli/src/main.rs) as
-`Command::Install` / `Command::Uninstall` (or a single `install`
-subcommand with `status` / nested uninstall — prefer matching the issue
-mockups: top-level `install` + `uninstall`).
+No `adapters/` directory or `HarnessAdapter` trait: brian's own installer
+uses a flat per-harness `if/elif` dispatch over shared helper functions
+rather than trait objects, and porting that directly kept each harness's
+install/uninstall/state-check logic next to its counterpart instead of
+split across a trait impl per file. `ToposPaths`-style resolution wasn't
+needed either — the MCP entry is the literal `{"command": "topos", "args":
+["mcp"]}` already documented in `skills/topos/SKILL.md`'s `claude mcp add`
+example (PATH-based, matching how the skill tells users to configure it
+by hand today), and the skill content is `include_str!`'d from
+`skills/topos/SKILL.md` into the binary — a real filesystem checkout of
+this repo isn't available once `topos` is installed globally.
 
-## Adapter trait
-
-```rust
-trait HarnessAdapter {
-    fn id(&self) -> HarnessId;
-    fn detect(&self) -> Detection; // NotFound | Detected | Active
-    fn plan_install(&self, topos: &ToposPaths) -> Plan;
-    fn plan_uninstall(&self) -> Plan;
-    fn apply(&self, plan: &Plan) -> Result<(), String>;
-}
-```
-
-`ToposPaths` resolves: `topos` on `PATH`, skill source (`skills/topos`),
-MCP stdio command (`topos mcp`).
+Wired into [`topos/cli/src/main.rs`](../../topos/cli/src/main.rs) as
+top-level `Command::Install` / `Command::Uninstall`, with `status` as a
+nested clap subcommand of `install` (`topos install status`).
 
 ## v1 harness matrix
 
 | Harness | Config location | Install action |
 | --- | --- | --- |
-| Claude Code | `~/.claude/settings.json` | MCP server entry + skill link |
-| Claude Desktop | `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) | MCP server entry |
-| Codex CLI | `~/.codex/config.toml` | MCP block |
-| Gemini CLI | `~/.gemini/settings.json` | SessionStart hook + skill |
-| Copilot CLI | `~/.copilot/copilot-instructions.md` | Instruction block |
-| Cursor & VS Code | `~/.agents/skills` and/or `.cursor/mcp.json` | Skill symlink + MCP config |
-| Antigravity | `~/.gemini/GEMINI.md` | `@import` line + permission rules |
+| Claude Code | `~/.claude.json` (**not** `settings.json` — that file is hooks/permissions only) | MCP server entry + skill file at `~/.claude/skills/topos/SKILL.md` |
+| Claude Desktop | `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS; `~/.config/Claude/...` kept as a cleanup target on Linux, where Desktop isn't shipped) | MCP server entry |
+| Codex CLI | `~/.codex/config.toml` | `[mcp_servers.topos]` table via `toml_edit` (preserves comments/formatting) |
+| Gemini CLI | `~/.gemini/settings.json` | MCP server entry |
+| Copilot CLI | `~/.copilot/copilot-instructions.md` | `<!-- topos:start/end -->` marker-delimited instruction block |
+| Cursor & VS Code | `~/.agents/skills/topos/SKILL.md` + `~/.cursor/mcp.json` | Skill file + MCP server entry |
+| Antigravity | `~/.gemini/GEMINI.md` + `~/.gemini/topos-skill.md` | `@import` line pointing at a written-out skill copy |
 
-If a harness’s on-disk format is unstable at implementation time, gate it
-behind `--experimental` rather than blocking the release — but aim to
-ship all seven.
+Every harness shipped in v1; none needed an `--experimental` gate.
 
 ## Safety rules
 
-- Merge into existing JSON/TOML; never wipe unrelated MCP servers.
-- Mark Topos-owned entries (e.g. `"managedBy": "topos"` or equivalent per format).
-- Uninstall removes only Topos-owned entries.
-- All writes: read → parse → merge → atomic write (temp + rename).
-- `--dry-run` makes zero filesystem changes.
+- Merge into existing JSON/TOML; never wipe unrelated MCP servers or other keys (verified: a foreign `mcpServers` entry and unrelated top-level keys both survive install + uninstall in `integrations.rs`'s tests).
+- The `topos` key itself is the ownership marker for MCP entries — install/uninstall only ever touch `mcpServers.topos` / `[mcp_servers.topos]`.
+- A separate install-state file (`~/.local/state/topos/install.json`) records which config *files* `topos install` created from scratch, so uninstall only deletes a now-empty file if Topos was the one who created it — a pre-existing file that happens to end up empty is left alone.
+- A written skill file is only ever deleted by uninstall if its content still matches exactly what was written; a user edit is preserved and reported, not clobbered.
+- All writes: read → parse → merge → atomic write (temp file + rename), with a `.topos.backup` snapshot of the previous contents (`--purge-backups` on uninstall clears those).
+- Dry-run (the uninstall default, and `topos install --dry-run`) makes zero filesystem changes — covered by a test that diffs file contents before/after a dry-run uninstall.
 
 ## Tests
 
-- Fixture unit tests per adapter under `topos/cli/tests/fixtures/install/`.
-- Integration: `topos install status --json` (no TTY).
-- Snapshot dry-run output strings for uninstall preview.
+- Inline `#[cfg(test)]` unit tests in `integrations.rs` (tempdir-based, matching the existing style in `commands/config.rs`) covering: JSON/TOML/text marker round-trips, stale-entry detection and removal, dry-run no-ops, owned-file content-match removal, and install-state ownership tracking.
+- Manually verified end-to-end against a scratch `$HOME`: real install/uninstall across all seven harnesses, idempotent re-install, foreign JSON/TOML/Markdown content preserved throughout, and backup purge.
+- Not added: fixture files under `topos/cli/tests/fixtures/install/` — the tempdir-based inline tests cover the same ground with less scaffolding.
 
 ## Docs (with implementation)
 
-- [`skills/topos/SKILL.md`](../../skills/topos/SKILL.md) — prefer `topos install` over manual MCP setup.
-- CLI `--help` for the new commands.
-- Optional note in distribution docs after OpenWiki regen.
+- `skills/topos/SKILL.md` still documents the manual `claude mcp add` path; pointing it at `topos install` instead is a follow-up once this is out of draft.
+- CLI `--help` covers the new commands (`topos install --help`, `topos uninstall --help`).
 
 ## Dependencies on the v0.4.4 train
 
-Land **after** #258 (`--gitnexus-dir` as project root) so install docs
-describe final COMPOSABLE root semantics. Stack/rebase this branch onto
-`release/v0.4.4` once #266–#270 are merged.
+Landed after #258 (`--gitnexus-dir` as project root) and the rest of
+#266–#270 — this branch was rebased onto the `release/v0.4.4` tip once
+those merged.
 
 ## Acceptance (from #256)
 
-- [ ] Interactive install multi-select in TTY
-- [ ] Dry-run uninstall preview by default
-- [ ] Status shows configured vs detected harnesses
-- [ ] Install + uninstall idempotent
-- [ ] Non-TTY path works without prompts
+- [x] Interactive install multi-select in TTY
+- [x] Dry-run uninstall preview by default
+- [x] Status shows configured vs detected harnesses (`topos install status`, `--json` for agents)
+- [x] Install + uninstall idempotent (re-running install reports "already configured" / "already up to date" with no writes; verified manually and via the `integrations.rs` round-trip tests)
+- [x] Non-TTY path works without prompts (explicit harness names or `--all`; errors clearly if neither is given)
 
 ## Out of scope for v1
 
-- Windows-specific Desktop paths beyond what adapters can detect cheaply
+- Windows-specific Desktop paths beyond what's needed to clean up a prior install
 - Auto-installing the `topos` binary itself (assume already on `PATH`)
 - Publishing to ClawHub from this command
+
+## Changes from the original plan
+
+- **Claude Code's MCP config location.** The original sketch pointed at
+  `~/.claude/settings.json`; that file is hooks/permissions/statusLine
+  only. User-scope MCP servers live in `~/.claude.json`, matching what
+  `claude mcp add` itself writes.
+- **No session-start hooks.** brian's installer injects wiki context via
+  `SessionStart` hooks on Claude Code/Gemini/Codex. Topos has no context
+  to inject at session start — its integration point is MCP tools — so
+  those harnesses get an MCP server entry instead of a hook, and the
+  hook-marker-stripping machinery in brian's `integrations.py`
+  (`WIKI_HOOK_MARKERS`, the Codex `[features]`/`writable_roots` state
+  machine) wasn't ported at all.
+- **Codex via `toml_edit`, not regex.** brian edits `config.toml` with
+  regex over raw text because Python's `tomllib` is read-only. Rust's
+  `toml_edit` (already a dependency, used by `commands/config.rs`) reads,
+  edits, and writes back while preserving comments/formatting, so the
+  Codex adapter is a plain table insert/remove instead of a hand-rolled
+  block-matching regex.
+- **Skill delivery is a file write, not a symlink.** brian's installer
+  always runs from inside a persistent git checkout, so it symlinks
+  `internal/skills/wiki-context` into each harness's skills directory.
+  A globally-installed `topos` binary has no such checkout, so the skill
+  content is `include_str!`'d into the binary at compile time and written
+  out (not symlinked) to each target path; uninstall only deletes it if
+  the on-disk content still matches exactly, so a user edit is preserved.

--- a/docs/decisions/cli-harness-install.md
+++ b/docs/decisions/cli-harness-install.md
@@ -1,0 +1,126 @@
+# CLI harness install / uninstall (`topos install`)
+
+Status: **PLANNED** (v0.4.4) — implementation owned by @sgathrid.  
+Issue: [#256](https://github.com/Krv-Labs/topos/issues/256).
+
+This document is the implementation plan. No install/uninstall code ships
+in this PR; merge the plan into `release/v0.4.4` so work can proceed in
+follow-up commits on this branch (or a successor PR stacked on the
+release train).
+
+## Goal
+
+Ship interactive, idempotent agent-harness setup from the Topos CLI:
+
+```text
+topos install [--dry-run] [--yes] [harness...]
+topos uninstall [--dry-run] [--yes] [harness...]
+topos install status   # or: topos status install
+```
+
+Inspired by skills.sh-style TTY selection and the existing
+`topos config` interactive selector
+([`topos/cli/src/commands/config.rs`](../../topos/cli/src/commands/config.rs)).
+
+## Commands
+
+| Command | Behavior |
+| --- | --- |
+| `topos install` | TTY: multi-select harnesses (↑↓, space, `a`, enter). Non-TTY: require explicit harness names or `--yes --all-detected`. |
+| `topos uninstall` | Default to dry-run preview of every file change; require `--apply` or confirmation to mutate. |
+| `topos install status` | Per-harness ✓/○ with paths; summary `N/M active`. Prefer `--json` for agents. |
+
+## Module layout
+
+```text
+topos/cli/src/commands/install/
+  mod.rs           # clap + dispatch
+  registry.rs      # HarnessId, detection, paths
+  interactive.rs   # multi-select TUI (reuse console patterns from config.rs)
+  plan.rs          # InstallPlan / UninstallPlan (dry-run preview)
+  apply.rs         # Idempotent apply/remove
+  adapters/
+    claude_code.rs
+    claude_desktop.rs
+    codex.rs
+    gemini.rs
+    copilot.rs
+    cursor_vscode.rs
+    antigravity.rs
+```
+
+Wire into [`topos/cli/src/main.rs`](../../topos/cli/src/main.rs) as
+`Command::Install` / `Command::Uninstall` (or a single `install`
+subcommand with `status` / nested uninstall — prefer matching the issue
+mockups: top-level `install` + `uninstall`).
+
+## Adapter trait
+
+```rust
+trait HarnessAdapter {
+    fn id(&self) -> HarnessId;
+    fn detect(&self) -> Detection; // NotFound | Detected | Active
+    fn plan_install(&self, topos: &ToposPaths) -> Plan;
+    fn plan_uninstall(&self) -> Plan;
+    fn apply(&self, plan: &Plan) -> Result<(), String>;
+}
+```
+
+`ToposPaths` resolves: `topos` on `PATH`, skill source (`skills/topos`),
+MCP stdio command (`topos mcp`).
+
+## v1 harness matrix
+
+| Harness | Config location | Install action |
+| --- | --- | --- |
+| Claude Code | `~/.claude/settings.json` | MCP server entry + skill link |
+| Claude Desktop | `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) | MCP server entry |
+| Codex CLI | `~/.codex/config.toml` | MCP block |
+| Gemini CLI | `~/.gemini/settings.json` | SessionStart hook + skill |
+| Copilot CLI | `~/.copilot/copilot-instructions.md` | Instruction block |
+| Cursor & VS Code | `~/.agents/skills` and/or `.cursor/mcp.json` | Skill symlink + MCP config |
+| Antigravity | `~/.gemini/GEMINI.md` | `@import` line + permission rules |
+
+If a harness’s on-disk format is unstable at implementation time, gate it
+behind `--experimental` rather than blocking the release — but aim to
+ship all seven.
+
+## Safety rules
+
+- Merge into existing JSON/TOML; never wipe unrelated MCP servers.
+- Mark Topos-owned entries (e.g. `"managedBy": "topos"` or equivalent per format).
+- Uninstall removes only Topos-owned entries.
+- All writes: read → parse → merge → atomic write (temp + rename).
+- `--dry-run` makes zero filesystem changes.
+
+## Tests
+
+- Fixture unit tests per adapter under `topos/cli/tests/fixtures/install/`.
+- Integration: `topos install status --json` (no TTY).
+- Snapshot dry-run output strings for uninstall preview.
+
+## Docs (with implementation)
+
+- [`skills/topos/SKILL.md`](../../skills/topos/SKILL.md) — prefer `topos install` over manual MCP setup.
+- CLI `--help` for the new commands.
+- Optional note in distribution docs after OpenWiki regen.
+
+## Dependencies on the v0.4.4 train
+
+Land **after** #258 (`--gitnexus-dir` as project root) so install docs
+describe final COMPOSABLE root semantics. Stack/rebase this branch onto
+`release/v0.4.4` once #266–#270 are merged.
+
+## Acceptance (from #256)
+
+- [ ] Interactive install multi-select in TTY
+- [ ] Dry-run uninstall preview by default
+- [ ] Status shows configured vs detected harnesses
+- [ ] Install + uninstall idempotent
+- [ ] Non-TTY path works without prompts
+
+## Out of scope for v1
+
+- Windows-specific Desktop paths beyond what adapters can detect cheaply
+- Auto-installing the `topos` binary itself (assume already on `PATH`)
+- Publishing to ClawHub from this command

--- a/topos/cli/src/commands/install/configure.rs
+++ b/topos/cli/src/commands/install/configure.rs
@@ -1,0 +1,342 @@
+//! `topos install` — configure one or more agent harnesses to use Topos.
+
+use std::path::Path;
+
+use console::Style;
+
+use super::integrations::{
+    self, antigravity_pointer_path, claude_desktop_config_path, record_created_file,
+    set_antigravity_import, set_codex_entry, set_copilot_block, set_mcp_entry, skill_path_agents,
+    skill_path_claude, write_skill, State,
+};
+use crate::commands::render::{paint, RenderOptions};
+
+fn ok(opts: RenderOptions) -> String {
+    paint("✓", Style::new().green(), opts)
+}
+
+fn pending(opts: RenderOptions) -> String {
+    paint("○", Style::new().color256(208), opts)
+}
+
+fn err(opts: RenderOptions) -> String {
+    paint("✕", Style::new().red(), opts)
+}
+
+/// Shared three-way branch every install step follows: already active, a
+/// dry-run preview, or an actual write. `apply` performs the write and
+/// returns whether anything changed.
+fn apply_step(
+    state: State,
+    dry_run: bool,
+    active_msg: &str,
+    preview_msg: &str,
+    applied_msg: &str,
+    apply: impl FnOnce() -> Result<bool, String>,
+    opts: RenderOptions,
+) -> bool {
+    match state {
+        State::Active => {
+            println!("│    {} {active_msg}", ok(opts));
+            true
+        }
+        _ if dry_run => {
+            println!("│    {} [dry run] {preview_msg}", pending(opts));
+            true
+        }
+        _ => match apply() {
+            Ok(_) => {
+                println!("│    {} {applied_msg}", ok(opts));
+                true
+            }
+            Err(e) => {
+                println!("│    {} {e}", err(opts));
+                false
+            }
+        },
+    }
+}
+
+type Handler = fn(&Path, bool, RenderOptions) -> bool;
+
+/// One entry per supported harness id — a data table instead of a match arm
+/// per harness keeps `run` itself flat regardless of how many harnesses
+/// exist.
+const HANDLERS: &[(&str, Handler)] = &[
+    ("claude", install_claude),
+    ("claude-desktop", install_claude_desktop),
+    ("codex", install_codex),
+    ("gemini", install_gemini),
+    ("copilot", install_copilot),
+    ("skills", install_skills),
+    ("antigravity", install_antigravity),
+];
+
+pub(crate) fn run(home: &Path, selected: &[String], dry_run: bool) -> Result<(), String> {
+    let opts = RenderOptions::stdout();
+    print_header(dry_run, opts);
+
+    let mut success = true;
+    for id in selected {
+        success &= dispatch(id, home, dry_run, opts);
+    }
+
+    print_summary(success, opts)
+}
+
+fn dispatch(id: &str, home: &Path, dry_run: bool, opts: RenderOptions) -> bool {
+    match HANDLERS.iter().find(|(harness_id, _)| *harness_id == id) {
+        Some((_, handler)) => handler(home, dry_run, opts),
+        None => {
+            println!("│  {} unknown harness: {id}", err(opts));
+            false
+        }
+    }
+}
+
+fn print_header(dry_run: bool, opts: RenderOptions) {
+    let mode = if dry_run {
+        " (DRY RUN — PREVIEW ONLY, NO CHANGES MADE)"
+    } else {
+        ""
+    };
+    println!(
+        "{}",
+        paint(
+            format!("┌  Topos Harness Install{mode}"),
+            Style::new().bold(),
+            opts
+        )
+    );
+    println!("│");
+}
+
+fn print_summary(success: bool, opts: RenderOptions) -> Result<(), String> {
+    if success {
+        println!("└  {}", paint("Done.", Style::new().bold(), opts));
+        Ok(())
+    } else {
+        println!(
+            "└  {}",
+            paint(
+                "Incomplete — existing files were preserved; review the errors above.",
+                Style::new().bold(),
+                opts
+            )
+        );
+        Err("one or more harnesses failed to configure".to_string())
+    }
+}
+
+fn install_claude(home: &Path, dry_run: bool, opts: RenderOptions) -> bool {
+    println!(
+        "│  {}",
+        paint("Claude Code (~/.claude)", Style::new().bold(), opts)
+    );
+    let config = home.join(".claude.json");
+    let existed = config.is_file();
+    let mut success = apply_step(
+        integrations::json_mcp_state(&config),
+        dry_run,
+        "MCP server already configured",
+        &format!("would add MCP server entry to {}", config.display()),
+        &format!("added MCP server entry to {}", config.display()),
+        || {
+            let changed = set_mcp_entry(&config)?;
+            if changed && !existed {
+                record_created_file(home, "claude", &config)?;
+            }
+            Ok(changed)
+        },
+        opts,
+    );
+    let skill = skill_path_claude(home);
+    success &= apply_step(
+        integrations::skill_state(&skill),
+        dry_run,
+        "skill already up to date",
+        &format!("would write skill to {}", skill.display()),
+        &format!("wrote skill to {}", skill.display()),
+        || write_skill(&skill),
+        opts,
+    );
+    println!("│");
+    success
+}
+
+fn install_claude_desktop(home: &Path, dry_run: bool, opts: RenderOptions) -> bool {
+    let config = claude_desktop_config_path(home);
+    println!(
+        "│  {}",
+        paint(
+            format!("Claude Desktop App ({})", config.display()),
+            Style::new().bold(),
+            opts
+        )
+    );
+    let existed = config.is_file();
+    let success = apply_step(
+        integrations::json_mcp_state(&config),
+        dry_run,
+        "MCP server already configured",
+        &format!("would add MCP server entry to {}", config.display()),
+        &format!("added MCP server entry to {}", config.display()),
+        || {
+            let changed = set_mcp_entry(&config)?;
+            if changed && !existed {
+                record_created_file(home, "claude-desktop", &config)?;
+            }
+            Ok(changed)
+        },
+        opts,
+    );
+    println!("│");
+    success
+}
+
+fn install_codex(home: &Path, dry_run: bool, opts: RenderOptions) -> bool {
+    println!(
+        "│  {}",
+        paint("Codex CLI (~/.codex)", Style::new().bold(), opts)
+    );
+    let config = home.join(".codex/config.toml");
+    let existed = config.is_file();
+    let success = apply_step(
+        integrations::codex_state(&config),
+        dry_run,
+        "MCP server already configured",
+        "would add [mcp_servers.topos] to ~/.codex/config.toml",
+        "added [mcp_servers.topos] to ~/.codex/config.toml",
+        || {
+            let changed = set_codex_entry(&config)?;
+            if changed && !existed {
+                record_created_file(home, "codex", &config)?;
+            }
+            Ok(changed)
+        },
+        opts,
+    );
+    println!("│");
+    success
+}
+
+fn install_gemini(home: &Path, dry_run: bool, opts: RenderOptions) -> bool {
+    println!(
+        "│  {}",
+        paint("Gemini CLI (~/.gemini)", Style::new().bold(), opts)
+    );
+    let config = home.join(".gemini/settings.json");
+    let existed = config.is_file();
+    let success = apply_step(
+        integrations::json_mcp_state(&config),
+        dry_run,
+        "MCP server already configured",
+        &format!("would add MCP server entry to {}", config.display()),
+        &format!("added MCP server entry to {}", config.display()),
+        || {
+            let changed = set_mcp_entry(&config)?;
+            if changed && !existed {
+                record_created_file(home, "gemini", &config)?;
+            }
+            Ok(changed)
+        },
+        opts,
+    );
+    println!("│");
+    success
+}
+
+fn install_copilot(home: &Path, dry_run: bool, opts: RenderOptions) -> bool {
+    println!(
+        "│  {}",
+        paint("GitHub Copilot CLI (~/.copilot)", Style::new().bold(), opts)
+    );
+    let config = home.join(".copilot/copilot-instructions.md");
+    let existed = config.is_file();
+    let success = apply_step(
+        integrations::copilot_state(&config),
+        dry_run,
+        "instructions already present",
+        "would add an instruction block to ~/.copilot/copilot-instructions.md",
+        "added an instruction block to ~/.copilot/copilot-instructions.md",
+        || {
+            let changed = set_copilot_block(&config)?;
+            if changed && !existed {
+                record_created_file(home, "copilot", &config)?;
+            }
+            Ok(changed)
+        },
+        opts,
+    );
+    println!("│");
+    success
+}
+
+fn install_skills(home: &Path, dry_run: bool, opts: RenderOptions) -> bool {
+    println!(
+        "│  {}",
+        paint(
+            "Cursor & VS Code (~/.agents/skills)",
+            Style::new().bold(),
+            opts
+        )
+    );
+    let skill = skill_path_agents(home);
+    let mut success = apply_step(
+        integrations::skill_state(&skill),
+        dry_run,
+        "skill already up to date",
+        &format!("would write skill to {}", skill.display()),
+        &format!("wrote skill to {}", skill.display()),
+        || write_skill(&skill),
+        opts,
+    );
+    let mcp_config = home.join(".cursor/mcp.json");
+    let existed = mcp_config.is_file();
+    success &= apply_step(
+        integrations::json_mcp_state(&mcp_config),
+        dry_run,
+        "MCP server already configured",
+        &format!("would add MCP server entry to {}", mcp_config.display()),
+        &format!("added MCP server entry to {}", mcp_config.display()),
+        || {
+            let changed = set_mcp_entry(&mcp_config)?;
+            if changed && !existed {
+                record_created_file(home, "skills", &mcp_config)?;
+            }
+            Ok(changed)
+        },
+        opts,
+    );
+    println!("│");
+    success
+}
+
+fn install_antigravity(home: &Path, dry_run: bool, opts: RenderOptions) -> bool {
+    println!(
+        "│  {}",
+        paint(
+            "Google Antigravity (~/.gemini/GEMINI.md)",
+            Style::new().bold(),
+            opts
+        )
+    );
+    let pointer = antigravity_pointer_path(home);
+    let success = apply_step(
+        integrations::antigravity_state(home),
+        dry_run,
+        "import already configured",
+        &format!(
+            "would write {} and add its @import to ~/.gemini/GEMINI.md",
+            pointer.display()
+        ),
+        &format!(
+            "wrote {} and added its @import to ~/.gemini/GEMINI.md",
+            pointer.display()
+        ),
+        || set_antigravity_import(home),
+        opts,
+    );
+    println!("│");
+    success
+}

--- a/topos/cli/src/commands/install/integrations.rs
+++ b/topos/cli/src/commands/install/integrations.rs
@@ -1,0 +1,740 @@
+//! Per-harness config paths, state detection, and the small persistence
+//! primitives `install`/`uninstall`/`status` build on: atomic writes with
+//! backups, and a tiny ownership-tracking file so uninstall only ever
+//! deletes what a previous `topos install` actually created.
+//!
+//! Ported from the harness-installer pattern in sgathrid/brian
+//! (`wikicli/lifecycle/{integrations,install,uninstall}.py`): a flat
+//! per-harness dispatch, marker-based idempotent edits, and an
+//! install-state file recording exactly what was added so uninstall never
+//! touches a setting it didn't create. Brian injects session-start context
+//! via hooks; Topos exposes MCP tools instead, so the Topos adapters
+//! register an MCP server (or, where a harness has no MCP support, drop a
+//! marked instructions block / skill file) rather than porting the hook
+//! machinery.
+//!
+//! Schema notes worth re-checking against each harness's current docs
+//! before this ships out of draft:
+//! - Claude Code stores user-scope MCP servers in `~/.claude.json`, not
+//!   `~/.claude/settings.json` (settings.json is hooks/permissions only).
+//! - Codex CLI, Gemini CLI, and Cursor accept the same
+//!   `{"command": "topos", "args": ["mcp"]}` shape Claude Desktop uses.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde_json::{json, Map, Value};
+use toml_edit::{value, Array, DocumentMut, Item, Table};
+
+/// Embedded so a globally-installed `topos` binary (cargo install, the
+/// curl installer, a package manager) can drop the skill file without a
+/// checkout of this repository on disk.
+pub(crate) const SKILL_MD: &str = include_str!("../../../../../skills/topos/SKILL.md");
+
+pub(crate) const SUPPORTED: [&str; 7] = [
+    "claude",
+    "claude-desktop",
+    "codex",
+    "gemini",
+    "copilot",
+    "skills",
+    "antigravity",
+];
+
+pub(crate) fn harness_name(id: &str) -> &'static str {
+    match id {
+        "claude" => "Claude Code",
+        "claude-desktop" => "Claude Desktop App",
+        "codex" => "Codex CLI",
+        "gemini" => "Gemini CLI",
+        "copilot" => "GitHub Copilot CLI",
+        "skills" => "Cursor & VS Code",
+        "antigravity" => "Google Antigravity",
+        _ => "Unknown harness",
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum State {
+    Active,
+    Stale,
+    Absent,
+}
+
+pub(crate) fn home_dir() -> Result<PathBuf, String> {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .filter(|p| !p.as_os_str().is_empty())
+        .ok_or_else(|| "cannot resolve home directory (HOME is unset)".to_string())
+}
+
+pub(crate) fn claude_desktop_config_path(home: &Path) -> PathBuf {
+    if cfg!(target_os = "macos") {
+        home.join("Library/Application Support/Claude/claude_desktop_config.json")
+    } else {
+        // Claude Desktop is not currently distributed for Linux; keep the
+        // conventional path so status/uninstall can clean up configs left
+        // by an earlier install.
+        home.join(".config/Claude/claude_desktop_config.json")
+    }
+}
+
+pub(crate) fn skill_path_claude(home: &Path) -> PathBuf {
+    home.join(".claude/skills/topos/SKILL.md")
+}
+
+pub(crate) fn skill_path_agents(home: &Path) -> PathBuf {
+    home.join(".agents/skills/topos/SKILL.md")
+}
+
+/// Directory used by the interactive menu to pre-select "detected" harnesses
+/// that aren't yet configured for Topos.
+pub(crate) fn detect_dir(id: &str, home: &Path) -> PathBuf {
+    match id {
+        "claude" => home.join(".claude"),
+        "claude-desktop" => claude_desktop_config_path(home)
+            .parent()
+            .expect("claude desktop config path always has a parent")
+            .to_path_buf(),
+        "codex" => home.join(".codex"),
+        "gemini" | "antigravity" => home.join(".gemini"),
+        "copilot" => home.join(".copilot"),
+        "skills" => home.join(".agents/skills"),
+        _ => home.to_path_buf(),
+    }
+}
+
+fn mcp_entry() -> Value {
+    json!({ "command": "topos", "args": ["mcp"] })
+}
+
+pub(crate) fn backup_path(path: &Path) -> PathBuf {
+    let mut name = path.file_name().unwrap_or_default().to_os_string();
+    name.push(".topos.backup");
+    path.with_file_name(name)
+}
+
+fn tmp_path(path: &Path) -> PathBuf {
+    let mut name = path.file_name().unwrap_or_default().to_os_string();
+    name.push(".topos.tmp");
+    path.with_file_name(name)
+}
+
+/// Write via a temp file + rename, optionally snapshotting the previous
+/// contents first. Creates parent directories as needed.
+fn atomic_write(path: &Path, contents: &str, backup: bool) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("creating {}: {e}", parent.display()))?;
+    }
+    if backup && path.is_file() {
+        fs::copy(path, backup_path(path))
+            .map_err(|e| format!("backing up {}: {e}", path.display()))?;
+    }
+    let tmp = tmp_path(path);
+    fs::write(&tmp, contents).map_err(|e| format!("writing {}: {e}", tmp.display()))?;
+    fs::rename(&tmp, path).map_err(|e| format!("replacing {}: {e}", path.display()))
+}
+
+/// Read a JSON object config, treating a missing file as empty. Errors on
+/// unreadable/invalid content or a non-object top level so callers never
+/// silently clobber something they can't safely parse.
+fn read_json_object(path: &Path) -> Result<Map<String, Value>, String> {
+    if !path.is_file() {
+        return Ok(Map::new());
+    }
+    let text = fs::read_to_string(path).map_err(|e| format!("reading {}: {e}", path.display()))?;
+    if text.trim().is_empty() {
+        return Ok(Map::new());
+    }
+    match serde_json::from_str(&text) {
+        Ok(Value::Object(map)) => Ok(map),
+        Ok(_) => Err(format!(
+            "{} top-level value must be an object",
+            path.display()
+        )),
+        Err(e) => Err(format!("parsing {}: {e}", path.display())),
+    }
+}
+
+fn write_json_object(path: &Path, data: &Map<String, Value>, backup: bool) -> Result<(), String> {
+    let contents = serde_json::to_string_pretty(data).map_err(|e| e.to_string())? + "\n";
+    atomic_write(path, &contents, backup)
+}
+
+/// `Active` when `mcpServers.topos` matches exactly, `Stale` when the key
+/// exists with different content (or the file fails to parse), `Absent`
+/// otherwise.
+pub(crate) fn json_mcp_state(path: &Path) -> State {
+    match read_json_object(path) {
+        Ok(map) => match map.get("mcpServers").and_then(|v| v.get("topos")) {
+            Some(entry) if *entry == mcp_entry() => State::Active,
+            Some(_) => State::Stale,
+            None => State::Absent,
+        },
+        Err(_) => State::Stale,
+    }
+}
+
+/// Merge `mcpServers.topos` into a JSON config. Returns `Ok(true)` if a
+/// write happened (the entry was missing or different).
+pub(crate) fn set_mcp_entry(path: &Path) -> Result<bool, String> {
+    let mut map = read_json_object(path)?;
+    let servers = map
+        .entry("mcpServers".to_string())
+        .or_insert_with(|| Value::Object(Map::new()));
+    let Value::Object(servers_map) = servers else {
+        return Err(format!("{} mcpServers must be an object", path.display()));
+    };
+    if servers_map.get("topos") == Some(&mcp_entry()) {
+        return Ok(false);
+    }
+    servers_map.insert("topos".to_string(), mcp_entry());
+    write_json_object(path, &map, true)?;
+    Ok(true)
+}
+
+/// Remove `mcpServers.topos`. The key name is the ownership marker, so any
+/// value under it is treated as Topos-owned even if stale.
+pub(crate) fn remove_mcp_entry(path: &Path, dry_run: bool) -> Result<bool, String> {
+    if !path.is_file() {
+        return Ok(false);
+    }
+    let mut map = read_json_object(path)?;
+    let removed = match map.get_mut("mcpServers") {
+        Some(Value::Object(servers)) => {
+            let removed = servers.remove("topos").is_some();
+            if removed && servers.is_empty() {
+                map.remove("mcpServers");
+            }
+            removed
+        }
+        _ => false,
+    };
+    if removed && !dry_run {
+        write_json_object(path, &map, true)?;
+    }
+    Ok(removed)
+}
+
+/// Delete a JSON config entirely if `topos install` created it and it has
+/// since been emptied back out by uninstall.
+pub(crate) fn delete_if_empty_and_owned(
+    path: &Path,
+    home: &Path,
+    harness: &str,
+    dry_run: bool,
+) -> Result<bool, String> {
+    if dry_run || !path.is_file() || !was_created_by_install(home, harness, path) {
+        return Ok(false);
+    }
+    if !read_json_object(path).unwrap_or_default().is_empty() {
+        return Ok(false);
+    }
+    fs::remove_file(path).map_err(|e| format!("removing {}: {e}", path.display()))?;
+    Ok(true)
+}
+
+/// Delete a text config entirely if `topos install` created it and its
+/// content has since been trimmed down to nothing.
+pub(crate) fn delete_text_if_blank_and_owned(
+    path: &Path,
+    home: &Path,
+    harness: &str,
+    dry_run: bool,
+) -> Result<bool, String> {
+    if dry_run || !path.is_file() || !was_created_by_install(home, harness, path) {
+        return Ok(false);
+    }
+    if !fs::read_to_string(path)
+        .unwrap_or_default()
+        .trim()
+        .is_empty()
+    {
+        return Ok(false);
+    }
+    fs::remove_file(path).map_err(|e| format!("removing {}: {e}", path.display()))?;
+    Ok(true)
+}
+
+pub(crate) fn codex_state(path: &Path) -> State {
+    let Ok(text) = fs::read_to_string(path) else {
+        return State::Absent;
+    };
+    let Ok(doc) = text.parse::<DocumentMut>() else {
+        return State::Stale;
+    };
+    let Some(servers) = doc.get("mcp_servers").and_then(Item::as_table) else {
+        return State::Absent;
+    };
+    let Some(entry) = servers.get("topos") else {
+        return State::Absent;
+    };
+    let Some(table) = entry.as_table() else {
+        return State::Stale;
+    };
+    let command = table.get("command").and_then(Item::as_str);
+    let args_ok = table
+        .get("args")
+        .and_then(Item::as_array)
+        .map(|a| a.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>() == vec!["mcp"])
+        .unwrap_or(false);
+    if command == Some("topos") && args_ok {
+        State::Active
+    } else {
+        State::Stale
+    }
+}
+
+pub(crate) fn set_codex_entry(path: &Path) -> Result<bool, String> {
+    if codex_state(path) == State::Active {
+        return Ok(false);
+    }
+    let text = fs::read_to_string(path).unwrap_or_default();
+    let mut doc = text
+        .parse::<DocumentMut>()
+        .map_err(|e| format!("parsing {}: {e}", path.display()))?;
+    if doc.get("mcp_servers").and_then(Item::as_table).is_none() {
+        doc["mcp_servers"] = Item::Table(Table::new());
+    }
+    let servers = doc["mcp_servers"]
+        .as_table_mut()
+        .ok_or_else(|| format!("{} mcp_servers must be a table", path.display()))?;
+    let mut entry = Table::new();
+    entry["command"] = value("topos");
+    let mut args = Array::new();
+    args.push("mcp");
+    entry["args"] = value(args);
+    servers.insert("topos", Item::Table(entry));
+    atomic_write(path, &doc.to_string(), path.is_file())?;
+    Ok(true)
+}
+
+pub(crate) fn remove_codex_entry(path: &Path, dry_run: bool) -> Result<bool, String> {
+    if !path.is_file() {
+        return Ok(false);
+    }
+    let text = fs::read_to_string(path).map_err(|e| format!("reading {}: {e}", path.display()))?;
+    let mut doc = text
+        .parse::<DocumentMut>()
+        .map_err(|e| format!("parsing {}: {e}", path.display()))?;
+    let removed = match doc.get_mut("mcp_servers").and_then(Item::as_table_mut) {
+        Some(servers) => {
+            let removed = servers.remove("topos").is_some();
+            if removed && servers.is_empty() {
+                doc.remove("mcp_servers");
+            }
+            removed
+        }
+        None => false,
+    };
+    if removed && !dry_run {
+        atomic_write(path, &doc.to_string(), true)?;
+    }
+    Ok(removed)
+}
+
+const COPILOT_START: &str = "<!-- topos:start -->";
+const COPILOT_END: &str = "<!-- topos:end -->";
+
+fn copilot_block() -> String {
+    format!(
+        "{COPILOT_START}\nTopos is available for structural code-quality checks: run \
+`topos evaluate <path> -r` or `topos inspect <file>` before committing significant \
+changes. See `topos --help`.\n{COPILOT_END}\n"
+    )
+}
+
+pub(crate) fn copilot_state(path: &Path) -> State {
+    let Ok(text) = fs::read_to_string(path) else {
+        return State::Absent;
+    };
+    match (text.contains(COPILOT_START), text.contains(COPILOT_END)) {
+        (true, true) => State::Active,
+        (false, false) => State::Absent,
+        _ => State::Stale,
+    }
+}
+
+pub(crate) fn set_copilot_block(path: &Path) -> Result<bool, String> {
+    let existing = fs::read_to_string(path).unwrap_or_default();
+    if existing.contains(COPILOT_START) {
+        return Ok(false);
+    }
+    let separator = if existing.is_empty() || existing.ends_with('\n') {
+        ""
+    } else {
+        "\n"
+    };
+    let updated = format!("{existing}{separator}\n{}", copilot_block());
+    atomic_write(path, &updated, true)?;
+    Ok(true)
+}
+
+pub(crate) fn remove_copilot_block(path: &Path, dry_run: bool) -> Result<bool, String> {
+    if !path.is_file() {
+        return Ok(false);
+    }
+    let text = fs::read_to_string(path).map_err(|e| format!("reading {}: {e}", path.display()))?;
+    let (Some(start), Some(end_marker)) = (text.find(COPILOT_START), text.find(COPILOT_END)) else {
+        return Ok(false);
+    };
+    let end = end_marker + COPILOT_END.len();
+    let before = text[..start].trim_end();
+    let after = text[end..].trim_start();
+    let mut updated = before.to_string();
+    if !before.is_empty() && !after.is_empty() {
+        updated.push_str("\n\n");
+    }
+    updated.push_str(after);
+    if !dry_run {
+        if updated.trim().is_empty() {
+            fs::remove_file(path).map_err(|e| format!("removing {}: {e}", path.display()))?;
+        } else {
+            atomic_write(path, &(updated.trim_end().to_string() + "\n"), true)?;
+        }
+    }
+    Ok(true)
+}
+
+pub(crate) fn skill_state(path: &Path) -> State {
+    match fs::read_to_string(path) {
+        Ok(text) if text == SKILL_MD => State::Active,
+        Ok(_) => State::Stale,
+        Err(_) => State::Absent,
+    }
+}
+
+pub(crate) fn write_skill(path: &Path) -> Result<bool, String> {
+    if fs::read_to_string(path).ok().as_deref() == Some(SKILL_MD) {
+        return Ok(false);
+    }
+    atomic_write(path, SKILL_MD, path.is_file())?;
+    Ok(true)
+}
+
+/// Remove a file this installer wrote only if its content still matches
+/// exactly what was written — a user edit is left in place, reported by the
+/// caller as preserved rather than silently overwritten or deleted.
+pub(crate) fn remove_owned_file(
+    path: &Path,
+    expected: &str,
+    dry_run: bool,
+) -> Result<bool, String> {
+    match fs::read_to_string(path) {
+        Ok(text) if text == expected => {
+            if !dry_run {
+                fs::remove_file(path).map_err(|e| format!("removing {}: {e}", path.display()))?;
+            }
+            Ok(true)
+        }
+        _ => Ok(false),
+    }
+}
+
+pub(crate) fn antigravity_pointer_path(home: &Path) -> PathBuf {
+    home.join(".gemini/topos-skill.md")
+}
+
+fn antigravity_import_line(home: &Path) -> String {
+    format!("@import {}", antigravity_pointer_path(home).display())
+}
+
+pub(crate) fn antigravity_state(home: &Path) -> State {
+    let gemini_md = home.join(".gemini/GEMINI.md");
+    let import_line = antigravity_import_line(home);
+    let import_present = fs::read_to_string(&gemini_md)
+        .map(|text| text.lines().any(|line| line.trim() == import_line))
+        .unwrap_or(false);
+    let pointer_present = antigravity_pointer_path(home).is_file();
+    match (import_present, pointer_present) {
+        (true, true) => State::Active,
+        (false, false) => State::Absent,
+        _ => State::Stale,
+    }
+}
+
+pub(crate) fn set_antigravity_import(home: &Path) -> Result<bool, String> {
+    let pointer = antigravity_pointer_path(home);
+    let pointer_changed = fs::read_to_string(&pointer).ok().as_deref() != Some(SKILL_MD);
+    if pointer_changed {
+        atomic_write(&pointer, SKILL_MD, pointer.is_file())?;
+    }
+    let gemini_md = home.join(".gemini/GEMINI.md");
+    let existing = fs::read_to_string(&gemini_md).unwrap_or_default();
+    let import_line = antigravity_import_line(home);
+    if existing.lines().any(|line| line.trim() == import_line) {
+        return Ok(pointer_changed);
+    }
+    let separator = if existing.is_empty() || existing.ends_with('\n') {
+        ""
+    } else {
+        "\n"
+    };
+    let updated = format!("{existing}{separator}{import_line}\n");
+    atomic_write(&gemini_md, &updated, true)?;
+    Ok(true)
+}
+
+pub(crate) fn remove_antigravity_import(home: &Path, dry_run: bool) -> Result<bool, String> {
+    let gemini_md = home.join(".gemini/GEMINI.md");
+    let import_line = antigravity_import_line(home);
+    let mut changed = false;
+    if let Ok(text) = fs::read_to_string(&gemini_md) {
+        if text.lines().any(|line| line.trim() == import_line) {
+            changed = true;
+            if !dry_run {
+                let kept: Vec<&str> = text
+                    .lines()
+                    .filter(|line| line.trim() != import_line)
+                    .collect();
+                if kept.iter().all(|line| line.trim().is_empty()) {
+                    fs::remove_file(&gemini_md).ok();
+                } else {
+                    atomic_write(&gemini_md, &(kept.join("\n") + "\n"), true)?;
+                }
+            }
+        }
+    }
+    let pointer = antigravity_pointer_path(home);
+    if pointer.is_file() {
+        changed = true;
+        if !dry_run {
+            fs::remove_file(&pointer)
+                .map_err(|e| format!("removing {}: {e}", pointer.display()))?;
+        }
+    }
+    Ok(changed)
+}
+
+fn combine(a: State, b: State) -> State {
+    match (a, b) {
+        (State::Active, State::Active) => State::Active,
+        (State::Absent, State::Absent) => State::Absent,
+        _ => State::Stale,
+    }
+}
+
+/// Overall state for one harness, folding together every artifact it owns
+/// (an MCP entry plus a skill file, for the two harnesses that get both).
+pub(crate) fn integration_state(id: &str, home: &Path) -> State {
+    match id {
+        "claude" => combine(
+            json_mcp_state(&home.join(".claude.json")),
+            skill_state(&skill_path_claude(home)),
+        ),
+        "claude-desktop" => json_mcp_state(&claude_desktop_config_path(home)),
+        "codex" => codex_state(&home.join(".codex/config.toml")),
+        "gemini" => json_mcp_state(&home.join(".gemini/settings.json")),
+        "copilot" => copilot_state(&home.join(".copilot/copilot-instructions.md")),
+        "skills" => combine(
+            json_mcp_state(&home.join(".cursor/mcp.json")),
+            skill_state(&skill_path_agents(home)),
+        ),
+        "antigravity" => antigravity_state(home),
+        _ => State::Absent,
+    }
+}
+
+fn state_file_path(home: &Path) -> PathBuf {
+    home.join(".local/state/topos/install.json")
+}
+
+/// Record that `topos install` created `path` from scratch (it didn't exist
+/// before), so uninstall knows it's safe to delete once emptied back out.
+pub(crate) fn record_created_file(home: &Path, harness: &str, path: &Path) -> Result<(), String> {
+    let state_path = state_file_path(home);
+    let mut state = read_json_object(&state_path).unwrap_or_default();
+    let entry = state
+        .entry(harness.to_string())
+        .or_insert_with(|| json!({ "createdFiles": [] }));
+    if let Value::Object(entry_map) = entry {
+        let list = entry_map
+            .entry("createdFiles".to_string())
+            .or_insert_with(|| Value::Array(Vec::new()));
+        if let Value::Array(arr) = list {
+            let value = Value::String(path.display().to_string());
+            if !arr.contains(&value) {
+                arr.push(value);
+            }
+        }
+    }
+    write_json_object(&state_path, &state, false)
+}
+
+pub(crate) fn was_created_by_install(home: &Path, harness: &str, path: &Path) -> bool {
+    let target = path.display().to_string();
+    read_json_object(&state_file_path(home))
+        .unwrap_or_default()
+        .get(harness)
+        .and_then(|v| v.get("createdFiles"))
+        .and_then(Value::as_array)
+        .map(|arr| arr.iter().any(|v| v.as_str() == Some(target.as_str())))
+        .unwrap_or(false)
+}
+
+pub(crate) fn clear_created_files(home: &Path, harness: &str) -> Result<(), String> {
+    let state_path = state_file_path(home);
+    let mut state = read_json_object(&state_path).unwrap_or_default();
+    if state.remove(harness).is_none() {
+        return Ok(());
+    }
+    if state.is_empty() {
+        if state_path.is_file() {
+            fs::remove_file(&state_path)
+                .map_err(|e| format!("removing {}: {e}", state_path.display()))?;
+        }
+        Ok(())
+    } else {
+        write_json_object(&state_path, &state, false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp_dir(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "topos-install-{label}-{}-{}",
+            std::process::id(),
+            label.len()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn json_mcp_entry_round_trips_through_install_and_uninstall() {
+        let dir = tmp_dir("json-roundtrip");
+        let path = dir.join("settings.json");
+        fs::write(&path, r#"{"mcpServers": {"other": {"command": "foo"}}}"#).unwrap();
+
+        assert_eq!(json_mcp_state(&path), State::Absent);
+        assert!(set_mcp_entry(&path).unwrap());
+        assert_eq!(json_mcp_state(&path), State::Active);
+        // Re-applying is a no-op, matching install's idempotency contract.
+        assert!(!set_mcp_entry(&path).unwrap());
+
+        assert!(remove_mcp_entry(&path, false).unwrap());
+        assert_eq!(json_mcp_state(&path), State::Absent);
+        // The foreign sibling entry must survive removal.
+        let text = fs::read_to_string(&path).unwrap();
+        assert!(text.contains("\"other\""));
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn dry_run_uninstall_makes_no_filesystem_changes() {
+        let dir = tmp_dir("dry-run");
+        let path = dir.join("settings.json");
+        set_mcp_entry(&path).unwrap();
+        let before = fs::read_to_string(&path).unwrap();
+
+        assert!(remove_mcp_entry(&path, true).unwrap());
+
+        let after = fs::read_to_string(&path).unwrap();
+        assert_eq!(before, after, "dry-run must not touch the file");
+        assert_eq!(json_mcp_state(&path), State::Active);
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn stale_entry_is_detected_and_still_removable() {
+        let dir = tmp_dir("stale");
+        let path = dir.join("settings.json");
+        fs::write(
+            &path,
+            r#"{"mcpServers": {"topos": {"command": "old-binary"}}}"#,
+        )
+        .unwrap();
+
+        assert_eq!(json_mcp_state(&path), State::Stale);
+        assert!(remove_mcp_entry(&path, false).unwrap());
+        assert_eq!(json_mcp_state(&path), State::Absent);
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn codex_toml_entry_round_trips_and_preserves_unrelated_tables() {
+        let dir = tmp_dir("codex");
+        let path = dir.join("config.toml");
+        fs::write(&path, "[model]\nname = \"gpt\"\n").unwrap();
+
+        assert_eq!(codex_state(&path), State::Absent);
+        assert!(set_codex_entry(&path).unwrap());
+        assert_eq!(codex_state(&path), State::Active);
+        assert!(!set_codex_entry(&path).unwrap());
+
+        assert!(remove_codex_entry(&path, false).unwrap());
+        assert_eq!(codex_state(&path), State::Absent);
+        let text = fs::read_to_string(&path).unwrap();
+        assert!(text.contains("name = \"gpt\""));
+        assert!(!text.contains("mcp_servers"));
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn copilot_block_is_marker_delimited_and_leaves_other_content_alone() {
+        let dir = tmp_dir("copilot");
+        let path = dir.join("copilot-instructions.md");
+        fs::write(&path, "# My instructions\nAlways use tabs.\n").unwrap();
+
+        assert!(set_copilot_block(&path).unwrap());
+        assert_eq!(copilot_state(&path), State::Active);
+
+        assert!(remove_copilot_block(&path, false).unwrap());
+        assert_eq!(copilot_state(&path), State::Absent);
+        let text = fs::read_to_string(&path).unwrap();
+        assert!(text.contains("Always use tabs."));
+        assert!(!text.contains("topos:start"));
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn owned_file_is_only_removed_when_content_still_matches() {
+        let dir = tmp_dir("owned-file");
+        let path = dir.join("SKILL.md");
+        fs::write(&path, "expected").unwrap();
+
+        // A user edit means the removal is skipped rather than clobbered.
+        fs::write(&path, "user edited this").unwrap();
+        assert!(!remove_owned_file(&path, "expected", false).unwrap());
+        assert!(path.is_file());
+
+        fs::write(&path, "expected").unwrap();
+        assert!(remove_owned_file(&path, "expected", false).unwrap());
+        assert!(!path.is_file());
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn created_file_ownership_is_tracked_and_cleared() {
+        let home = tmp_dir("ownership-home");
+        let target = home.join("some/config.json");
+
+        assert!(!was_created_by_install(&home, "claude", &target));
+        record_created_file(&home, "claude", &target).unwrap();
+        assert!(was_created_by_install(&home, "claude", &target));
+
+        clear_created_files(&home, "claude").unwrap();
+        assert!(!was_created_by_install(&home, "claude", &target));
+        fs::remove_dir_all(home).ok();
+    }
+
+    #[test]
+    fn antigravity_import_round_trips() {
+        let home = tmp_dir("antigravity");
+        fs::create_dir_all(home.join(".gemini")).unwrap();
+        fs::write(home.join(".gemini/GEMINI.md"), "# My rules\nBe concise.\n").unwrap();
+
+        assert_eq!(antigravity_state(&home), State::Absent);
+        assert!(set_antigravity_import(&home).unwrap());
+        assert_eq!(antigravity_state(&home), State::Active);
+
+        assert!(remove_antigravity_import(&home, false).unwrap());
+        assert_eq!(antigravity_state(&home), State::Absent);
+        let text = fs::read_to_string(home.join(".gemini/GEMINI.md")).unwrap();
+        assert!(text.contains("Be concise."));
+        fs::remove_dir_all(home).ok();
+    }
+}

--- a/topos/cli/src/commands/install/menu.rs
+++ b/topos/cli/src/commands/install/menu.rs
@@ -1,0 +1,129 @@
+//! Interactive multi-select TTY menu for `topos install` / `topos
+//! uninstall`, styled after the single-select loop in `commands/config.rs`
+//! but with checkboxes instead of a single choice.
+
+use console::{Key, Term};
+
+use crate::commands::render::{paint, RenderOptions};
+
+pub(crate) struct MenuOption {
+    pub(crate) id: &'static str,
+    pub(crate) name: &'static str,
+    pub(crate) hint: String,
+    pub(crate) checked: bool,
+}
+
+/// What a keypress means, independent of terminal/IO concerns — kept
+/// separate from `run_menu`'s loop so neither function's branching stacks
+/// on top of the other's.
+enum Action {
+    Move(isize),
+    Toggle,
+    ToggleAll,
+    Confirm,
+    Cancel,
+    Ignore,
+}
+
+fn interpret_key(key: Key) -> Action {
+    match key {
+        Key::ArrowUp | Key::Char('k') => Action::Move(-1),
+        Key::ArrowDown | Key::Char('j') => Action::Move(1),
+        Key::Char(' ') => Action::Toggle,
+        Key::Char('a') => Action::ToggleAll,
+        Key::Enter => Action::Confirm,
+        Key::Escape | Key::CtrlC | Key::Char('q') => Action::Cancel,
+        _ => Action::Ignore,
+    }
+}
+
+fn move_cursor(cursor: usize, delta: isize, len: usize) -> usize {
+    if delta < 0 {
+        cursor.checked_sub(1).unwrap_or(len - 1)
+    } else {
+        (cursor + 1) % len
+    }
+}
+
+fn toggle_all(options: &mut [MenuOption]) {
+    let all_checked = options.iter().all(|o| o.checked);
+    for option in options {
+        option.checked = !all_checked;
+    }
+}
+
+fn confirmed_selection(options: &[MenuOption]) -> Vec<String> {
+    options
+        .iter()
+        .filter(|o| o.checked)
+        .map(|o| o.id.to_string())
+        .collect()
+}
+
+/// Run an interactive checkbox list. Returns the selected ids, or `None` if
+/// the user cancelled (Esc/q/Ctrl-C).
+pub(crate) fn run_menu(
+    title: &str,
+    mut options: Vec<MenuOption>,
+) -> Result<Option<Vec<String>>, String> {
+    if options.is_empty() {
+        return Ok(Some(Vec::new()));
+    }
+    let term = Term::stderr();
+    let mut cursor = 0usize;
+    let mut rendered = 0usize;
+    term.hide_cursor().map_err(|e| e.to_string())?;
+    let result = (|| -> Result<Option<Vec<String>>, String> {
+        loop {
+            if rendered > 0 {
+                term.clear_last_lines(rendered).map_err(|e| e.to_string())?;
+            }
+            let lines = render(title, &options, cursor, RenderOptions::stderr());
+            rendered = lines.len();
+            for line in &lines {
+                term.write_line(line).map_err(|e| e.to_string())?;
+            }
+            match interpret_key(term.read_key().map_err(|e| e.to_string())?) {
+                Action::Move(delta) => cursor = move_cursor(cursor, delta, options.len()),
+                Action::Toggle => options[cursor].checked = !options[cursor].checked,
+                Action::ToggleAll => toggle_all(&mut options),
+                Action::Confirm => return Ok(Some(confirmed_selection(&options))),
+                Action::Cancel => return Ok(None),
+                Action::Ignore => {}
+            }
+        }
+    })();
+    term.show_cursor().ok();
+    result
+}
+
+fn render(title: &str, options: &[MenuOption], cursor: usize, opts: RenderOptions) -> Vec<String> {
+    let mut lines = vec![
+        paint(format!("┌  {title}"), console::Style::new().bold(), opts),
+        "│".to_string(),
+        format!(
+            "│  {}",
+            paint(
+                "↑↓ move · space toggle · a all · enter confirm · esc cancel",
+                console::Style::new().dim(),
+                opts,
+            )
+        ),
+        "│".to_string(),
+    ];
+    for (idx, option) in options.iter().enumerate() {
+        let pointer = if idx == cursor { "›" } else { " " };
+        let checkbox = if option.checked { "●" } else { "○" };
+        let row = format!("{pointer} {checkbox} {:<20} {}", option.name, option.hint);
+        let style = if idx == cursor {
+            console::Style::new().bold()
+        } else if option.checked {
+            console::Style::new()
+        } else {
+            console::Style::new().dim()
+        };
+        lines.push(format!("│ {}", paint(row, style, opts)));
+    }
+    lines.push("└".to_string());
+    lines
+}

--- a/topos/cli/src/commands/install/mod.rs
+++ b/topos/cli/src/commands/install/mod.rs
@@ -1,0 +1,211 @@
+//! `topos install` / `topos uninstall` — configure or remove Topos support
+//! in agent harnesses (Claude Code, Claude Desktop, Codex CLI, Gemini CLI,
+//! GitHub Copilot CLI, Cursor & VS Code, Google Antigravity).
+//!
+//! Structure follows the harness-installer pattern in sgathrid/brian
+//! (`wikicli/lifecycle/`): a small state module (`integrations`), an
+//! install/uninstall pass per harness, a status report, and an interactive
+//! TTY menu for picking targets. See `integrations.rs` for the schema
+//! notes and how Topos's mechanism (MCP registration + a skill file)
+//! differs from brian's session-start hooks.
+
+mod configure;
+mod integrations;
+mod menu;
+mod status;
+mod uninstall;
+
+use std::path::Path;
+
+use clap::{Args, Subcommand};
+use console::Term;
+
+use integrations::{detect_dir, harness_name, home_dir, integration_state, State, SUPPORTED};
+use menu::{run_menu, MenuOption};
+
+#[derive(Args)]
+pub struct InstallArgs {
+    #[command(subcommand)]
+    command: Option<InstallCommand>,
+    /// Harness ids to configure (claude, claude-desktop, codex, gemini,
+    /// copilot, skills, antigravity). Omit for interactive selection in a
+    /// TTY, or pass --all.
+    harnesses: Vec<String>,
+    /// Configure every supported harness.
+    #[arg(long)]
+    all: bool,
+    /// Preview changes without writing anything.
+    #[arg(long)]
+    dry_run: bool,
+}
+
+#[derive(Subcommand)]
+enum InstallCommand {
+    /// Show which harnesses are configured for Topos.
+    Status(StatusArgs),
+}
+
+#[derive(Args)]
+pub struct StatusArgs {
+    /// Emit machine-readable JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Args)]
+pub struct UninstallArgs {
+    /// Harness ids to remove. Omit for interactive selection in a TTY, or
+    /// pass --all.
+    harnesses: Vec<String>,
+    /// Target every supported harness.
+    #[arg(long)]
+    all: bool,
+    /// Actually remove Topos-owned entries. Without this, uninstall only
+    /// previews what would change.
+    #[arg(long)]
+    apply: bool,
+    /// Also delete the `.topos.backup` files left by earlier installs.
+    #[arg(long)]
+    purge_backups: bool,
+}
+
+pub fn run_install(args: InstallArgs) -> Result<(), String> {
+    let home = home_dir()?;
+    if let Some(InstallCommand::Status(status_args)) = args.command {
+        return status::run(&home, status_args.json);
+    }
+    let explicit = !args.harnesses.is_empty() || args.all;
+    let selected = if explicit {
+        validate_ids(&args.harnesses, args.all)?
+    } else if Term::stderr().is_term() {
+        match interactive_select(&home, Selection::Install)? {
+            Some(ids) => ids,
+            None => return Ok(()),
+        }
+    } else {
+        return Err(
+            "non-interactive shells must pass explicit harness names or --all \
+(see `topos install --help`)"
+                .to_string(),
+        );
+    };
+    if selected.is_empty() {
+        println!("No integrations selected.");
+        return Ok(());
+    }
+    configure::run(&home, &selected, args.dry_run)
+}
+
+pub fn run_uninstall(args: UninstallArgs) -> Result<(), String> {
+    let home = home_dir()?;
+    let interactive_tty = Term::stderr().is_term();
+    let explicit = !args.harnesses.is_empty() || args.all;
+    let selected = if explicit {
+        validate_ids(&args.harnesses, args.all)?
+    } else if interactive_tty {
+        match interactive_select(&home, Selection::Uninstall)? {
+            Some(ids) => ids,
+            None => return Ok(()),
+        }
+    } else {
+        SUPPORTED
+            .iter()
+            .copied()
+            .map(str::to_string)
+            .filter(|id| integration_state(id, &home) != State::Absent)
+            .collect()
+    };
+    if selected.is_empty() {
+        println!("No integrations selected for removal.");
+        return Ok(());
+    }
+
+    let mut apply = args.apply;
+    if !apply {
+        uninstall::run(&home, &selected, true, false)?;
+        if interactive_tty {
+            apply = confirm("Apply these changes?")?;
+        }
+    }
+    if apply {
+        uninstall::run(&home, &selected, false, args.purge_backups)
+    } else {
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Selection {
+    Install,
+    Uninstall,
+}
+
+fn interactive_select(home: &Path, mode: Selection) -> Result<Option<Vec<String>>, String> {
+    let title = match mode {
+        Selection::Install => "Which agent integrations do you want to configure?",
+        Selection::Uninstall => "Which agent integrations do you want to uninstall?",
+    };
+    let options = SUPPORTED
+        .iter()
+        .copied()
+        .map(|id| {
+            let state = integration_state(id, home);
+            let (hint, checked) = match (mode, state) {
+                (_, State::Active) => ("active".to_string(), true),
+                (_, State::Stale) => ("stale — needs repair".to_string(), true),
+                (Selection::Install, State::Absent) => {
+                    let detected = detect_dir(id, home).exists();
+                    let hint = if detected {
+                        "detected"
+                    } else {
+                        "not configured"
+                    };
+                    (hint.to_string(), detected)
+                }
+                (Selection::Uninstall, State::Absent) => ("not configured".to_string(), false),
+            };
+            MenuOption {
+                id,
+                name: harness_name(id),
+                hint,
+                checked,
+            }
+        })
+        .collect();
+    run_menu(title, options)
+}
+
+fn confirm(prompt: &str) -> Result<bool, String> {
+    use std::io::Write as _;
+    eprint!("{prompt} [y/N] ");
+    std::io::stderr().flush().map_err(|e| e.to_string())?;
+    let key = Term::stderr().read_key().map_err(|e| e.to_string())?;
+    eprintln!();
+    Ok(matches!(key, console::Key::Char('y' | 'Y')))
+}
+
+fn validate_ids(ids: &[String], all: bool) -> Result<Vec<String>, String> {
+    if all {
+        return Ok(SUPPORTED.iter().map(|s| s.to_string()).collect());
+    }
+    let mut unknown = Vec::new();
+    let mut selected = Vec::new();
+    for id in ids {
+        let lower = id.to_ascii_lowercase();
+        if SUPPORTED.contains(&lower.as_str()) {
+            if !selected.contains(&lower) {
+                selected.push(lower);
+            }
+        } else {
+            unknown.push(id.clone());
+        }
+    }
+    if !unknown.is_empty() {
+        return Err(format!(
+            "unknown harness(es): {} (supported: {})",
+            unknown.join(", "),
+            SUPPORTED.join(", ")
+        ));
+    }
+    Ok(selected)
+}

--- a/topos/cli/src/commands/install/status.rs
+++ b/topos/cli/src/commands/install/status.rs
@@ -1,0 +1,99 @@
+//! `topos install status` — report which harnesses are configured.
+
+use std::path::Path;
+
+use console::Style;
+use serde_json::json;
+
+use super::integrations::{harness_name, integration_state, State, SUPPORTED};
+use crate::commands::render::{paint, RenderOptions};
+
+pub(crate) fn run(home: &Path, json_output: bool) -> Result<(), String> {
+    let states: Vec<(&str, State)> = SUPPORTED
+        .iter()
+        .map(|id| (*id, integration_state(id, home)))
+        .collect();
+
+    if json_output {
+        let active = states.iter().filter(|(_, s)| *s == State::Active).count();
+        let harnesses: Vec<_> = states
+            .iter()
+            .map(|(id, state)| {
+                json!({
+                    "id": id,
+                    "name": harness_name(id),
+                    "state": state_label(*state),
+                })
+            })
+            .collect();
+        let payload = json!({
+            "active": active,
+            "total": SUPPORTED.len(),
+            "harnesses": harnesses,
+        });
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&payload).map_err(|e| e.to_string())?
+        );
+        return Ok(());
+    }
+
+    let opts = RenderOptions::stdout();
+    println!(
+        "{}",
+        paint("┌  Topos Harness Status", Style::new().bold(), opts)
+    );
+    println!("│");
+
+    let rank = |state: State| match state {
+        State::Active => 0,
+        State::Stale => 1,
+        State::Absent => 2,
+    };
+    let mut sorted = states;
+    sorted.sort_by_key(|(_, state)| rank(*state));
+
+    let mut active_count = 0;
+    for (idx, (id, state)) in sorted.iter().enumerate() {
+        println!("│  {}", paint(harness_name(id), Style::new().bold(), opts));
+        match state {
+            State::Active => {
+                println!("│    {} configured", paint("✓", Style::new().green(), opts));
+                active_count += 1;
+            }
+            State::Stale => println!(
+                "│    {} stale or incomplete — run `topos uninstall {id}` or `topos install {id}`",
+                paint("▲", Style::new().color256(208), opts)
+            ),
+            State::Absent => println!(
+                "│    {} not configured",
+                paint("○", Style::new().dim(), opts)
+            ),
+        }
+        if idx < sorted.len() - 1 {
+            println!("│");
+        }
+    }
+
+    println!("│");
+    println!(
+        "└  {}",
+        paint(
+            format!(
+                "Done. {active_count}/{} harness integrations active.",
+                SUPPORTED.len()
+            ),
+            Style::new().bold(),
+            opts,
+        )
+    );
+    Ok(())
+}
+
+fn state_label(state: State) -> &'static str {
+    match state {
+        State::Active => "active",
+        State::Stale => "stale",
+        State::Absent => "absent",
+    }
+}

--- a/topos/cli/src/commands/install/uninstall.rs
+++ b/topos/cli/src/commands/install/uninstall.rs
@@ -1,0 +1,358 @@
+//! `topos uninstall` — remove Topos-owned entries from one or more agent
+//! harnesses. Defaults to a dry-run preview; the caller decides whether to
+//! actually apply (see `mod.rs`'s `--apply` handling).
+
+use std::path::Path;
+
+use console::Style;
+
+use super::integrations::{
+    self, antigravity_pointer_path, backup_path, claude_desktop_config_path, clear_created_files,
+    delete_if_empty_and_owned, delete_text_if_blank_and_owned, remove_antigravity_import,
+    remove_codex_entry, remove_copilot_block, remove_mcp_entry, remove_owned_file,
+    skill_path_agents, skill_path_claude, State, SKILL_MD,
+};
+use crate::commands::render::{paint, RenderOptions};
+
+fn removed(opts: RenderOptions) -> String {
+    paint("●", Style::new().red(), opts)
+}
+
+fn absent(opts: RenderOptions) -> String {
+    paint("○", Style::new().dim(), opts)
+}
+
+fn err(opts: RenderOptions) -> String {
+    paint("✕", Style::new().red(), opts)
+}
+
+/// Shared three-way branch every uninstall step follows: nothing to do,
+/// a dry-run preview, or an actual removal.
+fn removal_step(
+    state: State,
+    dry_run: bool,
+    absent_msg: &str,
+    preview_msg: &str,
+    removed_msg: &str,
+    apply: impl FnOnce() -> Result<bool, String>,
+    opts: RenderOptions,
+) -> bool {
+    if state == State::Absent {
+        println!("│    {} {absent_msg}", absent(opts));
+        return true;
+    }
+    if dry_run {
+        println!("│    {} [dry run] {preview_msg}", removed(opts));
+        return true;
+    }
+    match apply() {
+        Ok(_) => {
+            println!("│    {} {removed_msg}", removed(opts));
+            true
+        }
+        Err(e) => {
+            println!("│    {} {e}", err(opts));
+            false
+        }
+    }
+}
+
+type Handler = fn(&Path, bool, RenderOptions) -> bool;
+
+/// One entry per supported harness id — a data table instead of a match arm
+/// per harness keeps `run` itself flat regardless of how many harnesses
+/// exist.
+const HANDLERS: &[(&str, Handler)] = &[
+    ("claude", uninstall_claude),
+    ("claude-desktop", uninstall_claude_desktop),
+    ("codex", uninstall_codex),
+    ("gemini", uninstall_gemini),
+    ("copilot", uninstall_copilot),
+    ("skills", uninstall_skills),
+    ("antigravity", uninstall_antigravity),
+];
+
+pub(crate) fn run(
+    home: &Path,
+    selected: &[String],
+    dry_run: bool,
+    purge_backups: bool,
+) -> Result<(), String> {
+    let opts = RenderOptions::stdout();
+    print_header(dry_run, opts);
+
+    let mut success = true;
+    for id in selected {
+        success &= dispatch(id, home, dry_run, opts);
+    }
+
+    if purge_backups && !dry_run {
+        println!("│  Purging backup files...");
+        purge_backup_files(home, opts);
+        println!("│");
+    }
+
+    print_summary(success, dry_run, opts)
+}
+
+fn dispatch(id: &str, home: &Path, dry_run: bool, opts: RenderOptions) -> bool {
+    match HANDLERS.iter().find(|(harness_id, _)| *harness_id == id) {
+        Some((_, handler)) => handler(home, dry_run, opts),
+        None => {
+            println!("│  {} unknown harness: {id}", err(opts));
+            false
+        }
+    }
+}
+
+fn print_header(dry_run: bool, opts: RenderOptions) {
+    let mode = if dry_run {
+        " (DRY RUN — PREVIEW ONLY, NO CHANGES MADE)"
+    } else {
+        ""
+    };
+    println!(
+        "{}",
+        paint(
+            format!("┌  Topos Harness Uninstall{mode}"),
+            Style::new().bold(),
+            opts
+        )
+    );
+    println!("│");
+}
+
+fn print_summary(success: bool, dry_run: bool, opts: RenderOptions) -> Result<(), String> {
+    let summary = if dry_run {
+        "Done. (dry run — re-run with --apply to make these changes)"
+    } else {
+        "Done."
+    };
+    println!("└  {}", paint(summary, Style::new().bold(), opts));
+    if success {
+        Ok(())
+    } else {
+        Err("one or more harnesses failed to uninstall cleanly".to_string())
+    }
+}
+
+fn uninstall_claude(home: &Path, dry_run: bool, opts: RenderOptions) -> bool {
+    println!(
+        "│  {}",
+        paint("Claude Code (~/.claude)", Style::new().bold(), opts)
+    );
+    let config = home.join(".claude.json");
+    let mut success = removal_step(
+        integrations::json_mcp_state(&config),
+        dry_run,
+        "no MCP server entry found",
+        &format!("would remove MCP server entry from {}", config.display()),
+        &format!("removed MCP server entry from {}", config.display()),
+        || remove_mcp_entry(&config, false),
+        opts,
+    );
+    if !dry_run {
+        delete_if_empty_and_owned(&config, home, "claude", false).ok();
+    }
+    let skill = skill_path_claude(home);
+    success &= removal_step(
+        integrations::skill_state(&skill),
+        dry_run,
+        "no skill file found",
+        &format!("would remove {}", skill.display()),
+        &format!("removed {}", skill.display()),
+        || remove_owned_file(&skill, SKILL_MD, false),
+        opts,
+    );
+    if !dry_run {
+        clear_created_files(home, "claude").ok();
+    }
+    println!("│");
+    success
+}
+
+fn uninstall_claude_desktop(home: &Path, dry_run: bool, opts: RenderOptions) -> bool {
+    let config = claude_desktop_config_path(home);
+    println!(
+        "│  {}",
+        paint(
+            format!("Claude Desktop App ({})", config.display()),
+            Style::new().bold(),
+            opts
+        )
+    );
+    let success = removal_step(
+        integrations::json_mcp_state(&config),
+        dry_run,
+        "no MCP server entry found",
+        &format!("would remove MCP server entry from {}", config.display()),
+        &format!("removed MCP server entry from {}", config.display()),
+        || remove_mcp_entry(&config, false),
+        opts,
+    );
+    if !dry_run {
+        delete_if_empty_and_owned(&config, home, "claude-desktop", false).ok();
+        clear_created_files(home, "claude-desktop").ok();
+    }
+    println!("│");
+    success
+}
+
+fn uninstall_codex(home: &Path, dry_run: bool, opts: RenderOptions) -> bool {
+    println!(
+        "│  {}",
+        paint("Codex CLI (~/.codex)", Style::new().bold(), opts)
+    );
+    let config = home.join(".codex/config.toml");
+    let success = removal_step(
+        integrations::codex_state(&config),
+        dry_run,
+        "no MCP server entry found",
+        "would remove [mcp_servers.topos] from ~/.codex/config.toml",
+        "removed [mcp_servers.topos] from ~/.codex/config.toml",
+        || remove_codex_entry(&config, false),
+        opts,
+    );
+    if !dry_run {
+        delete_text_if_blank_and_owned(&config, home, "codex", false).ok();
+        clear_created_files(home, "codex").ok();
+    }
+    println!("│");
+    success
+}
+
+fn uninstall_gemini(home: &Path, dry_run: bool, opts: RenderOptions) -> bool {
+    println!(
+        "│  {}",
+        paint("Gemini CLI (~/.gemini)", Style::new().bold(), opts)
+    );
+    let config = home.join(".gemini/settings.json");
+    let success = removal_step(
+        integrations::json_mcp_state(&config),
+        dry_run,
+        "no MCP server entry found",
+        &format!("would remove MCP server entry from {}", config.display()),
+        &format!("removed MCP server entry from {}", config.display()),
+        || remove_mcp_entry(&config, false),
+        opts,
+    );
+    if !dry_run {
+        delete_if_empty_and_owned(&config, home, "gemini", false).ok();
+        clear_created_files(home, "gemini").ok();
+    }
+    println!("│");
+    success
+}
+
+fn uninstall_copilot(home: &Path, dry_run: bool, opts: RenderOptions) -> bool {
+    println!(
+        "│  {}",
+        paint("GitHub Copilot CLI (~/.copilot)", Style::new().bold(), opts)
+    );
+    let config = home.join(".copilot/copilot-instructions.md");
+    let success = removal_step(
+        integrations::copilot_state(&config),
+        dry_run,
+        "no instruction block found",
+        "would remove the instruction block from ~/.copilot/copilot-instructions.md",
+        "removed the instruction block from ~/.copilot/copilot-instructions.md",
+        || remove_copilot_block(&config, false),
+        opts,
+    );
+    if !dry_run {
+        clear_created_files(home, "copilot").ok();
+    }
+    println!("│");
+    success
+}
+
+fn uninstall_skills(home: &Path, dry_run: bool, opts: RenderOptions) -> bool {
+    println!(
+        "│  {}",
+        paint(
+            "Cursor & VS Code (~/.agents/skills)",
+            Style::new().bold(),
+            opts
+        )
+    );
+    let skill = skill_path_agents(home);
+    let mut success = removal_step(
+        integrations::skill_state(&skill),
+        dry_run,
+        "no skill file found",
+        &format!("would remove {}", skill.display()),
+        &format!("removed {}", skill.display()),
+        || remove_owned_file(&skill, SKILL_MD, false),
+        opts,
+    );
+    let mcp_config = home.join(".cursor/mcp.json");
+    success &= removal_step(
+        integrations::json_mcp_state(&mcp_config),
+        dry_run,
+        "no MCP server entry found",
+        &format!(
+            "would remove MCP server entry from {}",
+            mcp_config.display()
+        ),
+        &format!("removed MCP server entry from {}", mcp_config.display()),
+        || remove_mcp_entry(&mcp_config, false),
+        opts,
+    );
+    if !dry_run {
+        delete_if_empty_and_owned(&mcp_config, home, "skills", false).ok();
+        clear_created_files(home, "skills").ok();
+    }
+    println!("│");
+    success
+}
+
+fn uninstall_antigravity(home: &Path, dry_run: bool, opts: RenderOptions) -> bool {
+    println!(
+        "│  {}",
+        paint(
+            "Google Antigravity (~/.gemini/GEMINI.md)",
+            Style::new().bold(),
+            opts
+        )
+    );
+    let pointer = antigravity_pointer_path(home);
+    let success = removal_step(
+        integrations::antigravity_state(home),
+        dry_run,
+        "no @import found",
+        &format!(
+            "would remove the @import from ~/.gemini/GEMINI.md and delete {}",
+            pointer.display()
+        ),
+        &format!(
+            "removed the @import from ~/.gemini/GEMINI.md and deleted {}",
+            pointer.display()
+        ),
+        || remove_antigravity_import(home, false),
+        opts,
+    );
+    println!("│");
+    success
+}
+
+fn purge_backup_files(home: &Path, opts: RenderOptions) {
+    let candidates = [
+        home.join(".claude.json"),
+        claude_desktop_config_path(home),
+        home.join(".codex/config.toml"),
+        home.join(".gemini/settings.json"),
+        home.join(".copilot/copilot-instructions.md"),
+        home.join(".cursor/mcp.json"),
+        home.join(".gemini/GEMINI.md"),
+    ];
+    for path in candidates {
+        let backup = backup_path(&path);
+        if backup.is_file() && std::fs::remove_file(&backup).is_ok() {
+            println!(
+                "│    {} removed backup: {}",
+                removed(opts),
+                backup.display()
+            );
+        }
+    }
+}

--- a/topos/cli/src/commands/mod.rs
+++ b/topos/cli/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod depgraph;
 pub mod evaluate;
 pub mod graphify;
 pub mod inspect;
+pub mod install;
 mod lang;
 pub mod mcp;
 mod render;

--- a/topos/cli/src/main.rs
+++ b/topos/cli/src/main.rs
@@ -12,9 +12,9 @@ use std::io::IsTerminal;
 use clap::{Parser, Subcommand};
 use console::Style;
 
-use commands::{compare, config, coverage, depgraph, evaluate, graphify, inspect, mcp};
+use commands::{compare, config, coverage, depgraph, evaluate, graphify, inspect, install, mcp};
 
-const ROOT_COMMANDS: [(&str, &str); 8] = [
+const ROOT_COMMANDS: [(&str, &str); 10] = [
     ("evaluate", "Score a file or directory"),
     ("inspect", "Explain one file"),
     ("config", "Set project priorities"),
@@ -22,6 +22,8 @@ const ROOT_COMMANDS: [(&str, &str); 8] = [
     ("coverage", "Compare source structure with tests"),
     ("depgraph", "Build the COMPOSABLE graph"),
     ("graphify", "Inspect graph health"),
+    ("install", "Configure agent harnesses to use Topos"),
+    ("uninstall", "Remove Topos from agent harnesses"),
     ("mcp", "Start the MCP server"),
 ];
 
@@ -57,6 +59,10 @@ enum Command {
     Graphify(graphify::GraphifyArgs),
     /// Build the GitNexus graph used by COMPOSABLE.
     Depgraph(depgraph::DepgraphArgs),
+    /// Configure agent harnesses (Claude Code, Codex, Gemini, ...) to use Topos.
+    Install(install::InstallArgs),
+    /// Remove Topos-owned entries from agent harnesses.
+    Uninstall(install::UninstallArgs),
     /// Start the MCP server over stdio.
     Mcp(mcp::McpArgs),
 }
@@ -86,6 +92,8 @@ fn main() {
         Command::Coverage(args) => coverage::run(args),
         Command::Graphify(args) => graphify::run(args),
         Command::Depgraph(args) => depgraph::run(args),
+        Command::Install(args) => install::run_install(args),
+        Command::Uninstall(args) => install::run_uninstall(args),
         Command::Mcp(args) => mcp::run(args),
     };
     if let Err(message) = result {
@@ -157,7 +165,16 @@ mod tests {
         assert!(plain.starts_with("topos "));
         assert!(plain.contains("\n    topos <command>\n"));
         for command in [
-            "config", "evaluate", "inspect", "compare", "coverage", "graphify", "depgraph", "mcp",
+            "config",
+            "evaluate",
+            "inspect",
+            "compare",
+            "coverage",
+            "graphify",
+            "depgraph",
+            "install",
+            "uninstall",
+            "mcp",
         ] {
             assert!(
                 plain.contains(&format!("\n    {command}")),
@@ -171,7 +188,7 @@ mod tests {
         let styled = root_help(true);
         assert!(styled.contains("\u{1b}[1mCommands\u{1b}[0m"));
         assert!(styled.contains("\u{1b}[2mScore a file or directory\u{1b}[0m"));
-        assert_eq!(ROOT_COMMANDS.len(), 8);
+        assert_eq!(ROOT_COMMANDS.len(), 10);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- **Draft / plan only — no implementation.** Assigned to @sgathrid.
- Adds [`docs/decisions/cli-harness-install.md`](docs/decisions/cli-harness-install.md) covering commands, adapter layout, harness matrix, safety rules, and acceptance criteria for #256.
- Targets `release/v0.4.4`. Rebase onto the tip of the release train after #266–#270 land (especially #258 for final `gitnexus_dir` docs).

## Implementation owner
@sgathrid

## Test plan
- [ ] N/A for this draft (docs-only)
- [ ] Follow-up commits on this branch (or successor PR) implement the plan and satisfy #256 acceptance

Closes nothing until implemented; tracks #256.


Made with [Cursor](https://cursor.com)