### PR TITLE
ci: enforce the pypi index-url invariant and run CI on release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, worktree-rust-migration-v0.4.0]
   pull_request:
-    branches: [main, worktree-rust-migration-v0.4.0]
+    branches: [main, worktree-rust-migration-v0.4.0, 'release/**']
 
 jobs:
   rust:

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -67,6 +67,22 @@ def main(argv: list[str] | None = None) -> int:
                 f"{package['identifier']!r} has {package['version']!r}, "
                 f"expected {expected!r}"
             )
+        # ponytail: pypi-only guard; generalize if a second registryType lands
+        if package.get("registryType") == "pypi":
+            if "registryBaseUrl" in package:
+                errors.append(
+                    ".mcp/server.json pypi package must omit registryBaseUrl: "
+                    "VS Code appends --index-url <registryBaseUrl> unconditionally, "
+                    "and the only publishable value is not a PEP 503 index"
+                )
+            if any(
+                arg.get("name") == "--index-url"
+                for arg in package.get("runtimeArguments", [])
+            ):
+                errors.append(
+                    ".mcp/server.json pypi package must not pin --index-url: "
+                    "uv rejects the flag when VS Code duplicates it"
+                )
 
     if errors:
         for message in errors:


### PR DESCRIPTION
Stacked on #276. That PR's fix is correct — this adds the two things that keep it from regressing a third time.

## 1. `scripts/check_versions.py` — enforce the invariant

`registryBaseUrl` / `--index-url` have been added to the pypi package record twice now: #252 added the flag pin, and `mcp-registry-publishing.md:90` documented the unpublishable `https://pypi.org/simple` that seeded the loop. #276 answers with a doc callout. Documentation did not prevent recurrence #2, and each recurrence costs an **immutable** registry version — `0.4.3`'s broken record can never be replaced in place.

`mcp-publisher validate` cannot catch this, as #276's own investigation establishes: it calls only the schema validator, and `registryBaseUrl` carries no `enum` or `pattern`. So a repo-side guard is the only place this is catchable before publish.

The guard extends the loop `check_versions.py` already runs over `.mcp/server.json` packages. No new file, no new dependency, no new CI step — `ci.yml:24` already invokes the script. Error text carries the *why*, so the next contributor hits the cause rather than a rule.

Considered and rejected: a pytest in `tests/packaging/` next to `test_install_sh_preflight.py`. No workflow invokes pytest, so that guard would never run.

## 2. `.github/workflows/ci.yml` — run CI on the release stack

`pull_request.branches` was `[main, worktree-rust-migration-v0.4.0]`. #276 targets `release/044-256-harness-install`, so **no job fires on it** — and the same is true of #271 and #275. Every PR in the release stack silently skips fmt, clippy, `cargo test`, `check_versions.py`, and the MCP stdio smoke test.

Adding `'release/**'` fixes the whole convention the repo already follows plus every future release branch. Retargeting #276's base would have rescued one PR and left its two siblings unchecked. `push.branches` is unchanged — PR coverage is what gates merges.

Note: a stacked PR's base is a topic branch, which `release/**` does not match, so this PR itself still gets no run. Verified locally instead:

```
--- registryBaseUrl: exit=1
.mcp/server.json pypi package must omit registryBaseUrl: VS Code appends --index-url <registryBaseUrl> unconditionally, and the only publishable value is not a PEP 503 index
--- runtimeArguments --index-url: exit=1
.mcp/server.json pypi package must not pin --index-url: uv rejects the flag when VS Code duplicates it
--- clean: exit=0 version check passed (0.4.3)
--- version drift: exit=1 (pre-existing check intact)
```

## Skipped

- Unit test for the guard — it *is* the check, and it runs against the real file on every PR. Add when it grows branches.
- Generalizing beyond `registryType: "pypi"` — marked with a `ponytail:` comment; generalize when a second registry type lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)