### PR TITLE
Unify AgentContract builders behind shared prelude (#233)

### DIFF
--- a/topos/mcp/src/formatting.rs
+++ b/topos/mcp/src/formatting.rs
@@ -125,6 +125,92 @@ pub fn composable_contract_signals(
     }
 }
 
+/// Shared `blocked_by` / `risk_flags` prelude for every `AgentContract` builder.
+#[derive(Debug, Default, Clone)]
+pub struct AgentContractPreludeInput<'a> {
+    pub coupling_available: bool,
+    pub warnings: &'a [String],
+    pub parse_failures: usize,
+    pub grade_capped: bool,
+    pub active_security_findings: bool,
+    pub acknowledged_security_risks: bool,
+}
+
+/// Shared prelude output: composable signals plus the common flag extensions.
+#[derive(Debug, Clone)]
+pub struct AgentContractPrelude {
+    pub blocked_by: Vec<String>,
+    pub risk_flags: Vec<String>,
+    pub composable: ComposableContractSignals,
+}
+
+/// Always uses `include_missing = true` (D2a).
+pub fn agent_contract_prelude(input: AgentContractPreludeInput<'_>) -> AgentContractPrelude {
+    let composable =
+        composable_contract_signals(input.coupling_available, input.warnings, true);
+    let mut blocked_by = composable.blocked_by.clone();
+    let mut risk_flags = composable.risk_flags.clone();
+
+    if input.parse_failures > 0 {
+        blocked_by.push("parse_failures".into());
+        risk_flags.push("parse_failures".into());
+    }
+    if input.active_security_findings {
+        risk_flags.push("active_security_findings".into());
+    }
+    if input.acknowledged_security_risks {
+        risk_flags.push("acknowledged_security_risk".into());
+    }
+    if input.grade_capped {
+        risk_flags.push("grade_capped".into());
+    }
+    if !input.warnings.is_empty() {
+        risk_flags.push("warnings".into());
+    }
+
+    AgentContractPrelude {
+        blocked_by,
+        risk_flags,
+        composable,
+    }
+}
+
+/// Wire code for an unparseable single-file evaluation.
+pub fn agent_contract_parse_blocked() -> AgentContract {
+    AgentContract {
+        next_tool: None,
+        next_actions: vec!["restore parseable source".into()],
+        blocked_by: vec!["parse_failures".into()],
+        verification_gates: Vec::new(),
+        risk_flags: vec!["parse_failures".into()],
+    }
+}
+
+/// Assemble the final contract from a shared prelude and tool-specific fields.
+pub fn finish_agent_contract(
+    blocked_by: Vec<String>,
+    risk_flags: Vec<String>,
+    next_tool: Option<String>,
+    next_actions: Vec<String>,
+    verification_gates: Vec<String>,
+) -> AgentContract {
+    AgentContract {
+        next_tool,
+        next_actions,
+        blocked_by,
+        verification_gates,
+        risk_flags,
+    }
+}
+
+/// Risk flags for depgraph responses when COMPOSABLE is not scorable.
+pub fn depgraph_unavailable_risk_flags(blocked_by: &[String]) -> Vec<String> {
+    let mut flags = vec!["composable_unavailable".into()];
+    flags.extend(blocked_by.iter().cloned());
+    flags
+}
+
+
 /// Materialize a `PreferenceWalk` for the result schema.
 pub fn build_preference_walk(prefs: &UserPreferences, current: EvaluationValue) -> PreferenceWalk {
     let target = prefs.aspirational_target();
@@ -216,49 +302,35 @@ pub fn build_agent_contract(
     refactor_targets: Option<&[RefactorTarget]>,
     offer_refactor_targets: bool,
 ) -> AgentContract {
-    let mut blocked_by: Vec<String> = Vec::new();
-    let mut risk_flags: Vec<String> = Vec::new();
-    let mut next_actions: Vec<String> = Vec::new();
-
     if !result.is_parseable {
-        return AgentContract {
-            next_tool: None,
-            next_actions: vec!["restore parseable source".into()],
-            blocked_by: vec!["parse_failure".into()],
-            verification_gates: Vec::new(),
-            risk_flags: vec!["parse_failure".into()],
-        };
+        return agent_contract_parse_blocked();
     }
 
-    let composable = composable_contract_signals(coupling_available, warnings, true);
-    blocked_by.extend(composable.blocked_by.clone());
-    risk_flags.extend(composable.risk_flags.clone());
-    if !security_findings.is_empty() {
-        risk_flags.push("active_security_findings".into());
-    }
-    if !acknowledged_risks.is_empty() {
-        risk_flags.push("acknowledged_security_risk".into());
-    }
-    if grade_capped {
-        risk_flags.push("grade_capped".into());
-    }
-    if !warnings.is_empty() {
-        risk_flags.push("warnings".into());
-    }
+    let prelude = agent_contract_prelude(AgentContractPreludeInput {
+        coupling_available,
+        warnings,
+        active_security_findings: !security_findings.is_empty(),
+        acknowledged_security_risks: !acknowledged_risks.is_empty(),
+        grade_capped,
+        ..Default::default()
+    });
 
     let summary = result.summary();
     let simple_ok = result.dimensions.get("simple") == Some(&EvaluationValue::Simple);
-    let missing_gitnexus = blocked_by.iter().any(|b| b == "missing_gitnexus_dir");
+    let missing_gitnexus = prelude
+        .blocked_by
+        .iter()
+        .any(|b| b == "missing_gitnexus_dir");
 
     let (next_tool, step_actions) = next_step_for_contract(
-        &composable,
+        &prelude.composable,
         refactor_targets,
         summary,
         simple_ok,
         security_findings,
         missing_gitnexus,
     );
-    next_actions.extend(step_actions);
+    let mut next_actions = step_actions;
 
     // Reachable only when the caller passed `refactor_targets=0`, since the
     // parameter now defaults to a non-zero count: this is a re-enable hint
@@ -271,18 +343,18 @@ pub fn build_agent_contract(
         );
     }
 
-    AgentContract {
+    finish_agent_contract(
+        prelude.blocked_by,
+        prelude.risk_flags,
         next_tool,
         next_actions,
-        blocked_by,
-        verification_gates: vec![
+        vec![
             "verify in-place edits with topos_assess_worktree_change".into(),
             "assessment status is IMPROVEMENT or IMPROVEMENT_SCORE".into(),
             "assessment status is not SUSPICIOUS_NO_STRUCTURAL_CHANGE".into(),
             "behavior tests or type/lint checks pass when available".into(),
         ],
-        risk_flags,
-    }
+    )
 }
 
 /// Priority-ordered next-tool/next-action dispatch for the agent contract:
@@ -1127,7 +1199,7 @@ mod tests {
         let model = to_evaluation_result(&result, false, EvalResultOptions::new());
         if !model.is_parseable {
             let contract = model.agent_contract.expect("contract present");
-            assert!(contract.blocked_by.contains(&"parse_failure".to_string()));
+            assert!(contract.blocked_by.contains(&"parse_failures".to_string()));
         }
     }
 }

--- a/topos/mcp/src/tools/assess.rs
+++ b/topos/mcp/src/tools/assess.rs
@@ -25,7 +25,8 @@ use crate::evaluation::{
     resolve_override_for_root,
 };
 use crate::formatting::{
-    composable_contract_signals, to_evaluation_result, to_tool_result, EvalResultOptions,
+    agent_contract_prelude, finish_agent_contract, to_evaluation_result, to_tool_result,
+    AgentContractPreludeInput, EvalResultOptions,
 };
 use crate::schemas::{
     lattice_to_str, priority_str, resolve_priority, AgentContract, AssessChangesetInput,
@@ -372,22 +373,17 @@ fn assessment_contract(
     warnings: &[String],
     proposed_eval: &EvaluationResult,
 ) -> AgentContract {
-    let mut risk_flags: Vec<String> = Vec::new();
-    let mut blocked_by: Vec<String> = Vec::new();
+    let prelude = agent_contract_prelude(AgentContractPreludeInput {
+        coupling_available: proposed_eval.coupling_available,
+        warnings,
+        grade_capped: proposed_eval.grade_capped,
+        active_security_findings: proposed_eval.secure_adjusted == Some(false),
+        ..Default::default()
+    });
+    let mut blocked_by = prelude.blocked_by;
+    let mut risk_flags = prelude.risk_flags;
+    let composable = prelude.composable;
     let mut next_actions: Vec<String> = Vec::new();
-
-    let composable = composable_contract_signals(proposed_eval.coupling_available, warnings, false);
-    blocked_by.extend(composable.blocked_by.clone());
-    risk_flags.extend(composable.risk_flags.clone());
-    if !warnings.is_empty() {
-        risk_flags.push("warnings".into());
-    }
-    if proposed_eval.grade_capped {
-        risk_flags.push("grade_capped".into());
-    }
-    if proposed_eval.secure_adjusted == Some(false) {
-        risk_flags.push("active_security_findings".into());
-    }
 
     let next_tool = if let Some(action) = composable.next_action {
         next_actions.push(action);
@@ -413,17 +409,17 @@ fn assessment_contract(
         Some("topos_inspect_code".to_string())
     };
 
-    AgentContract {
+    finish_agent_contract(
+        blocked_by,
+        risk_flags,
         next_tool,
         next_actions,
-        blocked_by,
-        verification_gates: vec![
+        vec![
             "assessment status is IMPROVEMENT or IMPROVEMENT_SCORE".into(),
             "assessment status is not SUSPICIOUS_NO_STRUCTURAL_CHANGE".into(),
             "behavior tests or type/lint checks pass when available".into(),
         ],
-        risk_flags,
-    }
+    )
 }
 
 fn err_assessment(
@@ -1616,16 +1612,16 @@ fn changeset_contract(
     coupling_available: bool,
     warnings: &[String],
 ) -> AgentContract {
-    let mut blocked_by: Vec<String> = Vec::new();
-    let mut risk_flags: Vec<String> = Vec::new();
+    let prelude = agent_contract_prelude(AgentContractPreludeInput {
+        coupling_available,
+        warnings,
+        ..Default::default()
+    });
+    let mut blocked_by = prelude.blocked_by;
+    let mut risk_flags = prelude.risk_flags;
+    let composable = prelude.composable;
     let mut next_actions: Vec<String> = Vec::new();
 
-    let composable = composable_contract_signals(coupling_available, warnings, true);
-    blocked_by.extend(composable.blocked_by.clone());
-    risk_flags.extend(composable.risk_flags.clone());
-    if !warnings.is_empty() {
-        risk_flags.push("warnings".into());
-    }
     if !relocated_files.is_empty() {
         risk_flags.push("complexity_relocated_within_file".into());
         next_actions.push(
@@ -1645,17 +1641,17 @@ fn changeset_contract(
         Some("topos_evaluate_project".to_string())
     };
 
-    AgentContract {
+    finish_agent_contract(
+        blocked_by,
+        risk_flags,
         next_tool,
         next_actions,
-        blocked_by,
-        verification_gates: vec![
+        vec![
             "no project_regression in the rollup".into(),
             "no complexity_relocated_within_file flags remain".into(),
             "behavior tests or type/lint checks pass when available".into(),
         ],
-        risk_flags,
-    }
+    )
 }
 
 fn changeset_error(

--- a/topos/mcp/src/tools/depgraph.rs
+++ b/topos/mcp/src/tools/depgraph.rs
@@ -14,9 +14,9 @@ use crate::evaluation::{
     cap_generation_detail, depgraph_status, resolve_mcp_composable_project_root,
     resolve_override_for_root, DepgraphStatus,
 };
-use crate::formatting::to_tool_result;
+use crate::formatting::{depgraph_unavailable_risk_flags, finish_agent_contract, to_tool_result};
 use crate::schemas::{
-    AgentContract, DepgraphState, DepgraphStatusInput, DepgraphStatusResult, GenerateDepgraphInput,
+    DepgraphState, DepgraphStatusInput, DepgraphStatusResult, GenerateDepgraphInput,
     GenerateDepgraphResult,
 };
 use crate::security::{resolve_file_root, resolve_within_root};
@@ -122,12 +122,10 @@ fn status_to_result(status: &DepgraphStatus) -> DepgraphStatusResult {
     let state = parse_state(status.state);
     let (action, next_tool, blocked_code) = state_guidance(state);
     let blocked_by: Vec<String> = blocked_code.into_iter().map(str::to_string).collect();
-    let risk_flags: Vec<String> = if state != DepgraphState::Present {
-        let mut flags = vec!["composable_unavailable".to_string()];
-        flags.extend(blocked_code.map(str::to_string));
-        flags
-    } else {
+    let risk_flags = if state == DepgraphState::Present {
         Vec::new()
+    } else {
+        depgraph_unavailable_risk_flags(&blocked_by)
     };
     DepgraphStatusResult {
         state,
@@ -137,13 +135,13 @@ fn status_to_result(status: &DepgraphStatus) -> DepgraphStatusResult {
         coupling_available: state == DepgraphState::Present,
         detail: status.detail.clone(),
         recommended_next_action: action.to_string(),
-        agent_contract: Some(AgentContract {
-            next_tool: next_tool.map(str::to_string),
-            next_actions: vec![action.to_string()],
+        agent_contract: Some(finish_agent_contract(
             blocked_by,
-            verification_gates: Vec::new(),
             risk_flags,
-        }),
+            next_tool.map(str::to_string),
+            vec![action.to_string()],
+            Vec::new(),
+        )),
         error: None,
     }
 }
@@ -157,16 +155,13 @@ fn status_error(message: String) -> DepgraphStatusResult {
         coupling_available: false,
         detail: None,
         recommended_next_action: "Fix the gitnexus_dir path, then retry.".to_string(),
-        agent_contract: Some(AgentContract {
-            next_tool: None,
-            next_actions: Vec::new(),
-            blocked_by: vec!["invalid_gitnexus_dir".to_string()],
-            verification_gates: Vec::new(),
-            risk_flags: vec![
-                "invalid_gitnexus_dir".to_string(),
-                "composable_unavailable".to_string(),
-            ],
-        }),
+        agent_contract: Some(finish_agent_contract(
+            vec!["invalid_gitnexus_dir".to_string()],
+            depgraph_unavailable_risk_flags(&["invalid_gitnexus_dir".to_string()]),
+            None,
+            Vec::new(),
+            Vec::new(),
+        )),
         error: Some(message),
     }
 }
@@ -179,13 +174,13 @@ fn generate_error(message: String) -> GenerateDepgraphResult {
         generated: false,
         state_before: None,
         message: message.clone(),
-        agent_contract: Some(AgentContract {
-            next_tool: None,
-            next_actions: Vec::new(),
-            blocked_by: vec!["path_error".to_string()],
-            verification_gates: Vec::new(),
-            risk_flags: Vec::new(),
-        }),
+        agent_contract: Some(finish_agent_contract(
+            vec!["path_error".to_string()],
+            Vec::new(),
+            None,
+            Vec::new(),
+            Vec::new(),
+        )),
         error: Some(message),
     }
 }
@@ -215,13 +210,13 @@ fn generation_failed(
         generated: false,
         state_before,
         message: detail.clone(),
-        agent_contract: Some(AgentContract {
-            next_tool: None,
-            next_actions: vec!["install/repair GitNexus, then retry".to_string()],
-            blocked_by: vec!["gitnexus_generate_failed".to_string()],
-            verification_gates: Vec::new(),
-            risk_flags: vec!["composable_unavailable".to_string()],
-        }),
+        agent_contract: Some(finish_agent_contract(
+            vec!["gitnexus_generate_failed".to_string()],
+            vec!["composable_unavailable".to_string()],
+            None,
+            vec!["install/repair GitNexus, then retry".to_string()],
+            Vec::new(),
+        )),
         error: Some(detail),
     }
 }
@@ -247,13 +242,13 @@ fn generation_succeeded(
         generated: true,
         state_before,
         message: cap_generation_detail(message),
-        agent_contract: Some(AgentContract {
-            next_tool: Some("topos_evaluate_file".to_string()),
-            next_actions: vec!["re-evaluate; COMPOSABLE is now scorable".to_string()],
-            blocked_by: Vec::new(),
-            verification_gates: Vec::new(),
-            risk_flags: Vec::new(),
-        }),
+        agent_contract: Some(finish_agent_contract(
+            Vec::new(),
+            Vec::new(),
+            Some("topos_evaluate_file".to_string()),
+            vec!["re-evaluate; COMPOSABLE is now scorable".to_string()],
+            Vec::new(),
+        )),
         error: None,
     }
 }
@@ -430,13 +425,13 @@ impl ToposServer {
                     generated: false,
                     state_before,
                     message: "Dependency graph already current.".to_string(),
-                    agent_contract: Some(AgentContract {
-                        next_tool: Some("topos_evaluate_file".to_string()),
-                        next_actions: vec!["re-evaluate; COMPOSABLE is scorable".to_string()],
-                        blocked_by: Vec::new(),
-                        verification_gates: Vec::new(),
-                        risk_flags: Vec::new(),
-                    }),
+                    agent_contract: Some(finish_agent_contract(
+                        Vec::new(),
+                        Vec::new(),
+                        Some("topos_evaluate_file".to_string()),
+                        vec!["re-evaluate; COMPOSABLE is scorable".to_string()],
+                        Vec::new(),
+                    )),
                     error: None,
                 };
                 let md = render_generate_md(&model);
@@ -452,15 +447,16 @@ impl ToposServer {
                     generated: false,
                     state_before,
                     message: message.clone(),
-                    agent_contract: Some(AgentContract {
-                        next_tool: None,
-                        next_actions: vec![action.to_string()],
-                        blocked_by: blocked_code.into_iter().map(str::to_string).collect(),
-                        verification_gates: Vec::new(),
-                        risk_flags: vec![
-                            "gitnexus_schema_mismatch".to_string(),
-                            "composable_unavailable".to_string(),
-                        ],
+                    agent_contract: Some({
+                        let blocked_by: Vec<String> =
+                            blocked_code.into_iter().map(str::to_string).collect();
+                        finish_agent_contract(
+                            blocked_by.clone(),
+                            depgraph_unavailable_risk_flags(&blocked_by),
+                            None,
+                            vec![action.to_string()],
+                            Vec::new(),
+                        )
                     }),
                     error: Some(message),
                 };

--- a/topos/mcp/src/tools/evaluate.rs
+++ b/topos/mcp/src/tools/evaluate.rs
@@ -17,8 +17,9 @@ use crate::evaluation::{
     gitnexus_warnings, resolve_mcp_composable_project_root, resolve_override_for_root,
 };
 use crate::formatting::{
-    build_pillars, composable_contract_signals, error_md, render_evaluation_md,
-    to_evaluation_result, to_tool_result, EvalResultOptions,
+    agent_contract_prelude, build_pillars, error_md, finish_agent_contract,
+    render_evaluation_md, to_evaluation_result, to_tool_result, AgentContractPreludeInput,
+    EvalResultOptions,
 };
 use crate::metric_locations::build_metric_locations;
 use crate::refactor_targets::build_refactor_targets;
@@ -860,53 +861,41 @@ fn project_contract(
     warnings: &[String],
     parse_failures: usize,
 ) -> AgentContract {
-    let mut blocked_by: Vec<String> = Vec::new();
-    let mut risk_flags: Vec<String> = Vec::new();
-    let mut next_actions: Vec<String> = Vec::new();
-
-    let composable = composable_contract_signals(coupling_available, warnings, true);
-    blocked_by.extend(composable.blocked_by.clone());
-    risk_flags.extend(composable.risk_flags.clone());
-    if parse_failures > 0 {
-        blocked_by.push("parse_failures".into());
-        risk_flags.push("parse_failures".into());
-    }
-    if !warnings.is_empty() {
-        risk_flags.push("warnings".into());
-    }
-    if worst_files.iter().any(|f| f.grade_capped) {
-        risk_flags.push("grade_capped".into());
-    }
-    // Verdict-anchored, not payload-anchored: secure_adjusted is false
-    // exactly when active findings survive the allowlist, and it is
-    // unaffected by the include_security_findings payload gate.
-    if worst_files.iter().any(|f| f.secure_adjusted == Some(false)) {
-        risk_flags.push("active_security_findings".into());
-    }
+    let prelude = agent_contract_prelude(AgentContractPreludeInput {
+        coupling_available,
+        warnings,
+        parse_failures,
+        grade_capped: worst_files.iter().any(|f| f.grade_capped),
+        active_security_findings: worst_files
+            .iter()
+            .any(|f| f.secure_adjusted == Some(false)),
+        ..Default::default()
+    });
 
     let verification_gates = vec![
         "topos_assess_worktree_change validates each accepted in-place refactor".to_string(),
         "project rollup does not regress after non-trivial changes".to_string(),
         "behavior tests or type/lint checks pass when available".to_string(),
     ];
-    if let Some(action) = composable.next_action {
-        return AgentContract {
-            next_tool: composable.next_tool,
-            next_actions: vec![action],
-            blocked_by,
+    if let Some(action) = prelude.composable.next_action {
+        return finish_agent_contract(
+            prelude.blocked_by,
+            prelude.risk_flags,
+            prelude.composable.next_tool,
+            vec![action],
             verification_gates,
-            risk_flags,
-        };
+        );
     }
     let Some(worst) = worst_files.first() else {
-        return AgentContract {
-            next_tool: None,
-            next_actions,
-            blocked_by,
-            verification_gates: Vec::new(),
-            risk_flags,
-        };
+        return finish_agent_contract(
+            prelude.blocked_by,
+            prelude.risk_flags,
+            None,
+            Vec::new(),
+            verification_gates,
+        );
     };
+    let mut next_actions = Vec::new();
     let next_tool = if overall == LatticeElement::IDEAL {
         next_actions.push("preserve behavior checks before accepting".into());
         None
@@ -918,13 +907,13 @@ fn project_contract(
         Some("topos_inspect_code".to_string())
     };
 
-    AgentContract {
+    finish_agent_contract(
+        prelude.blocked_by,
+        prelude.risk_flags,
         next_tool,
         next_actions,
-        blocked_by,
         verification_gates,
-        risk_flags,
-    }
+    )
 }
 
 /// The "## Agent Contract" section of the project markdown report.


### PR DESCRIPTION
## Summary
- Extract `agent_contract_prelude`, `finish_agent_contract`, and `agent_contract_parse_blocked` in `formatting.rs` as the shared builder for all MCP contract paths
- Set `include_missing = true` everywhere (D2a), including assessments
- Standardize on `parse_failures` (was `parse_failure` in file evaluate)
- Fix `project_contract` dropping `verification_gates` when `worst_files` is empty
- Migrate seven inline `AgentContract` literals in `tools/depgraph.rs` to `finish_agent_contract`

## Test plan
- [x] `cargo test -p topos-mcp` (95 passed)


Made with [Cursor](https://cursor.com)