### PR TITLE
fix: preserve finally completions and NAVIGABLE walk metadata

### DIFF
--- a/topos/engine/src/graphs/cfg/builder.rs
+++ b/topos/engine/src/graphs/cfg/builder.rs
@@ -35,11 +35,11 @@ struct LoopContext {
     continue_target: usize,
 }
 
-/// Pending control-flow destination after a `finally` block completes.
-enum FinallyExit {
-    Return,
-    Throw,
-    FallThrough { target: usize },
+/// Pending control-flow destinations after a `finally` block completes.
+struct FinallyExit {
+    fall_through_target: usize,
+    returns: bool,
+    throws: bool,
 }
 
 /// Mutable state threaded through the iterative builder.
@@ -142,7 +142,7 @@ fn handle_terminal_stmt(state: &mut CFGBuildState, stmt: &UASTNode, current_id: 
             state.push_statement(current_id, stmt);
             if let Some(finally_id) = state.finally_stack.last().map(|(id, _)| *id) {
                 if let Some(entry) = state.finally_stack.last_mut() {
-                    entry.1 = FinallyExit::Return;
+                    entry.1.returns = true;
                 }
                 state.add_edge(current_id, finally_id, EdgeKind::Unconditional);
             } else {
@@ -153,7 +153,7 @@ fn handle_terminal_stmt(state: &mut CFGBuildState, stmt: &UASTNode, current_id: 
             state.push_statement(current_id, stmt);
             if let Some(finally_id) = state.finally_stack.last().map(|(id, _)| *id) {
                 if let Some(entry) = state.finally_stack.last_mut() {
-                    entry.1 = FinallyExit::Throw;
+                    entry.1.throws = true;
                 }
                 state.add_edge(current_id, finally_id, EdgeKind::Unconditional);
             } else {
@@ -245,7 +245,7 @@ enum ContinuationTask<'a> {
     },
     TryFinallyDone {
         finally_output: usize,
-        join_block: usize,
+        exit: FinallyExit,
         output: usize,
         any_normal_path: bool,
     },
@@ -469,9 +469,14 @@ impl<'state, 'a> BuildMachine<'state, 'a> {
         let parts = try_parts(stmt);
         let finally_block = parts.finally_clause.map(|_| {
             let fb = self.state.new_block("try_finally");
-            self.state
-                .finally_stack
-                .push((fb, FinallyExit::FallThrough { target: join_block }));
+            self.state.finally_stack.push((
+                fb,
+                FinallyExit {
+                    fall_through_target: join_block,
+                    returns: false,
+                    throws: false,
+                },
+            ));
             fb
         });
         let body_output = self.new_output();
@@ -559,10 +564,10 @@ impl<'state, 'a> BuildMachine<'state, 'a> {
             } => self.finish_try_catch_arm(catch_output, cursor, post_handler_target),
             ContinuationTask::TryFinallyDone {
                 finally_output,
-                join_block,
+                exit,
                 output,
                 any_normal_path,
-            } => self.finish_try_finally(finally_output, join_block, output, any_normal_path),
+            } => self.finish_try_finally(finally_output, exit, output, any_normal_path),
         }
     }
 
@@ -662,12 +667,7 @@ impl<'state, 'a> BuildMachine<'state, 'a> {
                 EdgeKind::Exception,
             );
             if let Some(finally) = cursor.finally_clause {
-                self.start_finally_build(
-                    finally,
-                    cursor.join_block,
-                    cursor.output,
-                    body_had_normal,
-                );
+                self.start_finally_build(finally, cursor.output, body_had_normal);
             } else {
                 self.outputs[cursor.output] = if body_had_normal {
                     Some(cursor.join_block)
@@ -699,7 +699,6 @@ impl<'state, 'a> BuildMachine<'state, 'a> {
             if let Some(finally) = cursor.finally_clause {
                 self.start_finally_build(
                     finally,
-                    cursor.join_block,
                     cursor.output,
                     cursor.body_had_normal || cursor.any_handler_normal,
                 );
@@ -748,24 +747,17 @@ impl<'state, 'a> BuildMachine<'state, 'a> {
             )));
     }
 
-    fn start_finally_build(
-        &mut self,
-        finally: &'a UASTNode,
-        join_block: usize,
-        output: usize,
-        any_normal_path: bool,
-    ) {
-        let finally_block = self
+    fn start_finally_build(&mut self, finally: &'a UASTNode, output: usize, any_normal_path: bool) {
+        let (finally_block, exit) = self
             .state
             .finally_stack
-            .last()
-            .map(|(id, _)| *id)
+            .pop()
             .expect("finally_stack pushed before building finally body");
         let finally_output = self.new_output();
         self.tasks
             .push(BuildTask::Continuation(ContinuationTask::TryFinallyDone {
                 finally_output,
-                join_block,
+                exit,
                 output,
                 any_normal_path,
             }));
@@ -775,45 +767,48 @@ impl<'state, 'a> BuildMachine<'state, 'a> {
     fn finish_try_finally(
         &mut self,
         finally_output: usize,
-        join_block: usize,
+        exit: FinallyExit,
         output: usize,
         any_normal_path: bool,
     ) {
-        let Some((_, exit)) = self.state.finally_stack.pop() else {
-            self.outputs[output] = if any_normal_path {
-                Some(join_block)
-            } else {
-                None
-            };
-            return;
-        };
         let finally_tail = self.outputs[finally_output];
-        match exit {
-            FinallyExit::Return => {
-                if let Some(tail) = finally_tail {
+        if let Some(tail) = finally_tail {
+            let mut routed_to_outer = false;
+            if exit.returns {
+                if let Some((outer_finally, outer_exit)) = self.state.finally_stack.last_mut() {
+                    let outer_finally = *outer_finally;
+                    outer_exit.returns = true;
+                    self.state
+                        .add_edge(tail, outer_finally, EdgeKind::Unconditional);
+                    routed_to_outer = true;
+                } else {
                     self.state
                         .add_edge(tail, self.state.exit_id, EdgeKind::Return);
                 }
-                self.outputs[output] = None;
             }
-            FinallyExit::Throw => {
-                if let Some(tail) = finally_tail {
+            if exit.throws {
+                if let Some((outer_finally, outer_exit)) = self.state.finally_stack.last_mut() {
+                    let outer_finally = *outer_finally;
+                    outer_exit.throws = true;
+                    if !routed_to_outer {
+                        self.state
+                            .add_edge(tail, outer_finally, EdgeKind::Unconditional);
+                    }
+                } else {
                     self.state
                         .add_edge(tail, self.state.exit_id, EdgeKind::Exception);
                 }
-                self.outputs[output] = None;
             }
-            FinallyExit::FallThrough { target } => {
-                if let Some(tail) = finally_tail {
-                    self.state.add_edge(tail, target, EdgeKind::Unconditional);
-                }
-                self.outputs[output] = if any_normal_path {
-                    Some(join_block)
-                } else {
-                    None
-                };
+            if any_normal_path {
+                self.state
+                    .add_edge(tail, exit.fall_through_target, EdgeKind::Unconditional);
             }
         }
+        self.outputs[output] = if finally_tail.is_some() && any_normal_path {
+            Some(exit.fall_through_target)
+        } else {
+            None
+        };
     }
 }
 

--- a/topos/engine/src/graphs/cfg/edge_contracts.rs
+++ b/topos/engine/src/graphs/cfg/edge_contracts.rs
@@ -3,7 +3,7 @@
 
 use std::collections::BTreeSet;
 
-use super::object::ControlFlowGraph;
+use super::{models::EdgeKind, object::ControlFlowGraph};
 use crate::graphs::ast::dispatch::parse_source;
 use crate::graphs::ast::languages::SUPPORTED_LANGUAGES;
 
@@ -100,6 +100,33 @@ edge entry[] -unconditional-> call_FunctionDecl[TryStmt]
 edge try_body[ReturnStmt] -exception-> catch_handler[ReturnStmt]
 edge try_body[ReturnStmt] -unconditional-> try_finally[]
 edge try_finally[] -return-> exit[]"#;
+
+const CONDITIONAL_RETURN_FINALLY: &str = r#"blocks=8 edges=10
+edge call_FunctionDecl[TryStmt] -unconditional-> try_body[IfStmt]
+edge entry[] -unconditional-> call_FunctionDecl[TryStmt]
+edge if_join[ExprStmt] -unconditional-> try_finally[ExprStmt]
+edge if_then[ReturnStmt] -unconditional-> try_finally[ExprStmt]
+edge try_body[IfStmt] -exception-> try_join[ReturnStmt]
+edge try_body[IfStmt] -false-> if_join[ExprStmt]
+edge try_body[IfStmt] -true-> if_then[ReturnStmt]
+edge try_finally[ExprStmt] -return-> exit[]
+edge try_finally[ExprStmt] -unconditional-> try_join[ReturnStmt]
+edge try_join[ReturnStmt] -return-> exit[]"#;
+const RETURN_INSIDE_FINALLY: &str = r#"blocks=6 edges=5
+edge call_FunctionDecl[TryStmt] -unconditional-> try_body[ExprStmt]
+edge entry[] -unconditional-> call_FunctionDecl[TryStmt]
+edge try_body[ExprStmt] -exception-> try_join[]
+edge try_body[ExprStmt] -unconditional-> try_finally[ReturnStmt]
+edge try_finally[ReturnStmt] -return-> exit[]"#;
+const NESTED_FINALLY: &str = r#"blocks=9 edges=8
+edge call_FunctionDecl[TryStmt] -unconditional-> try_body[TryStmt]
+edge entry[] -unconditional-> call_FunctionDecl[TryStmt]
+edge try_body[ReturnStmt] -exception-> try_join[]
+edge try_body[ReturnStmt] -unconditional-> try_finally[ExprStmt]
+edge try_body[TryStmt] -exception-> try_join[]
+edge try_body[TryStmt] -unconditional-> try_body[ReturnStmt]
+edge try_finally[ExprStmt] -return-> exit[]
+edge try_finally[ExprStmt] -unconditional-> try_finally[ExprStmt]"#;
 
 const CASES: &[Case] = &[
     Case {
@@ -257,6 +284,24 @@ const CASES: &[Case] = &[
         expected: TRY_FINALLY,
     },
     Case {
+        language: "python",
+        name: "conditional_return_finally",
+        source: "def f(flag):\n    try:\n        if flag:\n            return 1\n        work()\n    finally:\n        cleanup()\n    return 0\n",
+        expected: CONDITIONAL_RETURN_FINALLY,
+    },
+    Case {
+        language: "python",
+        name: "return_inside_finally",
+        source: "def f():\n    try:\n        work()\n    finally:\n        return 1\n",
+        expected: RETURN_INSIDE_FINALLY,
+    },
+    Case {
+        language: "python",
+        name: "nested_finally",
+        source: "def f():\n    try:\n        try:\n            return 1\n        finally:\n            inner_cleanup()\n    finally:\n        outer_cleanup()\n",
+        expected: NESTED_FINALLY,
+    },
+    Case {
         language: "javascript",
         name: "try_finally",
         source: "function f() { try { return 1; } catch (e) { return 0; } finally {} }\n",
@@ -301,6 +346,64 @@ fn normalized_edge_contract(cfg: &ControlFlowGraph) -> String {
         cfg.edges.len(),
         edges.join("\n")
     )
+}
+
+fn cfg_for_python_case(name: &str) -> ControlFlowGraph {
+    let case = CASES
+        .iter()
+        .find(|case| case.language == "python" && case.name == name)
+        .expect("named Python CFG fixture exists");
+    let parsed = parse_source(case.source, case.language, None).expect("fixture parses");
+    assert!(!parsed.has_errors, "fixture must parse cleanly");
+    ControlFlowGraph::from_uast(&parsed.uast_root)
+}
+
+#[test]
+fn finally_paths_keep_distinct_completions_and_frames() {
+    let conditional = cfg_for_python_case("conditional_return_finally");
+    let conditional_finally = conditional
+        .blocks
+        .values()
+        .find(|block| block.label == "try_finally")
+        .expect("finally block exists")
+        .id;
+    assert!(conditional
+        .edges
+        .iter()
+        .any(|edge| { edge.source == conditional_finally && edge.kind == EdgeKind::Return }));
+    assert!(conditional.edges.iter().any(|edge| {
+        edge.source == conditional_finally && edge.kind == EdgeKind::Unconditional
+    }));
+
+    let returning = cfg_for_python_case("return_inside_finally");
+    assert!(returning
+        .edges
+        .iter()
+        .all(|edge| edge.source != edge.target));
+
+    let nested = cfg_for_python_case("nested_finally");
+    let finally_ids = nested
+        .blocks
+        .values()
+        .filter(|block| block.label == "try_finally")
+        .map(|block| block.id)
+        .collect::<BTreeSet<_>>();
+    assert_eq!(finally_ids.len(), 2);
+    let inner_to_outer = nested
+        .edges
+        .iter()
+        .find(|edge| {
+            finally_ids.contains(&edge.source)
+                && finally_ids.contains(&edge.target)
+                && edge.source != edge.target
+                && edge.kind == EdgeKind::Unconditional
+        })
+        .expect("inner finally flows through distinct outer finally");
+    assert!(nested.edges.iter().any(|edge| {
+        edge.source == inner_to_outer.target
+            && edge.target == nested.exit_id
+            && edge.kind == EdgeKind::Return
+    }));
 }
 
 #[test]

--- a/topos/mcp/src/tools/preferences.rs
+++ b/topos/mcp/src/tools/preferences.rs
@@ -32,6 +32,9 @@ fn generators_satisfied(value: EvaluationValue) -> Vec<GeneratorInput> {
     if bits & 0b100 != 0 {
         out.push(GeneratorInput::Secure);
     }
+    if bits & 0b1000 != 0 {
+        out.push(GeneratorInput::Navigable);
+    }
     out
 }
 
@@ -116,7 +119,7 @@ impl ToposServer {
     /// the goal gracefully under a token/time budget. Returns a
     /// PreferenceWalkResult: `walk` (steps from target down to just above
     /// `current`), `next_step`, `progress` in [0, 1],
-    /// `aspirational_target`/`fallback_target`, and `induced_order` (all 8
+    /// `aspirational_target`/`fallback_target`, and `induced_order` (all 16
     /// verdicts ranked).
     #[tool(
         name = "topos_preference_walk",
@@ -192,5 +195,35 @@ impl ToposServer {
         };
         let md = render_preference_walk_md(&model);
         to_tool_result(&model, md)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generators_satisfied_covers_all_four_generators() {
+        for value in EvaluationValue::ALL {
+            let generators = generators_satisfied(value);
+            let bits = value.bits();
+
+            assert_eq!(
+                generators.contains(&GeneratorInput::Simple),
+                bits & 0b0001 != 0
+            );
+            assert_eq!(
+                generators.contains(&GeneratorInput::Composable),
+                bits & 0b0010 != 0
+            );
+            assert_eq!(
+                generators.contains(&GeneratorInput::Secure),
+                bits & 0b0100 != 0
+            );
+            assert_eq!(
+                generators.contains(&GeneratorInput::Navigable),
+                bits & 0b1000 != 0
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- preserve normal, return, and throw completions through one finally block
- suspend the current finally frame while building its body and route nested abrupt exits through outer finally blocks
- include NAVIGABLE in MCP preference-walk generator metadata with exhaustive coverage

## Test plan
- [x] `cargo test -p topos-engine graphs::cfg::edge_contracts`
- [x] `cargo test -p topos-mcp generators_satisfied_covers_all_four_generators`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`

Part of #279 review remediation.

Made with [Cursor](https://cursor.com)