### PR TITLE
fix(packaging): drop redundant version stanza from Homebrew formula template

### DIFF
--- a/packaging/homebrew/topos.rb.template
+++ b/packaging/homebrew/topos.rb.template
@@ -4,8 +4,10 @@ class Topos < Formula
   # macOS default; Linux URLs are defined in the on_linux block. A top-level
   # URL must exist so `brew readall --os=all --arch=all` can load the formula
   # on Intel macOS, where no binary ships (guarded by depends_on arch below).
+  # No explicit `version`: Homebrew scans it from the release tag in the URL
+  # (Version::UrlParser for `releases/download/<tag>/`, brew >= 6.0.14). An
+  # explicit stanza duplicates that and fails `brew audit` in tap CI.
   url "https://github.com/Krv-Labs/topos/releases/download/v{{VERSION}}/topos-macos-arm64"
-  version "{{VERSION}}"
   sha256 "{{SHA_MACOS_ARM64}}"
   license "BSD-3-Clause"
 

--- a/tests/packaging/test_install_sh_preflight.py
+++ b/tests/packaging/test_install_sh_preflight.py
@@ -183,6 +183,22 @@ def test_homebrew_formula_template_has_foreign_detection() -> None:
     )
 
 
+def test_homebrew_formula_template_has_no_explicit_version() -> None:
+    """Homebrew scans the version from the release tag in the URL.
+
+    A `version` stanza duplicates it, and since brew 6.0.14 `brew audit` fails
+    the tap with "`version X` is redundant with version scanned from URL".
+    """
+    template = (REPO_ROOT / "packaging" / "homebrew" / "topos.rb.template").read_text(
+        encoding="utf-8"
+    )
+    assert not any(
+        line.lstrip().startswith("version ") for line in template.splitlines()
+    )
+    # The tag in the URL is what brew parses the version out of.
+    assert "releases/download/v{{VERSION}}/" in template
+
+
 def test_docs_prefer_fully_qualified_homebrew_install() -> None:
     readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
     install_rst = (REPO_ROOT / "docs" / "source" / "installation.rst").read_text(


### PR DESCRIPTION
## Summary

Removes the explicit `version` stanza from `packaging/homebrew/topos.rb.template`. Homebrew now derives the version from the release tag in the download URL, which made the stanza a duplicate and turned `brew audit` red in tap CI.

This unblocks **Krv-Labs/homebrew-tap#6** (topos 0.4.3), open and failing since 2026-07-28. `brew install krv-labs/tap/topos` is still serving **0.4.2** while 0.4.3 has been released.

## What happened

| When (UTC) | Event | brew in CI |
| --- | --- | --- |
| 2026-07-26 09:34 | tap CI for `bot/topos-0.4.2` — `brew audit` green | `6.0.12-161-ge09ba897b7` |
| 2026-07-28 14:06 | Homebrew/brew [`bae7b0408a`](https://github.com/Homebrew/brew/commit/bae7b0408a0a626d17ba52db327266174b4c012b) lands on `main` | — |
| 2026-07-28 21:38 | tap CI for `bot/topos-0.4.3` — `brew audit` fails, both legs | `6.0.13-64-g77d90328ca` |

The formula shape is identical in both runs; only brew changed. `git merge-base --is-ancestor` confirms it: `e09ba897b7` does **not** contain `bae7b0408a`, `77d90328ca` does.

That commit ("Fix GitHub release version detection", fixing Homebrew/brew#23336, first released in **6.0.14** on 2026-07-31) added a URL parser for GitHub release downloads:

```ruby
# GitHub releases
# e.g. `https://github.com/foo/bar/releases/download/v1.2/foo-1.2.0.tar.gz`
UrlParser.new(%r{github\.com/.+/releases/download/(?:[rvV]_?)?(#{NUMERIC_WITH_DOTS})/}),
```

brew now scans `0.4.3` from the tag in our URL path, so `Library/Homebrew/resource_auditor.rb:103` fires:

```
krv-labs/tap/topos
  * Stable: `version 0.4.3` is redundant with version scanned from URL
Error: 1 problem in 1 formula detected.
```

Both tap CI legs track brew `main` (`ghcr.io/homebrew/brew:main` on Linux; `setup-homebrew` logged `branch 'main' set up to track 'origin/main'` on macOS), which is why the failure landed on 7/28 — three days before the change reached a tagged release. Anyone on a released brew hit it from 6.0.14 onward.

## Why this is the fix, not a bandaid

**The stanza was correct when written and is now genuinely redundant.** Before that parser existed, our asset filenames (`topos-macos-arm64`, `topos-linux-amd64`) carried no version digits, so brew could not detect one — the explicit `version` was required. It no longer is, and Homebrew's documented model is that the URL is the source of truth:

> Homebrew tries to automatically determine the `version` from the `url` to avoid duplication. If the tarball has an unusual name you may need to manually assign the `version`.
> — Formula Cookbook, *Version detection failures*

The Cookbook says the same thing twice more: add an explicit `version` when detection *fails* (line 71) or is *wrong* (line 403). Detection now succeeds and is correct, so the fallback should go. After this change the release tag in `url` is the single source of truth for all three platform URLs — one fewer `{{VERSION}}` substitution that can drift from the tag.

Alternatives considered and rejected:

- **Pin brew in tap CI.** Freezes an upstream that the tap deliberately tracks (`ghcr.io/homebrew/brew:main`), hides future drift, and leaves the real duplication in place.
- **Add `--except` to skip the audit rule.** Suppresses a correct finding; the formula would stay non-idiomatic and the next audit change hits us again.
- **Hand-edit the tap formula only.** `publish-homebrew` force-pushes `bot/topos-<version>` from this template (`release.yml:369`), so every future release would regenerate the bad line.

**Regression guard.** `tests/packaging/test_install_sh_preflight.py` already asserts template invariants (openssl bundling, foreign-binary detection, no `conflicts_with`), so this adds `test_homebrew_formula_template_has_no_explicit_version` in that style. Note for the reviewer: `tests/packaging/` is **not currently run by any CI workflow** in this repo, so treat that test as documenting the invariant, not enforcing it — real enforcement is tap CI's `brew audit`, which is exactly what caught this.

## Verification

Rendered the template with the same `sed` invocation `release.yml:344-349` uses, against the real v0.4.3 checksums, and diffed it against the formula currently on `bot/topos-0.4.3` — the only changes are the removed stanza and the new comment. Ran tap CI's syntax checks against that exact rendered artifact (brew 6.0.15-9-g2bdc553):

| Check | Before | After |
| --- | --- | --- |
| `brew audit --except=installed --tap=krv-labs/tap` | 1 problem | exit 0 |
| `brew style krv-labs/tap` | exit 0 | exit 0 (2 files, no offenses) |
| `brew readall --os=all --arch=all krv-labs/tap` | exit 0 | exit 0 |

Version resolution confirmed via `Version.detect` on all three asset URLs — `0.4.3`, `detected_from_url? == true` for each — so `version` still resolves on macOS arm64, Intel macOS (falls through to the top-level URL), and both Linux arches. The template's `assert_match version.to_s, shell_output("#{bin}/topos --version")` therefore keeps working.

Also ran `uv run pytest tests/packaging/ -q` — 17 passed.

## Known constraint: prerelease tags

This fix assumes stable `vX.Y.Z` tags. `release.yml` triggers on `v*` and `publish-homebrew` has no prerelease filter, and brew's parser does **not** handle a prerelease suffix — it falls through to a different parser and picks up the `64` from the asset filename:

```
v0.4.3       -> "0.4.3"
v0.4.0-rc    -> "64"
v0.5.0-rc1   -> "64"
v1.2.3-beta.1-> "64"
```

No prerelease has ever reached this job (`publish-homebrew` landed 2026-07-23; the only prerelease tag, `v0.4.0-rc`, predates it by two days), and if one did, tap CI's `brew test` would fail on `assert_match version.to_s` rather than ship a misversioned formula. Left as-is deliberately: if publishing prereleases to the tap ever becomes intended, gating this job to stable versions is a separate change with its own decision to make.

## Test plan

- [ ] CI green on this PR
- [ ] Merge, then unblock homebrew-tap#6 (its formula is hand-fixed to match this template; a re-run of the 0.4.3 release would regenerate it identically once this is merged)
- [ ] Next release: confirm the rendered formula has no `version` line and tap CI passes `--only-tap-syntax`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
