### PR TITLE
docs: plan the v0.5.0 release stack

### DIFF
--- a/docs/decisions/v0.5.0-open-questions.md
+++ b/docs/decisions/v0.5.0-open-questions.md
@@ -1,0 +1,319 @@
+# v0.5.0 Stack — Open Design Questions
+
+Written 2026-08-04. Companion to [#281](https://github.com/Krv-Labs/topos/pull/281)
+(`docs/decisions/v0.5.0-stack.md`), which chunks the release. That doc settled
+D3/D4/D5 and withdrew D1. This one holds the questions that surfaced when I
+went to *implement* the chunks — they are answerable from the evidence below,
+but each one changes what gets written, so none of them should be guessed.
+
+Nothing has been implemented. No branches created, no worktrees added.
+
+---
+
+## Context
+
+**Goal:** implement the stacked PRs #281 proposes, each in its own worktree off
+`release/v0.5.0`.
+
+**Where the stack actually stands (verified 2026-08-04):**
+
+| Branch / PR | State |
+| --- | --- |
+| #275 `release/v0.4.4` → `main` | OPEN, `MERGEABLE`, **`BLOCKED`** |
+| #279 `release/v0.5.0` → `main` | OPEN. 2 ahead of `main`, 1 behind — needs `git merge origin/main` to pick up #273 |
+| #280 `release/050-navigable-pillar` | OPEN, `CLEAN`, +2679 −970 across 46 files |
+| #281 `release/050-stack-plan` | OPEN — this plan's source |
+
+**Ordering consequence #281 does not state:** #280 touches
+`mcp/src/{formatting,schemas,metric_locations}.rs`,
+`mcp/src/tools/{evaluate,assess,preferences}.rs`, `policies/gates.rs`, and
+`mcp/docs/content/metrics.md`. So chunks 4 and 8 (both MCP-side) **cannot fan
+off `release/v0.5.0`** — they must chain off `release/050-navigable-pillar` or
+wait for it to merge. Only the engine-side chunks (3, 5, 7, 9) fan cleanly.
+
+Verified non-conflict: #280's `metrics.md` diff is at lines 1–7 and 113+; the
+Go-skew blockquote chunk 3 must edit is at lines 48–57. Safe.
+
+---
+
+## Q1 — Scope: which chunks now?
+
+| Option | Chunks | Note |
+| --- | --- | --- |
+| **A (recommended)** | 3, 4, 5, 7, 8, 9 | Everything except CI. Needs Q2–Q4 answered. |
+| B | 3, 5, 7, 9 | Only chunks with zero open questions. Defers #233 and #234. |
+| C | all seven | Adds chunk 6 (#66). |
+
+**Why chunk 6 is excluded from A.** #66 must be written against the *post*-#276
+`.mcp/server.json` (no `registryBaseUrl`, no `--index-url` runtime arg), and
+that file only exists on `origin/release/v0.4.4`. #275 is `BLOCKED`. Writing it
+now means writing against a file that is not on any branch this stack can base
+on, then rebasing. Cheap to do later, not cheap to do now.
+
+Related, and worth knowing regardless of the answer: **the #277 invariant guard
+is not on `main`.** `git merge-base --is-ancestor fe1deec HEAD` → no. `main`'s
+`scripts/check_versions.py` has no `registryBaseUrl` / `--index-url` check, and
+`main`'s `ci.yml` still excludes `release/**` from `pull_request.branches` — so
+the whole release stack is skipping fmt, clippy, tests and `check_versions.py`
+today. That is a live gap independent of #66.
+
+---
+
+## Q2 — D2a: `include_missing` when the contract builders unify (#233)
+
+`assessment_contract` (`topos/mcp/src/tools/assess.rs:378`) passes
+`include_missing = false`; the other three (`formatting.rs:224`,
+`tools/evaluate.rs:847`, `assess.rs:1592`) pass `true`. So
+`missing_gitnexus_dir` never reaches an assessment's `blocked_by`. Unifying
+forces one answer.
+
+- **Option A** — always `true`. Treats the asymmetry as the accident #233 calls
+  it. Behavior change: assessments gain a `blocked_by` entry.
+- **Option B** — keep it, write the rationale that was never written: an
+  assessment is a *delta* between two measurements, so if both sides lack
+  COMPOSABLE the delta is still valid and `missing_gitnexus_dir` is noise
+  rather than a blocker.
+
+**New evidence that was not in #281 or #233.** Option B has a real mechanism
+behind it, not just a story. `composable_contract_signals`
+(`topos/mcp/src/formatting.rs:62-133`) gives `missing_gitnexus_dir` a
+`blocked_by` entry but **no** `risk_flags` entry and **no** `next_action` — it
+is the one signal the helper deliberately leaves incomplete, which is why
+`build_agent_contract` re-derives it at `formatting.rs:242` and threads
+`missing_gitnexus` separately into `next_step_for_contract`. So "missing" is
+already modeled as weaker than the other three signals. That is consistent with
+B, and it means A is not purely a bug fix — it promotes a signal the helper
+treats as advisory.
+
+**Blast radius of A:** `formatting.rs:1030-1120` pins `missing_gitnexus_dir` in
+`blocked_by` today; assess-side tests would need the new entry added.
+
+---
+
+## Q3 — Chunk 4 shape: how much unification is actually there? (#233)
+
+**This is the question that changed most on contact with the code.** #233 and
+#281 both describe chunk 4 as "four builders duplicating flag logic → collapse
+to one builder." Measured, the duplication is about **six lines**.
+
+The four builders:
+
+| Builder | Location | Ladder driven by |
+| --- | --- | --- |
+| `build_agent_contract` | `formatting.rs:199-277` | `RefactorTarget` (6-way, via `next_step_for_contract` at `:287-327`) |
+| `project_contract` | `tools/evaluate.rs:836-908` | `LatticeElement` + worst rows |
+| `assessment_contract` | `tools/assess.rs:369-425` | `AssessmentStatus` |
+| `changeset_contract` | `tools/assess.rs:1582-1628` | `project_regression: bool` |
+
+What they genuinely share: call `composable_contract_signals`, extend
+`blocked_by`/`risk_flags`, push `"warnings"` if warnings are non-empty.
+
+What they do **not** share:
+
+- Whether the composable blocker **early-returns** (project, `evaluate.rs:874-882`)
+  or **appends** (the other three).
+- Four different `verification_gates` lists — 4, 3, 3, 3 entries, all different
+  prose — plus an edge case at `evaluate.rs:882-889` where an empty
+  `worst_files` returns with the gates it just built silently discarded (looks
+  unintentional; flagging separately).
+- `build_agent_contract` alone has a hard early return on `!is_parseable`
+  (`formatting.rs:214-222`) and is alone in consulting `refactor_targets`.
+- `changeset_contract` alone seeds `next_actions` *before* the ladder
+  (`assess.rs:1601-1606`).
+
+A single builder subsuming all four needs a `verification_gates` param, an
+`include_missing` param, and a closure-or-enum for the ladder. **The
+parameterization is as large as the duplication it removes.**
+
+The genuinely valuable half is the part #233 files under "Related": the codes
+are bare `Vec<String>` literals (`schemas.rs:817-829` — `blocked_by` and
+`risk_flags` are untyped, no enum, no dedup) scattered across five files,
+including **seven hand-rolled `AgentContract` literals in `tools/depgraph.rs`**
+(`:101, :121, :143, :179, :211, :362, :384`) that never call
+`composable_contract_signals` at all, plus five more in `evaluate.rs:736` and
+`assess.rs:452, :903, :1231, :1651`.
+
+**A live divergence that consolidation would catch:** `build_agent_contract`
+emits `"parse_failure"` (singular, `formatting.rs:214-222`); `project_contract`
+emits `"parse_failures"` (plural, `evaluate.rs:857-865`). Two different codes
+for the same condition, on the wire, today.
+
+Options:
+
+- **Option A (recommended)** — extract the shared prelude *and* hoist every
+  code literal into one `const` module. Ladders stay where they are. This is
+  D2b = "same PR", and it is where the value is.
+- **Option B** — full single builder with a ladder enum. Bigger diff, and the
+  four ladders are genuinely four different functions.
+- **Option C** — prelude only; structured codes ship as their own chunk. Keeps
+  the unification behavior-neutral, since codes are consumer-visible.
+
+**Recommendation: A.** If A is chosen, #233's title ("collapse to one builder")
+should be amended on the issue, because that is not what would ship.
+
+---
+
+## Q4 — #234: does `worst_files` survive the named lists?
+
+D4 settled *what* the lists are. It left two sub-questions open, and both bite
+during implementation.
+
+**Q4a — does `worst_files` stay?**
+
+- Keep it, add the lists beside it. Non-breaking, wider response.
+- Replace it. Cleaner, but it is a breaking output change stacked on v0.5.0's
+  already-breaking lattice change, and `worst_files` is load-bearing in more
+  places than the field itself.
+
+`worst_files` is computed at `tools/evaluate.rs:634-676`; the ranking key is
+`worst_key` (`:554-556`) → `weakest_score` (`engine/src/evaluation/mod.rs:29-31`).
+Seven consumers, not one:
+
+1. `evaluate.rs:635-639` — the sort orders **the whole paginated `files` table**,
+   not just the top 3. Changing the ranking changes the page order.
+2. `evaluate.rs:576-580` — `build_language_rollups` reuses `worst_key` for
+   `ProjectLanguageRollup::worst_file_path`.
+3. `evaluate.rs:766-808` — `aggregate_explanation` independently `min_by`s it.
+4. `evaluate.rs:811-833` — `project_guidance`.
+5. `evaluate.rs:836-908` — `project_contract` (which is also chunk 4's file).
+6. `worst_file_verdict` wire field (`:644`).
+7. `topos/mcp/docs/content/workflows.md:85`.
+
+Pinned by `worst_files_are_page_global_and_slim` (`evaluate.rs:1096-1126`),
+which asserts the serialized keys are exactly `["filepath","lattice_element"]`
+— any added field breaks it.
+
+**Q4b — does `leaf_composable_zeros[]` need to be in the response, or is
+exclusion from `hard_fails[]` enough?**
+
+Implementation note that makes this cheaper than expected: **the leaf predicate
+already exists and is already computed.** `coupling_gate_input`
+(`engine/src/evaluation/policies/composable.rs:100-123`) computes
+`has_coupling_signal = !(fan_in == 0.0 && fan_out == 0.0)`. A "leaf composable
+zero" is exactly `!has_coupling_signal`. Reuse it — do not write a third copy.
+There are already two (`mcp/src/refactor_targets.rs:181-210` and
+`engine/src/evaluation/suggestions.rs:75-90`), and `refactor_targets.rs:181-194`
+carries a long comment explaining why the copy exists.
+
+**Constraint to respect either way:** `ProjectFileEntry` carries `raw_metrics`
+only under `verbose` (`schemas.rs:1010-1038`), so any list needing
+fan_in/fan_out must derive from the in-memory `ClassificationResult` in
+`build_project_result` (`evaluate.rs:606`), before the wire slimming — not from
+`entries`.
+
+**Budget note:** `context_budget.rs:19` — `TOTAL_CEILING_CHARS = 34_500` with
+~764 chars of headroom, and #280 already spends into it. Output shape is free
+(tool defs carry `inputSchema` only), but `topos_evaluate_project`'s
+description at `evaluate.rs:141-155` promises "a paginated per-file table
+(worst first)" — prose that a named-list change contradicts and would have to
+be re-worded within budget.
+
+---
+
+## Findings worth recording regardless of the answers
+
+These came out of the exploration and are not in #281. Each is a real defect or
+a real saving; none needs a decision.
+
+1. **#231 needs no new algorithm.** `petgraph 0.6.5` is already a direct
+   dependency (`topos/engine/Cargo.toml:21`) and ships
+   `algo::dominators::simple_fast`. Wrap in `visit::Reversed`, root at
+   `exit_id` → post-dominators. `object.rs:132-145` already has the
+   `blocks → NodeIndex` idiom to copy. Caveat: blocks with no path to exit
+   (infinite loop; the `if_join` orphaned when both branches return) get
+   `immediate_dominator == None` and must degrade gracefully — precedent is
+   `longest_acyclic_path_returns_zero_on_untagged_cycle` (`object.rs:354-363`).
+
+2. **#230 is a one-condition fix, and the ticket understates it.**
+   `builder.rs:636` tests emptiness on the *raw* children instead of on
+   `unwrap_to_statements(...)`. Gating on the unwrapped statements fixes Go
+   `package` *and* Go `import_declaration`, Python bare `import`, JS `import`,
+   and C++ `#include` — all six languages, one condition. Do not add a
+   `package`/`import` blocklist. Then `GO_BRANCH_LOOP` and `GO_MATCH_RETURN`
+   (`edge_contracts.rs:49-61, 88-100`) can be deleted outright and the two Go
+   cases pointed at the shared consts.
+
+3. **#225 is blocked on a prior bug nobody has filed.** `builder.rs:421-425`
+   collects the try body as `children.filter(|c| c.kind != "Unknown")` — but
+   the try body *is* a `block`/`statement_block`/`compound_statement`, all of
+   which map to `"Unknown"`. **The entire try body is discarded**; only the
+   `CatchClause` survives. The `TRY_RETURN` golden (`edge_contracts.rs:102-109`)
+   confirms it: a `try: return 1 / except: return 0` fixture contains exactly
+   one modeled `ReturnStmt`. #225 notices the symptom and attributes it to
+   handler modeling. Also: there is **no `FinallyClause` UAST kind anywhere** —
+   `finally_clause` maps to `"Unknown"` in all six mappers, so `finally` bodies
+   are currently invisible. Modeling `finally` needs a new mapper kind first.
+
+4. **#210's hard part is already written.** `has_function_declarator`
+   (`mapper_cpp.rs:58`) exists and is correct — it even rejects function
+   pointers. Widening the callback (`mapper_common.rs:248`, `&str` → `&Node`)
+   is mechanical across six mappers plus one TS→JS delegation
+   (`mapper_typescript.rs:9,12`). The `Node` is already in scope at the sole
+   call site (`mapper_common.rs:298`). **`mapper_cpp.rs` has zero tests** (no
+   `#[cfg(test)]` module at all; same for go and ts), so this ships untested
+   unless a test is added.
+
+5. **#211 is a read/write mismatch, and it is not dormant.** #281 calls it
+   "dormant (nothing reads it back)" — but `freshness.rs:37` reads it, and
+   `graph_freshness` (`freshness.rs:198-207`) resolves the store via
+   `resolve_lbug_store` then reads the fingerprint from *that store's* parent.
+   The writer (`gitnexus.rs:311`) always writes flat `.gitnexus/`. So whenever
+   GitNexus produces a branch-scoped store, every content-hash/SHA anchor
+   **silently degrades to the mtime fallback today**. Both existing tests
+   (`gitnexus.rs:667, :694`) only cover the flat layout, which is why CI is
+   green.
+
+6. **#212's reference implementation is recoverable verbatim.**
+   `git show 3212ca2^:topos/graphs/mdg/object.py`, lines 117–191 (`_load_ladybugdb`
+   — note `_load_`, not `_from_`). `CALL show_tables() RETURN *` works against
+   the bundled lbug engine (`SHOW_TABLES` is a registered table function), so
+   no new client API is needed. Restoring it makes `stub_missing_endpoints`
+   (`ladybug.rs:160-176`) dead code and breaks its only test (`ladybug.rs:183`),
+   which asserts the lossy behavior.
+
+7. **`project_contract` discards its own verification gates** when
+   `worst_files` is empty (`evaluate.rs:882-889`). Looks unintentional. Falls
+   inside chunk 4 or 8 depending on Q3/Q4.
+
+---
+
+## Branch topology, once the questions are answered
+
+Fan off `release/v0.5.0` (engine-side, disjoint from #280):
+
+- chunk 3 → `release/050-cfg-metric-correctness` (#231, #230)
+- chunk 5 → `release/050-parity-fixes` (#210, #211)
+- chunk 9 → `release/050-ladybug-full-ingest` (#212)
+
+Chain (shared files):
+
+- chunk 7 → `release/050-cfg-switch-try-semantics` **off chunk 3** — both edit
+  `cfg/builder.rs` and `cfg/edge_contracts.rs`
+- chunk 4 → `release/050-agent-contract-builder` **off `release/050-navigable-pillar`**
+  — #280 edits `formatting.rs`, `evaluate.rs`, `assess.rs`, `schemas.rs`
+- chunk 8 → `release/050-project-ranking-lists` **off chunk 4** — both edit
+  `project_contract` in `evaluate.rs`
+
+Deferred:
+
+- chunk 6 → after #275 merges and `release/v0.5.0` syncs
+
+Each in `.worktrees/<short-name>/`, matching the existing convention
+(`.worktrees/v050`, `.worktrees/050-navigable`, `.worktrees/050-stack-plan`).
+Merge into `release/v0.5.0` with `gh pr merge --merge`, per the recorded
+strategy — never squash into the release branch.
+
+## Verification, per chunk
+
+- 3, 7: `cargo test -p topos-engine graphs::cfg` — `edge_contracts.rs` goldens
+  are hand-edited `&'static str` consts, there is no `UPDATE_SNAPSHOTS` path.
+  Then confirm `cfg.nesting_depth` for `adapters/discovery.rs` drops 1008 → ~3.
+- 4, 8: `cargo test -p topos-mcp`, plus `cargo test -p topos-mcp
+  dump_tool_surface -- --ignored --nocapture` to re-measure against
+  `TOTAL_CEILING_CHARS`.
+- 5: `cargo test -p topos-engine` + a new branch-scoped fingerprint test (the
+  gap that lets #211 pass CI today).
+- 9: `cargo test -p topos-engine graphs::mdg`.
+- All: `cargo fmt --check`, `cargo clippy`, `python3 scripts/check_versions.py`
+  — and note these are **not** running in CI on `release/**` branches until
+  #277's `ci.yml` change reaches `main`.

--- a/docs/decisions/v0.5.0-stack-wip.md
+++ b/docs/decisions/v0.5.0-stack-wip.md
@@ -1,0 +1,251 @@
+# v0.5.0 Stack — WIP Status
+
+Last updated 2026-08-04. Read
+[`v0.5.0-stack.md`](./v0.5.0-stack.md) for the plan and
+[`v0.5.0-open-questions.md`](./v0.5.0-open-questions.md) for the four
+decisions that gate the rest.
+
+Nothing here is pushed. Every branch below is local-only.
+
+---
+
+## Where things stand
+
+| Chunk | Issues | Branch | State |
+| --- | --- | --- | --- |
+| 3 — CFG metric correctness | #231, #230 | `release/050-cfg-metric-correctness` | **Done, committed, unpushed** |
+| 5 — mechanical parity | #210, #211 | `release/050-parity-fixes` | Worktree created, empty |
+| 9 — LadybugDB full ingest | #212 | `release/050-ladybug-full-ingest` | Worktree created, empty |
+| 7 — CFG switch/try | #225 | not created | Blocked, see below |
+| 4 — AgentContract builders | #233 | not created | Blocked on **Q2**, **Q3** |
+| 8 — project ranking lists | #234 | not created | Blocked on **Q4**, chains off 4 |
+| 6 — MCP Registry publish | #66 | not created | Blocked on #275 |
+
+Worktrees live under `.worktrees/`, matching the existing convention:
+
+```
+.worktrees/050-cfg-metrics    release/050-cfg-metric-correctness
+.worktrees/050-parity         release/050-parity-fixes
+.worktrees/050-ladybug        release/050-ladybug-full-ingest
+.worktrees/050-stack-plan     release/050-stack-plan          (this doc)
+.worktrees/050-navigable      release/050-navigable-pillar    (#280)
+.worktrees/v050               release/v0.5.0                  (#279)
+```
+
+All three new branches fan off `origin/release/v0.5.0` at `2679bfd`.
+
+---
+
+## Chunk 3 — done
+
+Commit `dac7e28` on `release/050-cfg-metric-correctness`. Four files,
++167 −67.
+
+**#231.** `max_nesting_depth` now bounds each branch region by
+post-domination: a block is inside branch head `h` when it is reachable
+from one of `h`'s `True`/`SwitchCase` successors **and does not
+post-dominate `h`**. The join post-dominates the head, so the walk stops
+there and the code after a branch falls outside it. Post-dominators come
+from `petgraph::algo::dominators::simple_fast` over `Reversed(&graph)`
+rooted at `exit` — petgraph was already a direct dependency and
+`longest_acyclic_path` already had the `blocks → NodeIndex` idiom to copy.
+
+**Verified:** `cfg.nesting_depth` for `topos/engine/src/adapters/discovery.rs`
+was 1008, now reads **4**.
+
+The mis-named test is split into three: `max_nesting_depth_of_nested_branches`
+(what the old test actually built), `..._of_sequential_branches_does_not_accumulate`
+(the sibling case nothing pinned), and `..._stays_flat_across_many_sequential_branches`
+(40 diamonds — the shape that produced 1008).
+
+**#230.** `collect_callable_bodies` tested emptiness on the module body's
+*raw children* instead of on its unwrapped statements, so any file whose
+module-level content is only a preamble still got a callable worth one
+block and two edges. One condition change at `builder.rs:636` covers Go's
+`package` clause plus Go/JS `import`, Python bare `import` and C++
+`#include` — no per-language blocklist needed. Go's cyclomatic drops by
+exactly 1 per file, `GO_BRANCH_LOOP` and `GO_MATCH_RETURN` collapse onto
+the shared contracts and are deleted, and the stale Go-skew blockquote
+comes out of `mcp/docs/content/metrics.md`.
+
+**Known ceiling, marked with a `ponytail:` comment in the code.** A branch
+whose join does not post-dominate its head — a `switch` where one arm
+returns — leaks one level of depth onto the code after it, because there
+is no join left to stop the walk. Bounded and rare, where the old bug was
+unbounded and routine. The real upgrade is reading nesting off the UAST
+scope tree, which is exactly what #280's new `functors/probes/ast/scopes.rs`
+computes for NAVIGABLE. **Worth revisiting once #280 lands** — the two
+metrics would then share one notion of depth instead of two.
+
+**Verification run:** `cargo test --workspace` green (53 + 322 + 79).
+`cargo fmt --all` applied. **`cargo clippy` was not run** — pick that up
+before opening the PR.
+
+---
+
+## Chunk 5 — next, unblocked
+
+Worktree `.worktrees/050-parity`, branch created, no commits.
+
+**#210** — widen the `map_node_kind` callback from `&str` to `&Node`.
+
+- Callback declared at `graphs/uast/mapper_common.rs:248`, called once at
+  `:298`, where the `Node` is already in scope. The plumbing cost is
+  entirely in the six implementations, not the caller.
+- Six impls to change: `mapper_{go:14, javascript:10, python:92, cpp:90,
+  rust:50, typescript:12}.rs`, each also passed at the
+  `map_tree_sitter_to_uast(...)` call site (`:105, :66, :207, :193, :124, :60`).
+- One extra edge: `mapper_typescript.rs:9` re-exports JS's version
+  (`use super::mapper_javascript::map_node_kind as map_javascript_node_kind`),
+  so TS has a second internal call site.
+- **The hard part is already written.** `has_function_declarator`
+  (`mapper_cpp.rs:58`) exists and is correct — it even rejects function
+  pointers via `is_named_function_declarator` (`:47`). Widening the
+  callback just lets `map_node_kind` call it. Remove the `ponytail:` block
+  at `mapper_cpp.rs:95-107`, which already names this exact upgrade path.
+- **`mapper_cpp.rs` has no `#[cfg(test)]` module at all** (nor do
+  `mapper_go.rs` or `mapper_typescript.rs`), and no `.cpp`/`.hpp` fixtures
+  exist. This ships untested unless a test is added — add one for a header
+  prototype and a pure-virtual signature via
+  `parse_source(source, "cpp", None)` (`graphs/ast/dispatch.rs:79`).
+
+**#211** — route the fingerprint write through the resolved store.
+
+- `write_fingerprint` (`adapters/gitnexus.rs:295`) writes to
+  `target_dir.join(".gitnexus")` at `:311`, always flat. `finished_result`
+  (`:427`) is the caller.
+- Fix mirrors the read side: `current_git_branch` (`:496`) →
+  `resolve_lbug_store` (`:519`), falling back to flat.
+- **Correction to the stack plan: this is not dormant.** `freshness.rs:37`
+  reads the fingerprint, and `graph_freshness` (`freshness.rs:198-207`)
+  resolves the store then reads from *that store's* parent dir. So
+  whenever GitNexus produces a branch-scoped store the fingerprint is
+  never found and every content-hash/SHA anchor silently degrades to the
+  mtime fallback. That is happening today.
+- Both existing tests (`gitnexus.rs:667, :694`) only cover the flat
+  layout, which is why CI is green. **A branch-scoped test is the
+  deliverable here** — without it the fix is unpinned.
+
+---
+
+## Chunk 9 — unblocked
+
+Worktree `.worktrees/050-ladybug`, branch created, no commits.
+
+**#212**, decided as D5 = restore.
+
+- `from_ladybug_native` (`graphs/mdg/ladybug.rs:18`) queries only
+  `MATCH (n:File) RETURN n.id, n.filePath, n.name` (`:62`), hard-codes the
+  label `"File"` (`:87`), stubs every other endpoint as a bare `Symbol`
+  with empty properties (`stub_missing_endpoints`, `:160-176`), and
+  hard-codes `confidence: 1.0` / `reason: ""` (`:150-151`) — the
+  relationship queries at `:100-113` never select them at all.
+- **The Python reference is recoverable verbatim:**
+  `git show 3212ca2^:topos/graphs/mdg/object.py`, lines 117–191. The
+  function is `_load_ladybugdb` (note `_load_`, not the `_from_ladybgdb`
+  the issue names). It enumerated node tables with
+  `CALL show_tables() RETURN *` filtered on `row[2] == "NODE"`, then ran
+  `MATCH (n:\`{label}\`) RETURN n` per label keeping every
+  non-`_`-prefixed property, and applied `confidence or 1.0` /
+  `reason or ""` as *fallbacks* rather than constants.
+- `CALL show_tables() RETURN *` works against the bundled engine —
+  `SHOW_TABLES` is a registered table function — so no new client API is
+  needed. `Connection::query(&str)` is what the loader already uses.
+- Restoring this makes `stub_missing_endpoints` dead code and breaks its
+  only test (`ladybug.rs:183`), which asserts the lossy behavior. Delete
+  both.
+- Nothing currently exercises `load_file_nodes` or `load_relationships`
+  against a real store, and `tests/fixtures/composable_mdg/` holds only
+  Rust sources. Some fixture store is needed to pin the restoration.
+
+---
+
+## Chunk 7 — blocked on a bug that needs filing first
+
+**Do not start #225 as scoped.** `start_try` (`graphs/cfg/builder.rs:421-425`)
+collects the try body as `children.filter(|c| c.kind != "Unknown")` — but
+the try body *is* a `block` / `statement_block` / `compound_statement`,
+all of which map to `"Unknown"`. **The entire try body is discarded**;
+the only surviving child is the `CatchClause`.
+
+The `TRY_RETURN` golden (`edge_contracts.rs`) confirms it: a
+`try: return 1 / except: return 0` fixture contains exactly one modeled
+`ReturnStmt`. #225 notices that symptom and attributes it to missing
+handler modeling, but the cause is the filter. Modeling handlers on top of
+a discarded try body would produce a contract that is still wrong, and
+#224's golden matrix would then freeze it.
+
+Two more facts that change the scope:
+
+- `CatchClause` is in neither `STATEMENT_KINDS` (`builder.rs:647`) nor
+  `RELEVANT_KINDS` (`:818`), so naively swapping the filter for
+  `unwrap_to_statements` drops the handlers instead of the body. Both
+  need handling together.
+- **There is no `FinallyClause` UAST kind anywhere.** `finally_clause`
+  maps to `"Unknown"` in all six mappers and is not in
+  `BLOCK_NATIVE_KINDS`, so `finally` bodies are currently invisible.
+  Modeling `finally` needs a new mapper kind first — that is mapper work
+  before it is CFG work.
+
+Chunk 7 also chains off chunk 3: both edit `cfg/builder.rs` and
+`cfg/edge_contracts.rs`.
+
+Suggested next step: file the try-body bug as its own issue, then rescope
+#225 as (a) switch context for `break`, (b) try-body filter, (c) handler
+and `finally` modeling — in that order, since (c) depends on (b).
+
+---
+
+## Chunks 4 and 8 — blocked on decisions
+
+See `v0.5.0-open-questions.md`. In short:
+
+- **Q2 / D2a** — `include_missing` always `true`, or keep the asymmetry
+  with the rationale written down. New evidence leans toward keeping it:
+  `composable_contract_signals` gives `missing_gitnexus_dir` a
+  `blocked_by` entry but deliberately no risk flag and no next_action, so
+  "missing" is already modeled as the weakest of the four signals.
+- **Q3** — chunk 4 is not a "collapse four builders into one." Measured,
+  they share about six lines; the four routing ladders take four different
+  domain inputs. The value is in hoisting the bare-string codes out of 12
+  hand-rolled construction sites, which would also catch
+  `"parse_failure"` vs `"parse_failures"` — two codes for one condition,
+  both on the wire today.
+- **Q4** — does `worst_files` survive. It has seven consumers, not one;
+  the same sort orders the whole paginated `files` table.
+
+Both must base on `release/050-navigable-pillar`, not `release/v0.5.0`:
+#280 edits `formatting.rs`, `evaluate.rs`, `assess.rs` and `schemas.rs`.
+Chunk 8 then chains off chunk 4 — both edit `project_contract`.
+
+---
+
+## Chunk 6 — blocked on #275
+
+#66 must be written against the post-#276 `.mcp/server.json` (no
+`registryBaseUrl`, no `--index-url` runtime argument), which exists only
+on `origin/release/v0.4.4`. #275 is `MERGEABLE` but `BLOCKED`.
+
+Shape when it unblocks: a `publish-mcp-registry` job in `release.yml`
+with `needs: [publish-pypi]` and a job-level `permissions: id-token: write`
+— copy `publish-pypi`'s block at `release.yml:626-627`, noting that a
+job-level `permissions:` replaces the workflow-level one wholesale.
+
+---
+
+## Loose ends worth someone's attention
+
+1. **`project_contract` discards its own verification gates** when
+   `worst_files` is empty (`tools/evaluate.rs:882-889`). Looks
+   unintentional. Lands in chunk 4 or 8 depending on Q3/Q4.
+2. **`main` does not have #277's guard.** `main`'s
+   `scripts/check_versions.py` has no `registryBaseUrl` / `--index-url`
+   check and `main`'s `ci.yml` still excludes `release/**` from
+   `pull_request.branches`. Both are on `release/v0.5.0` already (its tip
+   `2679bfd` is "ci: run CI on pull requests targeting release branches"),
+   so the stack is covered — but `main` is not, until a release lands.
+3. **`release/v0.5.0` is 1 commit behind `main`** (#273, the Homebrew
+   template fix) and needs `git merge origin/main`.
+4. **#193 should be closed** — fixed in v0.4.3 by #251, per the withdrawn
+   D1. Leaving it on the v0.5.0 milestone implies this release shipped
+   the fix.

--- a/docs/decisions/v0.5.0-stack.md
+++ b/docs/decisions/v0.5.0-stack.md
@@ -1,0 +1,329 @@
+# v0.5.0 Release Stack
+
+How the v0.5.0 release is chunked, in what order, and which decisions are
+still open. Companion to the release PR
+([#279](https://github.com/Krv-Labs/topos/pull/279)).
+
+## Topology and merge strategy
+
+```
+main
+ └── release/v0.5.0                      #279  (squash-merge into main)
+      ├── release/050-navigable-pillar   #280  (merge commit)
+      ├── release/050-stack-plan         this doc
+      └── … one branch per chunk below
+```
+
+Two different strategies, deliberately:
+
+| Edge | Strategy | Why |
+| --- | --- | --- |
+| chunk PR → `release/v0.5.0` | **merge commit** | Squashing into the release branch diverges the history that later PRs in the stack are built on, which is what hurt on v0.4.4. Merge commits keep the stack rebasable. |
+| `release/v0.5.0` → `main` | **squash** | Matches v0.3.12 / v0.4.2 / v0.4.3. One release commit per version on `main`. |
+
+`release/v0.5.0` is based on `main`, **not** on `release/v0.4.4`. Because
+release PRs squash-merge, carrying v0.4.4's individual commits here would
+guarantee conflicts the moment [#275](https://github.com/Krv-Labs/topos/pull/275)
+lands. Consequence: **#275 merges first**, then `release/v0.5.0` syncs with
+`git merge origin/main`.
+
+Chunks fan off `release/v0.5.0` rather than chaining off each other wherever
+the file sets are disjoint — a fan needs no rebasing when a sibling merges.
+Only genuinely dependent chunks chain.
+
+## The stack
+
+### Landed / open
+
+| # | PR | Issues | Files | Design risk |
+| --- | --- | --- | --- | --- |
+| 1 | [#280](https://github.com/Krv-Labs/topos/pull/280) | — (+ silently **#193**) | `engine/{core,evaluation,functors}`, `mcp`, `cli`, docs | **decision needed — see D1** |
+| 2 | this PR | — | `docs/decisions/` | none |
+
+PR 1 is the pillar change and everything else is ordered behind it, because
+it moves $\Omega$ from 8 to 16 elements, renames `GOLD` → `PLATINUM`, widens
+the preference ranking to 4, and changes what `Φ_SIMPLE` gates on.
+
+### Chunk 3 — CFG metric correctness
+
+**Branch:** `release/050-cfg-metric-correctness` · **Issues:**
+[#231](https://github.com/Krv-Labs/topos/issues/231),
+[#230](https://github.com/Krv-Labs/topos/issues/230)
+
+Both are self-contained CFG bugs with an agreed fix sketch in the issue, no
+open design question.
+
+- **#231** — `cfg.nesting_depth` never restores depth at a branch join, so
+  sequential non-nested branches accumulate: **1008** for a 460-line file
+  whose true max nesting is ~3. Needs post-dominator-aware traversal instead
+  of monotonic relaxation. Also fix the mis-named test at `cfg/object.rs:288`
+  (`max_nesting_depth_of_sequential_true_branches` actually builds a *nested*
+  chain, so it never pinned the sibling-accumulation behavior).
+- **#230** — Go's `package` clause survives the module-level statement
+  filter, so every Go file grows an extra empty callable: one extra block and
+  two extra edges vs the identical program in the other five languages. Fix
+  excludes package/import clauses and updates the locked Go edge contracts.
+
+**Why after PR 1:** #230's stated impact is that Go's inflated block/edge
+counts nudge `cfg.cyclomatic` one higher, skewing SIMPLE across languages.
+PR 1 makes `cfg.cyclomatic` advisory, which downgrades #230 from a scoring
+bug to a reporting bug — smaller blast radius, and the golden-contract
+updates no longer need a scoring review.
+
+**Verification:** `cfg.nesting_depth` for `adapters/discovery.rs` drops from
+1008 to ~3; Go fixtures match the other five languages block-for-block.
+
+### Chunk 4 — one `AgentContract` builder
+
+**Branch:** `release/050-agent-contract-builder` · **Issue:**
+[#233](https://github.com/Krv-Labs/topos/issues/233)
+
+Four builders (`build_agent_contract`, `project_contract`,
+`assessment_contract`, `changeset_contract`) plus inline literals in
+`tools/depgraph.rs` each re-implement the same flag logic. Only
+`composable_contract_signals` is shared. Collapse to one builder.
+
+Carries one **observed divergence** to settle, not just a refactor:
+`assessment_contract` passes `include_missing = false` where the other three
+pass `true`, so `missing_gitnexus_dir` never reaches an assessment's
+`blocked_by`. Undocumented and looks unintentional — unifying the builders
+forces a choice. See **D2**.
+
+**Why it chains off nothing:** touches only `topos/mcp/`, disjoint from
+chunks 3 and 5.
+
+### Chunk 5 — mechanical parity fixes
+
+**Branch:** `release/050-parity-fixes` · **Issues:**
+[#210](https://github.com/Krv-Labs/topos/issues/210),
+[#211](https://github.com/Krv-Labs/topos/issues/211)
+
+Two independent Python-parity gaps from the #159 migration review, both with
+a settled fix in the issue and no user-visible behavior question.
+
+- **#210** — `mapper_cpp.rs`'s `map_node_kind` callback receives only the
+  kind string, so `is_declaration_only_kind` unconditionally returns
+  `VarDecl`. Every header prototype and pure-virtual signature that Python
+  emitted as `FunctionDecl` diverges. Fix widens the callback to `&Node` so
+  it can reuse the node-aware `has_function_declarator` already in the file.
+  Removes an existing `ponytail:` acknowledgment.
+- **#211** — `gitnexus.rs`'s `finished_result` always writes
+  `.topos-fingerprint.json` to a flat `target_dir/.gitnexus` instead of
+  resolving the branch-scoped store. Dormant (nothing reads it back) but a
+  trap for the first staleness reader. Fix mirrors Python's
+  `current_git_branch` → `resolve_lbug_store`, falling back to flat.
+
+Grouped because both are small, both are #159 review debt, and neither needs
+a reviewer to weigh options.
+
+### Chunk 6 — MCP Registry publish automation
+
+**Branch:** `release/050-mcp-registry-publish` · **Issue:**
+[#66](https://github.com/Krv-Labs/topos/issues/66)
+
+Add a `release.yml` job that runs `mcp-publisher login github-oidc` +
+`publish .mcp/server.json` after the PyPI job succeeds. No repo secret needed
+(GitHub OIDC). Self-contained CI work, touches no engine code.
+
+**Ordering note:** must land *after* the v0.4.4 sync, because
+[#276](https://github.com/Krv-Labs/topos/pull/276) rewrites `.mcp/server.json`
+(dropping `registryBaseUrl` and the `--index-url` runtime argument) and
+[#277](https://github.com/Krv-Labs/topos/pull/277) adds the CI invariant that
+guards it. Publishing automation built against the pre-#276 file would
+re-introduce what #276 removed.
+
+### Chunks pending a decision
+
+These are scoped but **not branched** — each needs an answer below before it
+can be written without guessing.
+
+| Chunk | Issues | Blocked on |
+| --- | --- | --- |
+| CFG switch/try semantics | [#225](https://github.com/Krv-Labs/topos/issues/225) | **D3** |
+| Project ranking / ROI head | [#234](https://github.com/Krv-Labs/topos/issues/234) | **D4** |
+| LadybugDB loader breadth | [#212](https://github.com/Krv-Labs/topos/issues/212) | **D5** |
+
+### Explicitly out of scope for v0.5.0
+
+| Issue | Why deferred |
+| --- | --- |
+| [#264](https://github.com/Krv-Labs/topos/issues/264) rmcp 3.x / MCP `2026-07-28` | A protocol-core migration (stateless, no `initialize`, `server/discover`, dropped `ping`/`logging`) landing in the same release as a lattice change means two independent breaking surfaces in one version. Own release. See **D6**. |
+| [#235](https://github.com/Krv-Labs/topos/issues/235) UAST visibility | Six per-language visibility models plus assess-path surface diffing, and its consumer (`public_api_changed`) has an unresolved noise question. Real feature, own release. |
+| [#237](https://github.com/Krv-Labs/topos/issues/237) Graphify Phase 2 | Dependency Inflation and Semantic Drift both need a stored baseline-graph design that doesn't exist yet. |
+| [#149](https://github.com/Krv-Labs/topos/issues/149) crates.io | Externally blocked on Sighthound's git-only dependency. |
+| [#129](https://github.com/Krv-Labs/topos/issues/129) Visual Recap | Reviewer tooling, no release coupling — land whenever. |
+| [#265](https://github.com/Krv-Labs/topos/issues/265) brew resolves to v0.3.12 | **Should not wait for v0.5.0.** Users cannot install any Rust release via Homebrew today. Belongs in #275 or a standalone hotfix off `main`. See **D7**. |
+
+## Open decisions
+
+### D1 — #193 is being decided inside PR #280
+
+PR #280 sets `gates_achieved: false` on `cfg.cyclomatic`, with the rationale
+in a code comment citing #193. That is **option 2 of the two options #193
+lists**, and it silently resolves the issue.
+
+#193 asked for the opposite process, verbatim: *"changes SIMPLE's meaning for
+every future evaluation, wanted a separate decision/review rather than
+folding it into a cleanup pass."* Right now it is folded into a pillar PR.
+
+The change itself looks correct — #193's own evidence is that 33/99
+`topos-engine` files fail SIMPLE on `cfg.cyclomatic` alone while passing
+`ast.max_function_complexity`, and that splitting a file by responsibility
+took cyclomatic 48 → 25 + 24, both still failing. Gating per-function is the
+right call. The problem is only that it is invisible in a PR titled
+"NAVIGABLE".
+
+- **Option A (recommended)** — split it into its own chunk PR against
+  `release/v0.5.0`, land it *before* #280, close #193 with that PR. Costs one
+  small extra PR; gets the SIMPLE-semantics change its own review and its own
+  CHANGELOG entry.
+- **Option B** — keep it in #280 but retitle/expand the PR body to say it
+  resolves #193, and add a `### Changed` CHANGELOG entry. Cheaper, but a
+  reviewer looking for the SIMPLE change won't find it by PR title.
+- **Option C** — revert the `gates_achieved: false` from #280 and leave #193
+  open for v0.6.0. Not recommended: NAVIGABLE's own doc comment argues from
+  the per-function-gate principle, so shipping the pillar without it leaves
+  the codebase internally inconsistent.
+
+### D2 — `include_missing` when the contract builders unify (#233)
+
+Unifying the four builders forces one answer for whether
+`missing_gitnexus_dir` appears in `blocked_by`.
+
+- **Option A (recommended)** — always `true`. An assessment whose COMPOSABLE
+  dimension is unavailable *is* blocked by a missing GitNexus dir; hiding it
+  from `blocked_by` is the asymmetry #233 calls unintentional. Behavior
+  change: assessments gain a `blocked_by` entry they didn't have.
+- **Option B** — keep the asymmetry and document why (e.g. an assessment is
+  a delta between two measurements, and if both sides lack COMPOSABLE the
+  delta is still valid). Defensible, needs a stated rationale.
+
+Related sub-question from #233: `blocked_by` / `risk_flags` are bare
+`Vec<String>`, and `composable_contract_signals` recovers codes by
+**substring-matching marker constants against prose warning text** — so any
+warning-copy edit can silently change `blocked_by`. Should the unification
+also introduce structured codes? Recommendation: **yes, in the same PR** —
+unifying the builders is exactly when the flag vocabulary is cheapest to
+type, and the substring coupling is a live footgun. Say if you'd rather keep
+that separate.
+
+### D3 — CFG switch `break` and try/catch contract (#225)
+
+Two semantics are currently ambiguous, and #224's edge-contract matrix will
+freeze whatever we choose, so this needs answering before goldens expand.
+
+**Switch `break`.** The builder's docs say `break` resolves against the
+innermost loop *or switch*, but only loop construction pushes a
+`LoopContext`. So a JS/C++ `switch` inside a loop resolves `break` against
+the enclosing loop. Recommendation: **push a switch context** so `break`
+exits to the switch join and `continue` still targets the loop — that is what
+every one of the six languages actually means, and the current behavior is a
+straightforward bug rather than a modeling choice.
+
+**Try/catch/finally.** Today `TryStmt` emits one coarse exception edge to
+`try_join` with no handler or `finally` modeling, so a source where both the
+try body and the catch handler `return` contains only one modeled
+`ReturnStmt`. Options:
+
+- **Option A (recommended)** — model each handler as its own block with an
+  exception edge from the try body, and `finally` as a join every path
+  traverses. Most faithful; raises `cfg.cyclomatic` for try-heavy files,
+  which is now advisory-only after PR 1 — so the cost that would previously
+  have made this scary is largely gone.
+- **Option B** — keep the coarse single-edge model, document it as a
+  permanent narrowing, and expand goldens around it. Cheapest, but bakes in
+  "a return inside a catch is invisible", which will read as a bug later.
+
+How faithful do you want the exception model? A is more work and moves
+numbers; B is stable and lossy.
+
+### D4 — What ranks the head of `worst_files` (#234)
+
+`agent_contract.next_tool` after `topos_evaluate_project` is
+`topos_inspect_code`, and `worst_files` ranks by ascending minimum score
+across dimensions. On a repo full of leaf modules at `mdg.instability = 0.0`,
+COMPOSABLE zeros flood the head, so "start here" points at files that are
+already `SIMPLE_SECURE` while real SIMPLE gate failures sit further down.
+Reported twice independently.
+
+#234 is explicit that this is a ranking-mode request, not a `next_tool`
+swap. Two shapes:
+
+- **Option A (recommended)** — separate lists: `hard_fails[]` (a gate
+  actually failing), `leaf_composable_zeros[]`, `maintainability_giants[]`
+  (high complexity, still passing). Self-describing, needs no ROI definition
+  to survive review, and the agent contract can point `next_tool` at
+  `topos_evaluate_file` on `hard_fails[0]`. Cost: a wider response shape.
+- **Option B** — a `rank_by` parameter (`roi | max_function_complexity |
+  simple_gap | composable_gap`). One list, caller chooses. Cost: needs a
+  defensible ROI definition, which is exactly what #234 says got it scoped
+  out of the #159 pass.
+- **Option C** — minimal: keep one list, just fix `next_tool` to
+  `topos_evaluate_file` on the head. Rejected — the head is the wrong file,
+  so this points the agent at the wrong work faster.
+
+A also interacts with PR 1: with four pillars the "minimum score across
+dimensions" tie-breaking gets noisier, so splitting the lists ages better
+than ranking them.
+
+### D5 — LadybugDB loader: narrow permanently, or restore (#212)
+
+`from_ladybug_native` queries only `MATCH (n:File)`, stubs every other
+referenced id as a bare `Symbol` with empty properties, and hard-codes
+`confidence: 1.0` / `reason: ""`. Python discovered all node tables via
+`show_tables()` and selected real `confidence`/`reason` per edge. #212 offers
+exactly two paths and asks for a pick.
+
+- **Option A (recommended for v0.5.0)** — document the narrowing as
+  permanent. Today's MDG metrics read only the `File` label and `filePath`
+  and traverse edges by id/type, so nothing consumes the dropped data. Cost
+  is a doc change; the debt stays visible in `docs/decisions/`.
+- **Option B** — restore full node-table discovery and `confidence`/`reason`
+  selection. Only worth it if something is about to consume edge confidence.
+  Is anything? If a confidence-weighted coupling metric is on the roadmap, B
+  now is cheaper than B later.
+
+### D6 — Does #264 (rmcp 3.x) belong in v0.5.0?
+
+Recommendation: **no** — v0.6.0. v0.5.0 already breaks the lattice
+(8 → 16 elements, `GOLD` → `PLATINUM`, 4-wide rankings). #264 breaks the
+protocol lifecycle independently: no `initialize`, no `Mcp-Session-Id`,
+`server/discover`, dropped `ping` / `logging/setLevel`. Shipping both in one
+version means a consumer hitting a regression can't tell which surface moved,
+and a bisect lands on a single squashed release commit.
+
+Counter-argument if you want them together: both are "consumers must adapt"
+changes, so one adaptation window is kinder than two. Your call — it changes
+whether chunk 6 (#66) should also wait, since registry metadata describes the
+protocol revision.
+
+### D7 — #265 should not ride v0.5.0
+
+`brew install krv-labs/tap/topos` resolves to `v0.3.12`, the last Python
+release, so **no Rust release is installable via Homebrew today**. That is a
+live install-path outage, and v0.5.0 is at minimum one release away.
+
+Recommendation: fix in [#275](https://github.com/Krv-Labs/topos/pull/275)
+(already open, already touching packaging) or as a standalone hotfix off
+`main`. Flagging rather than acting because the tap lives in a different
+repo, and the root cause — stale formula vs. a tap that never got the Rust
+formula — determines which repo the fix lands in.
+
+## Pre-tag checklist
+
+Tracked on [#279](https://github.com/Krv-Labs/topos/pull/279); repeated here
+because two items are easy to lose:
+
+- **`NAVIGABLE`'s thresholds are `PROVISIONAL`** —
+  `max_function_divergence = 8.0`, `divergence_cap = 20.0` are first-pass
+  estimates, not run through the corpus ECDF calibration that SIMPLE and
+  SECURE constants received. `calibration.rs` says they must be replaced
+  before v0.5.0 is tagged.
+- **`.agents/AGENTS.md` still describes 3 generators and an 8-element
+  lattice.** PR #280 updates `docs/`, `topos/mcp/docs/content/`, and
+  `skills/topos/SKILL.md` but not the canonical agent rules. It is also the
+  one file OpenWiki's PR is allowed to touch, so a regeneration could fight
+  a hand-edit here.
+- `main` carries [#273](https://github.com/Krv-Labs/topos/pull/273) (Homebrew
+  template fix) which `release/v0.4.4` does **not**. Worth confirming that is
+  intentional before #275 merges.

--- a/docs/decisions/v0.5.0-stack.md
+++ b/docs/decisions/v0.5.0-stack.md
@@ -1,7 +1,7 @@
 # v0.5.0 Release Stack
 
-How the v0.5.0 release is chunked, in what order, and which decisions are
-still open. Companion to the release PR
+How the v0.5.0 release is chunked, in what order, and which design decisions
+are settled versus still open. Companion to the release PR
 ([#279](https://github.com/Krv-Labs/topos/pull/279)).
 
 ## Topology and merge strategy
@@ -37,7 +37,7 @@ Only genuinely dependent chunks chain.
 
 | # | PR | Issues | Files | Design risk |
 | --- | --- | --- | --- | --- |
-| 1 | [#280](https://github.com/Krv-Labs/topos/pull/280) | — (+ silently **#193**) | `engine/{core,evaluation,functors}`, `mcp`, `cli`, docs | **decision needed — see D1** |
+| 1 | [#280](https://github.com/Krv-Labs/topos/pull/280) | — | `engine/{core,evaluation,functors}`, `mcp`, `cli`, docs | breaking surface, see below |
 | 2 | this PR | — | `docs/decisions/` | none |
 
 PR 1 is the pillar change and everything else is ordered behind it. Its
@@ -54,7 +54,8 @@ breaking surface is wider than "a new pillar":
 - Preference rankings must list **all four** pillars; a three-element
   `.topos.toml` ranking is dropped and the default order applies.
 - MCP tool-definition context budget grows 33,736 → 39,584 chars.
-- `Φ_SIMPLE` changes what it gates on (see **D1**).
+
+It does **not** change what `Φ_SIMPLE` gates on — see the withdrawn **D1**.
 
 ### Chunk 3 — CFG metric correctness
 
@@ -76,11 +77,13 @@ open design question.
   two extra edges vs the identical program in the other five languages. Fix
   excludes package/import clauses and updates the locked Go edge contracts.
 
-**Why after PR 1:** #230's stated impact is that Go's inflated block/edge
-counts nudge `cfg.cyclomatic` one higher, skewing SIMPLE across languages.
-PR 1 makes `cfg.cyclomatic` advisory, which downgrades #230 from a scoring
-bug to a reporting bug — smaller blast radius, and the golden-contract
-updates no longer need a scoring review.
+**Ordering: independent of PR 1.** #230's stated impact is that Go's inflated
+block/edge counts nudge `cfg.cyclomatic` one higher, skewing SIMPLE across
+languages. That impact is already stale — `cfg.cyclomatic` stopped gating
+`achieved` in v0.4.3 (#251, see withdrawn **D1**), so #230 is a reporting
+bug today and the golden-contract updates need no scoring review. This chunk
+can land before or after PR 1; it touches `graphs/cfg/` only, which PR 1 does
+not.
 
 **Verification:** `cfg.nesting_depth` for `adapters/discovery.rs` drops from
 1008 to ~3; Go fixtures match the other five languages block-for-block.
@@ -144,16 +147,72 @@ Add a `release.yml` job that runs `mcp-publisher login github-oidc` +
 guards it. Publishing automation built against the pre-#276 file would
 re-introduce what #276 removed.
 
-### Chunks pending a decision
+### Chunk 7 — CFG switch and exception semantics
 
-These are scoped but **not branched** — each needs an answer below before it
-can be written without guessing.
+**Branch:** `release/050-cfg-switch-try-semantics` · **Issue:**
+[#225](https://github.com/Krv-Labs/topos/issues/225) · **Decided: D3 = model
+handlers and `finally`**
 
-| Chunk | Issues | Blocked on |
-| --- | --- | --- |
-| CFG switch/try semantics | [#225](https://github.com/Krv-Labs/topos/issues/225) | **D3** |
-| Project ranking / ROI head | [#234](https://github.com/Krv-Labs/topos/issues/234) | **D4** |
-| LadybugDB loader breadth | [#212](https://github.com/Krv-Labs/topos/issues/212) | **D5** |
+Unblocked. Two parts:
+
+- **Switch `break`** — push a switch context alongside `LoopContext` so `break`
+  exits to the switch join while `continue` still targets the enclosing loop.
+  Treated as a bug fix: the builder's own docs already claim this behavior.
+- **Try/catch/finally** — model each handler as its own block reached by an
+  exception edge from the try body, and `finally` as a join every path
+  traverses. Contract to lock as goldens: single catch; handler returns
+  (→ exit, not → join); handler throws (→ enclosing exception target);
+  `finally` fallthrough on every path including returns; multiple handlers.
+
+Raises `cfg.cyclomatic` for try-heavy files, which is advisory-only
+(v0.4.3, #251) — a reporting change, not a scoring one.
+
+**Must land before #224's golden matrix expands**, since those tests would
+otherwise freeze the coarse model.
+
+### Chunk 8 — project ranking by named lists
+
+**Branch:** `release/050-project-ranking-lists` · **Issue:**
+[#234](https://github.com/Krv-Labs/topos/issues/234) · **Decided: D4 =
+separate named lists**
+
+Replace the single ascending-minimum-score `worst_files` ranking with:
+
+| List | Membership |
+| --- | --- |
+| `hard_fails[]` | at least one `GATE_SPECS` entry with `gates_achieved: true` is failing |
+| `leaf_composable_zeros[]` | `mdg.instability = 0.0` with no coupling signal — structurally a leaf, not a defect |
+| `maintainability_giants[]` | high complexity, all gates still passing |
+
+`agent_contract.next_tool` then points at
+`topos_evaluate_file(refactor_targets=…)` on `hard_fails[0]`, falling back to
+`inspect_code` only when that is insufficient. No ROI definition needed —
+"fails a gate" is objective, which is what kept this out of the #159 pass.
+
+**Why after PR 1:** with four pillars, "minimum score across dimensions" gets
+noisier — NAVIGABLE can hold the minimum — so the flooding this issue
+describes gets worse, and the list definitions should be written against the
+four-pillar `GATE_SPECS`.
+
+**Two sub-questions still open** (asked on #234, not blocking the branch):
+whether `worst_files` may disappear or must stay for compatibility, and
+whether `leaf_composable_zeros[]` needs to be in the response at all versus
+just excluded from `hard_fails[]`.
+
+### Chunk 9 — restore full LadybugDB ingestion
+
+**Branch:** `release/050-ladybug-full-ingest` · **Issue:**
+[#212](https://github.com/Krv-Labs/topos/issues/212) · **Decided: D5 = restore**
+
+Add `show_tables()` node-table discovery so every label (Class/Function/
+Method/Import/…) loads with its real properties instead of being stubbed as a
+bare `Symbol`, and select `r.confidence` / `r.reason` per edge instead of
+hard-coding `1.0` / `""`. Mirrors Python's `_from_ladybgdb`.
+
+Chosen over documenting the narrowing because retrofitting confidence into
+`mdg.*` later means touching the loader, the `Representation`, `GATE_SPECS`
+and calibration together, whereas the loader work is self-contained now. No
+metric consumes confidence yet — this lands the data, not a new gate.
 
 ### Explicitly out of scope for v0.5.0
 
@@ -166,36 +225,35 @@ can be written without guessing.
 | [#129](https://github.com/Krv-Labs/topos/issues/129) Visual Recap | Reviewer tooling, no release coupling — land whenever. |
 | [#265](https://github.com/Krv-Labs/topos/issues/265) brew resolves to v0.3.12 | **Should not wait for v0.5.0.** Users cannot install any Rust release via Homebrew today. Belongs in #275 or a standalone hotfix off `main`. See **D7**. |
 
-## Open decisions
+## Decisions
 
-### D1 — #193 is being decided inside PR #280
+D1 was withdrawn as a misreading. D3, D4 and D5 are **settled**; D2, D6 and D7
+are still open.
 
-PR #280 sets `gates_achieved: false` on `cfg.cyclomatic`, with the rationale
-in a code comment citing #193. That is **option 2 of the two options #193
-lists**, and it silently resolves the issue.
+### D1 — withdrawn: #193 was already fixed in v0.4.3
 
-#193 asked for the opposite process, verbatim: *"changes SIMPLE's meaning for
-every future evaluation, wanted a separate decision/review rather than
-folding it into a cleanup pass."* Right now it is folded into a pillar PR.
+An earlier revision of this doc claimed PR #280 silently resolved #193 by
+making `cfg.cyclomatic` advisory. **That was wrong.** `gates_achieved: false`
+has been on `main` since **v0.4.3 (#251)**; `gates.rs`'s diff in #280 adds only
+`interpret_divergence` and the `nav.max_function_divergence` spec, and #280
+does not touch `simple.rs` at all. `main`'s `simple.rs` header already
+documents the resolved contract:
 
-The change itself looks correct — #193's own evidence is that 33/99
-`topos-engine` files fail SIMPLE on `cfg.cyclomatic` alone while passing
-`ast.max_function_complexity`, and that splitting a file by responsibility
-took cyclomatic 48 → 25 + 24, both still failing. Gating per-function is the
-right call. The problem is only that it is invisible in a PR titled
-"NAVIGABLE".
+```text
+Φ_SIMPLE(metrics) → ScoredDecision
+achieved = (entropy in band) ∧ (max_func ≤ gate)
+score    = min(per-metric qualities)   # reporting only; does not gate achieved
+```
 
-- **Option A (recommended)** — split it into its own chunk PR against
-  `release/v0.5.0`, land it *before* #280, close #193 with that PR. Costs one
-  small extra PR; gets the SIMPLE-semantics change its own review and its own
-  CHANGELOG entry.
-- **Option B** — keep it in #280 but retitle/expand the PR body to say it
-  resolves #193, and add a `### Changed` CHANGELOG entry. Cheaper, but a
-  reviewer looking for the SIMPLE change won't find it by PR title.
-- **Option C** — revert the `gates_achieved: false` from #280 and leave #193
-  open for v0.6.0. Not recommended: NAVIGABLE's own doc comment argues from
-  the per-function-gate principle, so shipping the pillar without it leaves
-  the codebase internally inconsistent.
+The mistake was reading the gate spec on the feature branch and assuming the
+change originated there, without diffing against the base first.
+
+**#193 is stale, not open work** — it took option 2 from its own body (demote
+the gate, gate on `ast.max_function_complexity`) and only ever lacked a
+CHANGELOG entry, which is why it stayed open. Recommend closing it. If the
+undocumented-behavior-change matters, the cheap fix is a `### Changed` line
+under `## [0.4.3]`; that is bookkeeping, not a chunk.
+
 
 ### D2 — `include_missing` when the contract builders unify (#233)
 
@@ -219,7 +277,10 @@ unifying the builders is exactly when the flag vocabulary is cheapest to
 type, and the substring coupling is a live footgun. Say if you'd rather keep
 that separate.
 
-### D3 — CFG switch `break` and try/catch contract (#225)
+### D3 — CFG switch `break` and try/catch contract (#225) — **DECIDED: A**
+
+> Resolved: model handlers and `finally` (Option A). Implementation scoped as
+> chunk 7. Deliberation kept below as rationale.
 
 Two semantics are currently ambiguous, and #224's edge-contract matrix will
 freeze whatever we choose, so this needs answering before goldens expand.
@@ -249,7 +310,10 @@ try body and the catch handler `return` contains only one modeled
 How faithful do you want the exception model? A is more work and moves
 numbers; B is stable and lossy.
 
-### D4 — What ranks the head of `worst_files` (#234)
+### D4 — What ranks the head of `worst_files` (#234) — **DECIDED: A**
+
+> Resolved: separate named lists (Option A). Implementation scoped as chunk 8.
+> Two sub-questions remain open, listed at the end of this section.
 
 `agent_contract.next_tool` after `topos_evaluate_project` is
 `topos_inspect_code`, and `worst_files` ranks by ascending minimum score
@@ -278,7 +342,11 @@ A also interacts with PR 1: with four pillars the "minimum score across
 dimensions" tie-breaking gets noisier, so splitting the lists ages better
 than ranking them.
 
-### D5 — LadybugDB loader: narrow permanently, or restore (#212)
+### D5 — LadybugDB loader: narrow permanently, or restore (#212) — **DECIDED: B**
+
+> Resolved: restore full ingestion (Option B), *against* the recommendation
+> below — a confidence-consuming metric is close enough that doing the loader
+> work now beats retrofitting it. Implementation scoped as chunk 9.
 
 `from_ladybug_native` queries only `MATCH (n:File)`, stubs every other
 referenced id as a bare `Symbol` with empty properties, and hard-codes
@@ -297,8 +365,9 @@ exactly two paths and asks for a pick.
 
 ### D6 — Does #264 (rmcp 3.x) belong in v0.5.0?
 
-Recommendation: **no** — v0.6.0. v0.5.0 already breaks the lattice
-(8 → 16 elements, `GOLD` → `PLATINUM`, 4-wide rankings). #264 breaks the
+Recommendation: **no** — v0.6.0. v0.5.0 already breaks the lattice (8 → 16
+elements, `IDEAL` re-defined to require four pillars, medals re-graded, 4-wide
+rankings). #264 breaks the
 protocol lifecycle independently: no `initialize`, no `Mcp-Session-Id`,
 `server/discover`, dropped `ping` / `logging/setLevel`. Shipping both in one
 version means a consumer hitting a regression can't tell which surface moved,

--- a/docs/decisions/v0.5.0-stack.md
+++ b/docs/decisions/v0.5.0-stack.md
@@ -223,6 +223,7 @@ metric consumes confidence yet — this lands the data, not a new gate.
 | [#237](https://github.com/Krv-Labs/topos/issues/237) Graphify Phase 2 | Dependency Inflation and Semantic Drift both need a stored baseline-graph design that doesn't exist yet. |
 | [#149](https://github.com/Krv-Labs/topos/issues/149) crates.io | Externally blocked on Sighthound's git-only dependency. |
 | [#129](https://github.com/Krv-Labs/topos/issues/129) Visual Recap | Reviewer tooling, no release coupling — land whenever. |
+| [#283](https://github.com/Krv-Labs/topos/issues/283) lattice figures | The 8-element artwork needs a layout decision for 16 elements, not just more nodes. #280's captions make the docs honest in the meantime. |
 | [#265](https://github.com/Krv-Labs/topos/issues/265) brew resolves to v0.3.12 | **Should not wait for v0.5.0.** Users cannot install any Rust release via Homebrew today. Belongs in #275 or a standalone hotfix off `main`. See **D7**. |
 
 ## Decisions
@@ -390,6 +391,33 @@ Recommendation: fix in [#275](https://github.com/Krv-Labs/topos/pull/275)
 repo, and the root cause — stale formula vs. a tap that never got the Rust
 formula — determines which repo the fix lands in.
 
+## Issue and milestone state
+
+Milestones were reconciled against this plan on 2026-08-04.
+
+| Milestone | Contents |
+| --- | --- |
+| **Release v0.5.0** | Chunks 3–5 and 7–9 (#231, #230, #233, #210, #211, #225, #234, #212) plus the tag blocker #282 |
+| **Release v0.6.0** | #264, #235, #237, #283 — created for this deferral set |
+| **Release v0.4.4** | gained #265, which should not wait for v0.5.0 (**D7**) |
+| **Increase Distribution Coverage** | keeps #66 (chunk 6), #149, #129 |
+
+Changes worth noting:
+
+- **[#193](https://github.com/Krv-Labs/topos/issues/193) closed** and removed
+  from the v0.5.0 milestone — fixed in v0.4.3 by #251, so leaving it on v0.5.0
+  would have implied this release shipped the fix. See withdrawn **D1**.
+- **[#282](https://github.com/Krv-Labs/topos/issues/282) filed** for the
+  `PROVISIONAL` NAVIGABLE thresholds, so the tag blocker exists as an issue
+  rather than only as a checklist line in a PR body.
+- **[#66](https://github.com/Krv-Labs/topos/issues/66) stays on Increase
+  Distribution Coverage** even though it is chunk 6 — registry publishing is
+  that milestone's theme and it has an active due date. Move it if the release
+  milestone should be the complete picture of what ships.
+- **D2 is now posted on [#233](https://github.com/Krv-Labs/topos/issues/233)**
+  as two sub-questions (`include_missing`, and whether structured `blocked_by`
+  codes ride the same PR). It was previously only in this doc.
+
 ## Pre-tag checklist
 
 Tracked on [#279](https://github.com/Krv-Labs/topos/pull/279); repeated here
@@ -399,7 +427,9 @@ because two items are easy to lose:
   `max_function_divergence = 8.0`, `divergence_cap = 20.0` are first-pass
   estimates, not run through the corpus ECDF calibration that SIMPLE and
   SECURE constants received. `calibration.rs` says they must be replaced
-  before v0.5.0 is tagged. #280's CHANGELOG has the starting distribution
+  before v0.5.0 is tagged. Tracked as
+  [#282](https://github.com/Krv-Labs/topos/issues/282). #280's CHANGELOG has
+  the starting distribution
   over Topos's own 157 Rust files — median `0.69`, p75 `2.08`, p90 `4.56`,
   p95 `5.98` — so `8.0` sits near p97 and fails 2.5% of files. Worth deciding
   what failure rate the gate is *supposed* to produce before picking the
@@ -407,7 +437,9 @@ because two items are easy to lose:
   percentile, not from a target failure count.
 - **Docs figures are stale.** `docs/source/_static/figures/topos-lattice*.svg`
   still depict the three-generator sub-cube. #280 makes the captions say so,
-  but the artwork has not been redrawn for 16 elements.
+  but the artwork has not been redrawn for 16 elements. Tracked as
+  [#283](https://github.com/Krv-Labs/topos/issues/283), deferred to v0.6.0 —
+  not a tag blocker, since the captions make the docs honest.
 - **`.agents/AGENTS.md` still describes 3 generators and an 8-element
   lattice.** PR #280 updates `docs/`, `topos/mcp/docs/content/`, and
   `skills/topos/SKILL.md` but not the canonical agent rules. It is also the

--- a/docs/decisions/v0.5.0-stack.md
+++ b/docs/decisions/v0.5.0-stack.md
@@ -40,9 +40,21 @@ Only genuinely dependent chunks chain.
 | 1 | [#280](https://github.com/Krv-Labs/topos/pull/280) | — (+ silently **#193**) | `engine/{core,evaluation,functors}`, `mcp`, `cli`, docs | **decision needed — see D1** |
 | 2 | this PR | — | `docs/decisions/` | none |
 
-PR 1 is the pillar change and everything else is ordered behind it, because
-it moves $\Omega$ from 8 to 16 elements, renames `GOLD` → `PLATINUM`, widens
-the preference ranking to 4, and changes what `Φ_SIMPLE` gates on.
+PR 1 is the pillar change and everything else is ordered behind it. Its
+breaking surface is wider than "a new pillar":
+
+- $\Omega$ moves from 8 to 16 elements; `LatticeElement` gains 8 variants on
+  the MCP wire.
+- **`IDEAL` now requires all four pillars.** The verdict formerly called
+  `IDEAL` is now `SIMPLE_COMPOSABLE_SECURE`. **CI pinned to `IDEAL` starts
+  failing** on files that pass the original three pillars but fail NAVIGABLE.
+- **Medals re-grade in both directions**, banding on satisfied-pillar count:
+  4 → `PLATINUM`, 3 → `GOLD`, 2 → `SILVER`, 1 → `BRONZE`, 0 → `SLOP`. `GOLD`
+  is not renamed — it now means 3 of 4, so the old top verdict lands there.
+- Preference rankings must list **all four** pillars; a three-element
+  `.topos.toml` ranking is dropped and the default order applies.
+- MCP tool-definition context budget grows 33,736 → 39,584 chars.
+- `Φ_SIMPLE` changes what it gates on (see **D1**).
 
 ### Chunk 3 — CFG metric correctness
 
@@ -147,7 +159,7 @@ can be written without guessing.
 
 | Issue | Why deferred |
 | --- | --- |
-| [#264](https://github.com/Krv-Labs/topos/issues/264) rmcp 3.x / MCP `2026-07-28` | A protocol-core migration (stateless, no `initialize`, `server/discover`, dropped `ping`/`logging`) landing in the same release as a lattice change means two independent breaking surfaces in one version. Own release. See **D6**. |
+| [#264](https://github.com/Krv-Labs/topos/issues/264) rmcp 3.x / MCP `2026-07-28` | A protocol-core migration (stateless, no `initialize`, `server/discover`, dropped `ping`/`logging`) landing in the same release as an `IDEAL`-breaking lattice change means two independent breaking surfaces in one version. Own release. See **D6**. |
 | [#235](https://github.com/Krv-Labs/topos/issues/235) UAST visibility | Six per-language visibility models plus assess-path surface diffing, and its consumer (`public_api_changed`) has an unresolved noise question. Real feature, own release. |
 | [#237](https://github.com/Krv-Labs/topos/issues/237) Graphify Phase 2 | Dependency Inflation and Semantic Drift both need a stored baseline-graph design that doesn't exist yet. |
 | [#149](https://github.com/Krv-Labs/topos/issues/149) crates.io | Externally blocked on Sighthound's git-only dependency. |
@@ -318,7 +330,15 @@ because two items are easy to lose:
   `max_function_divergence = 8.0`, `divergence_cap = 20.0` are first-pass
   estimates, not run through the corpus ECDF calibration that SIMPLE and
   SECURE constants received. `calibration.rs` says they must be replaced
-  before v0.5.0 is tagged.
+  before v0.5.0 is tagged. #280's CHANGELOG has the starting distribution
+  over Topos's own 157 Rust files — median `0.69`, p75 `2.08`, p90 `4.56`,
+  p95 `5.98` — so `8.0` sits near p97 and fails 2.5% of files. Worth deciding
+  what failure rate the gate is *supposed* to produce before picking the
+  calibrated value; every other pillar's gate was set from a target
+  percentile, not from a target failure count.
+- **Docs figures are stale.** `docs/source/_static/figures/topos-lattice*.svg`
+  still depict the three-generator sub-cube. #280 makes the captions say so,
+  but the artwork has not been redrawn for 16 elements.
 - **`.agents/AGENTS.md` still describes 3 generators and an 8-element
   lattice.** PR #280 updates `docs/`, `topos/mcp/docs/content/`, and
   `skills/topos/SKILL.md` but not the canonical agent rules. It is also the


### PR DESCRIPTION
**PR 2 of the v0.5.0 stack.** Base: `release/v0.5.0` (#279). Docs only, no code.

Adds `docs/decisions/v0.5.0-stack.md`: how v0.5.0 is chunked, in what order, and the decisions still open.

## What it settles

- **Merge strategy, written down.** Chunk PRs merge into `release/v0.5.0` with **merge commits**; the release branch squashes into `main`. Squashing into the release branch is what diverged the stack on v0.4.4.
- **Why `release/v0.5.0` is based on `main`, not `release/v0.4.4`.** Release PRs squash-merge, so carrying v0.4.4's individual commits would guarantee conflicts once #275 lands. #275 merges first, then this branch syncs.
- **Chunk boundaries and ordering rationale** for the remaining open issues, including which chunks are safe to fan (disjoint file sets) versus chain.

## Chunks ready to write

| Chunk | Issues | Why grouped |
| --- | --- | --- |
| 3 — CFG metric correctness | #231, #230 | Both self-contained CFG bugs with a settled fix sketch. Ordered after #280 because it makes `cfg.cyclomatic` advisory, downgrading #230 from a scoring bug to a reporting bug. |
| 4 — one `AgentContract` builder | #233 | Four builders duplicating flag logic; touches only `topos/mcp/`. |
| 5 — mechanical parity fixes | #210, #211 | Both #159 review debt, both with a settled fix, neither needs a reviewer to weigh options. |
| 6 — MCP Registry publish automation | #66 | CI only. Must land after the v0.4.4 sync, since #276 rewrites `.mcp/server.json`. |

## Chunks blocked on a decision

#225 (CFG switch/try semantics), #234 (project ranking / ROI head), #212 (LadybugDB loader breadth) — scoped but deliberately not branched, because each needs an answer to avoid guessing at behavior a golden test would then freeze.

## Deferred out of v0.5.0

#264 (rmcp 3.x — second independent breaking surface), #235 (UAST visibility), #237 (Graphify Phase 2), #149 (externally blocked), #129 (no release coupling), and **#265**, which should not wait at all — see below.

## Two things worth reading even if you skim the rest

**D1 — #193 is currently being decided inside #280.** That PR sets `gates_achieved: false` on `cfg.cyclomatic`, which is option 2 of the two options #193 lists, and silently resolves it. #193 asked for the opposite process verbatim: *"wanted a separate decision/review rather than folding it into a cleanup pass."* The change looks right; the problem is that it is invisible in a PR titled "NAVIGABLE". Doc recommends splitting it into its own PR ahead of #280.

**D7 — #265 is a live outage.** `brew install krv-labs/tap/topos` resolves to `v0.3.12`, so no Rust release is installable via Homebrew today. It should ride #275 or a standalone hotfix off `main`, not v0.5.0.

## Also flagged for the pre-tag checklist

- `NAVIGABLE`'s thresholds are `PROVISIONAL` and `calibration.rs` says they must be replaced before the tag.
- `.agents/AGENTS.md` still describes **3 generators and an 8-element lattice** — #280 updates `docs/`, `topos/mcp/docs/content/`, and `SKILL.md` but not the canonical agent rules.
- `main` carries #273 which `release/v0.4.4` does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
