### PR TITLE
ci(release): automate MCP Registry publish after PyPI (#66)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -793,3 +793,28 @@ jobs:
 
 
 
+  publish-mcp-registry:
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    needs:
+      - publish-pypi
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install mcp-publisher
+        run: |
+          curl -fsSL \
+            "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
+            | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Validate MCP Registry metadata
+        run: ./mcp-publisher validate .mcp/server.json
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish .mcp/server.json


### PR DESCRIPTION
## Summary
- Add `publish-mcp-registry` job to `release.yml` after `publish-pypi`
- Authenticate with `mcp-publisher login github-oidc` (no repo secret)
- Validate and publish checked-in `.mcp/server.json`

Closes #66.

## Test plan
- [ ] CI passes on this PR (verify-version + existing release workflow jobs)
- [ ] On next tag/workflow_dispatch release, `publish-mcp-registry` runs after PyPI and publishes `io.github.Krv-Labs/topos`

## Notes
- `scripts/check_versions.py` already guards `.mcp/server.json` version alignment and PyPI package invariants (#277); no script changes needed.
- Job uses `permissions: id-token: write` + `contents: read` for OIDC auth and checkout.

Made with [Cursor](https://cursor.com)