### PR TITLE
fix(vscode): patch vulnerable transitive dependencies

### DIFF
--- a/extensions/vscode/pnpm-lock.yaml
+++ b/extensions/vscode/pnpm-lock.yaml
@@ -7,7 +7,8 @@ settings:
 overrides:
   serialize-javascript: ^7.0.5
   diff: ^9.0.0
-  fast-uri: ^3.1.4
+  fast-uri: ^3.1.5
+  undici: ^7.29.0
 
 importers:
 
@@ -963,8 +964,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -1901,8 +1902,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.1.0:
@@ -2586,7 +2587,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -2734,7 +2735,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.28.0
+      undici: 7.29.0
       whatwg-mimetype: 4.0.0
 
   chokidar@3.6.0:
@@ -3042,7 +3043,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fastq@1.20.1:
     dependencies:
@@ -4035,7 +4036,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unicorn-magic@0.1.0: {}
 

--- a/extensions/vscode/pnpm-workspace.yaml
+++ b/extensions/vscode/pnpm-workspace.yaml
@@ -8,7 +8,9 @@ overrides:
   diff: "^9.0.0"
   # GHSA-v2hh-gcrm-f6hx / CVE-2026-16221: host confusion via backslash authority.
   # Transitive via @vscode/vsce → secretlint → ajv@8 (fast-uri ^3.0.1).
-  fast-uri: "^3.1.4"
+  fast-uri: "^3.1.5"
+  # Transitive via @vscode/vsce → cheerio.
+  undici: "^7.29.0"
 
 # Allow postinstall scripts required by the extension toolchain.
 allowBuilds:


### PR DESCRIPTION
## Summary
- require `fast-uri` 3.1.5 to resolve Dependabot alert #20
- require `undici` 7.29.0 to resolve Dependabot alerts #11–15
- regenerate the pnpm lockfile with the first patched releases

## Test plan
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm test` (24 tests passed)
- [x] confirmed the lockfile contains `fast-uri@3.1.5` and `undici@7.29.0`

## Dependabot alerts
- https://github.com/Krv-Labs/topos/security/dependabot/20
- https://github.com/Krv-Labs/topos/security/dependabot/15
- https://github.com/Krv-Labs/topos/security/dependabot/14
- https://github.com/Krv-Labs/topos/security/dependabot/13
- https://github.com/Krv-Labs/topos/security/dependabot/12
- https://github.com/Krv-Labs/topos/security/dependabot/11

Made with [Cursor](https://cursor.com)