### PR TITLE
ci: unbreak the rust job (rustfmt drift + missing liblbug)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Install build deps (lbug / OpenSSL)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends cmake libssl-dev pkg-config
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -19,6 +24,19 @@ jobs:
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
+
+      # Clippy and the test suite link topos-engine, so this job needs
+      # liblbug just as much as `composable` does. Without it, a cold cargo
+      # cache fails at link time with "could not find native static library
+      # `lbug`". See scripts/setup-lbug-prebuilt.sh and issue #239.
+      - name: Cache lbug prebuilt
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/lbug-prebuilt
+          key: lbug-prebuilt-0.17.1-static-${{ runner.os }}-${{ runner.arch }}
+
+      - name: Setup lbug prebuilt
+        run: ./scripts/setup-lbug-prebuilt.sh
 
       - name: Check versions (Cargo.toml is source of truth)
         run: python3 scripts/check_versions.py

--- a/topos/engine/src/graphs/graphify/object.rs
+++ b/topos/engine/src/graphs/graphify/object.rs
@@ -45,7 +45,10 @@ pub enum GraphifyError {
     /// Neither a `"links"` nor an `"edges"` top-level array was present.
     MissingEdgeKey,
     /// File exceeded [`MAX_GRAPH_JSON_BYTES`].
-    TooLarge { path: PathBuf, size: u64 },
+    TooLarge {
+        path: PathBuf,
+        size: u64,
+    },
 }
 
 impl std::fmt::Display for GraphifyError {
@@ -262,10 +265,8 @@ mod tests {
 
     #[test]
     fn oversized_file_is_rejected() {
-        let dir = std::env::temp_dir().join(format!(
-            "topos-graphify-oversized-{}",
-            std::process::id()
-        ));
+        let dir =
+            std::env::temp_dir().join(format!("topos-graphify-oversized-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join("graph.json");
         let file = std::fs::File::create(&path).unwrap();

--- a/topos/mcp/src/schemas.rs
+++ b/topos/mcp/src/schemas.rs
@@ -1393,8 +1393,7 @@ mod tests {
 
     #[test]
     fn generate_depgraph_accepts_and_advertises_gitnexus_dir() {
-        let defaulted: GenerateDepgraphInput =
-            serde_json::from_str(r#"{}"#).expect("deserialize");
+        let defaulted: GenerateDepgraphInput = serde_json::from_str(r#"{}"#).expect("deserialize");
         assert!(defaulted.gitnexus_dir.is_none());
         assert!(defaulted.directory.is_none());
         assert!(!defaulted.force);


### PR DESCRIPTION
Makes the `rust` CI job pass on `release/v0.4.4`, which is currently red on every run. Two independent causes, both pre-existing and neither specific to any feature branch.

## 1. `Format check` — rustfmt drift

`cargo fmt --all --check` fails on `release/v0.4.4` itself, in `topos/engine/src/graphs/graphify/object.rs` and `topos/mcp/src/schemas.rs`. CI installs `dtolnay/rust-toolchain@stable` and there is no `rust-toolchain.toml`, so a newer stable rustfmt reformats what an older one wrote. Nothing was misformatted on purpose.

This commit is rustfmt output only — no logic change. Local rustfmt 1.8.0 produces output byte-identical to what the failing job asked for.

## 2. `Clippy` — the job never had liblbug

With the format check passing, the next step fails:

```
error: could not find native static library `lbug`, perhaps an -L flag is missing?
error: could not compile `lbug` (lib) due to 1 previous error
```

Clippy and the test suite both link `topos-engine`, which depends on `lbug = "=0.17.1"` — so the `rust` job needs liblbug exactly as much as `composable` does. `composable` sets it up in three steps and passes; `rust` has none of them and fails at link time.

This adds those same three steps, copied from `composable` in the same file and in the same order: apt `cmake libssl-dev pkg-config`, cache `~/.cargo/lbug-prebuilt`, then `scripts/setup-lbug-prebuilt.sh` — whose header states its purpose is to point `build.rs` at a pinned prebuilt so it skips both the in-crate downloader and the cmake source fallback (issue #239).

### Why it went unnoticed

`Format check` runs before `Clippy`, so while cause 1 was failing, clippy never executed and cause 2 stayed invisible. Fixing the formatting is what surfaced it — confirmed deterministic across two runs of #278.

`main` has a byte-identical `rust` job and the same pinned `lbug`, and is green only because its cargo cache carries the built artifact. Any cache miss or eviction there fails the same way, so this hardens `main` too rather than only unblocking the release branch.

## Verification

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` (487 tests) all clean locally.
- `ci.yml` parses, and the `rust` job's step order now matches `composable`'s.
- The real check is this PR's own `rust` job: it must get past `Format check` and through `Clippy` and `Tests`, which is the first time those steps will have run on this branch family.

Unblocks the `rust` check on #278.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
