### PR TITLE
feat: Agent Plugins 1.0 portable package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Check agent skills
         run: python3 scripts/check_skill.py
 
+      - name: Check Agent Plugins package
+        run: python3 scripts/check_agent_plugin.py
+
       - name: Format check
         run: cargo fmt --all --check
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,13 +16,16 @@ The scheduled OpenWiki GitHub Actions workflow refreshes the repository wiki. Do
 
 Canonical skill at [`skills/topos/SKILL.md`](skills/topos/SKILL.md) — published to ClawHub and installable via Hermes taps.
 
+Portable [Agent Plugins](https://agent-plugins.org/) 1.0 package: [`agent-plugin/`](agent-plugin/) (`plugin.json` + skill + `mcp.json`).
+
 | Runtime | Install |
 | --- | --- |
 | OpenClaw / ClawHub | `openclaw skills install @Krv-Labs/topos` |
 | Hermes | `hermes skills tap add Krv-Labs/topos` then `hermes skills install Krv-Labs/topos/topos` |
+| Agent Plugins client | Point the client at `./agent-plugin` (requires `topos` on `PATH`) |
 | Local (dev) | `openclaw skills install ./skills/topos` |
 
-Validate with `python scripts/check_skill.py` (requires each skill's `version:` to match `Cargo.toml`).
+Validate with `python scripts/check_skill.py` and `python scripts/check_agent_plugin.py` (skill / plugin versions must match `Cargo.toml`; packaged skill must match `skills/topos/SKILL.md`).
 
 **ClawHub publish setup:** add repo secret `CLAWHUB_TOKEN` — create a token at [clawhub.ai](https://clawhub.ai) (`clh_...`), then GitHub → Settings → Secrets and variables → Actions. The [ClawHub Skill Publish](.github/workflows/clawhub-publish.yml) workflow dry-runs on PRs and publishes on `main` (`skills/**`) and `v*` tags. Manual fallback: `clawhub skill publish ./skills/topos --owner Krv-Labs`.
 <!-- SKILLS:END -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,12 @@ that section. See the Git History & Release Convention in [`.agents/AGENTS.md`](
 
 Docs figures under `docs/source/_static/figures/topos-lattice*.svg` have been redrawn for the full sixteen-element 4-cube (PLATINUM down to SLOP). The benchmark figures (`topos-medal-mix*`, `topos-typical-profiles*`, `topos-library-profiles*`, `topos-bronze-ready*`) still plot the three-pillar corpus run and will be regenerated when the benchmark is re-run under NAVIGABLE.
 
+## [Unreleased]
+
+### Added
+
+- **Agent Plugins package** ([#310](https://github.com/Krv-Labs/topos/issues/310)) — portable `agent-plugin/` tree (`plugin.json`, `mcp.json`, synced skill) for [Agent Plugins](https://agent-plugins.org/) 1.0 clients, with `scripts/check_agent_plugin.py`.
+
 ## [0.4.4] - 2026-08-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ that section. See the Git History & Release Convention in [`.agents/AGENTS.md`](
 
 ## [Unreleased]
 
+### Added
+
+- **Agent Plugins package** ([#310](https://github.com/Krv-Labs/topos/issues/310)) — portable `agent-plugin/` tree (`plugin.json`, `mcp.json`, synced skill) for [Agent Plugins](https://agent-plugins.org/) 1.0 clients, with `scripts/check_agent_plugin.py`.
+
 ### Breaking
 
 - **Graphify integration removed** (~1,680 production lines). Every signal it provided was already available from the GitNexus/MDG graph Topos loads for COMPOSABLE, usually at better fidelity — full `startLine`/`endLine` spans instead of point anchors, a first-class `Community` node label with `MEMBER_OF` edges instead of a bare Louvain field, and a continuous `confidence: f64` + `reason` instead of a three-value enum. It had no production consumer, no CI coverage, and no agent-facing recommendation, and it wrapped a pre-1.0 external tool with a documented history of schema breaks. See [`docs/decisions/refactor-suite.md`](docs/decisions/refactor-suite.md) § Removed target and issue [#325](https://github.com/Krv-Labs/topos/issues/325).
@@ -91,12 +95,6 @@ that section. See the Git History & Release Convention in [`.agents/AGENTS.md`](
 > **NAVIGABLE thresholds calibrated** on a balanced 6,390-file leaderboard corpus (2026-08-07): `max_function_divergence = 10.0` (p95 `10.37`; ~5.2% gate failure rate) and `divergence_cap = 12.0` (spans p99 across Rust `10.40`, Go `13.64`, and Python `12.31` so scores decay linearly without early flooring). Topos's 176 Rust sources remain a reference ECDF (`p95` `5.65`, p99 `8.62`, max `12.19`).
 
 Docs figures under `docs/source/_static/figures/topos-lattice*.svg` have been redrawn for the full sixteen-element 4-cube (PLATINUM down to SLOP). The benchmark figures (`topos-medal-mix*`, `topos-typical-profiles*`, `topos-library-profiles*`, `topos-bronze-ready*`) still plot the three-pillar corpus run and will be regenerated when the benchmark is re-run under NAVIGABLE.
-
-## [Unreleased]
-
-### Added
-
-- **Agent Plugins package** ([#310](https://github.com/Krv-Labs/topos/issues/310)) — portable `agent-plugin/` tree (`plugin.json`, `mcp.json`, synced skill) for [Agent Plugins](https://agent-plugins.org/) 1.0 clients, with `scripts/check_agent_plugin.py`.
 
 ## [0.4.4] - 2026-08-04
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,13 +16,16 @@ The scheduled OpenWiki GitHub Actions workflow refreshes the repository wiki. Do
 
 Canonical skill at [`skills/topos/SKILL.md`](skills/topos/SKILL.md) — published to ClawHub and installable via Hermes taps.
 
+Portable [Agent Plugins](https://agent-plugins.org/) 1.0 package: [`agent-plugin/`](agent-plugin/) (`plugin.json` + skill + `mcp.json`).
+
 | Runtime | Install |
 | --- | --- |
 | OpenClaw / ClawHub | `openclaw skills install @Krv-Labs/topos` |
 | Hermes | `hermes skills tap add Krv-Labs/topos` then `hermes skills install Krv-Labs/topos/topos` |
+| Agent Plugins client | Point the client at `./agent-plugin` (requires `topos` on `PATH`) |
 | Local (dev) | `openclaw skills install ./skills/topos` |
 
-Validate with `python scripts/check_skill.py` (requires each skill's `version:` to match `Cargo.toml`).
+Validate with `python scripts/check_skill.py` and `python scripts/check_agent_plugin.py` (skill / plugin versions must match `Cargo.toml`; packaged skill must match `skills/topos/SKILL.md`).
 
 **ClawHub publish setup:** add repo secret `CLAWHUB_TOKEN` — create a token at [clawhub.ai](https://clawhub.ai) (`clh_...`), then GitHub → Settings → Secrets and variables → Actions. The [ClawHub Skill Publish](.github/workflows/clawhub-publish.yml) workflow dry-runs on PRs and publishes on `main` (`skills/**`) and `v*` tags. Manual fallback: `clawhub skill publish ./skills/topos --owner Krv-Labs`.
 <!-- SKILLS:END -->

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ The result is one agent-facing contract over several structural lenses: one scor
 
 - **OpenClaw / ClawHub:** [`openclaw skills install @Krv-Labs/topos`](https://clawhub.ai/krv-labs/skills/topos)
 - **Hermes:** `hermes skills tap add Krv-Labs/topos` then `hermes skills install Krv-Labs/topos/topos`
+- **Agent Plugins:** point a [compatible client](https://agent-plugins.org/compatible-clients) at [`agent-plugin/`](agent-plugin/) ([spec](https://agent-plugins.org/))
 - **MCP Registry name:** `io.github.Krv-Labs/topos`
 - **CLI reference:** [docs.krv.ai/topos/cli](https://docs.krv.ai/topos/cli.html)
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Or install with Homebrew:
 brew install krv-labs/tap/topos
 ```
 
+On Homebrew 6+, that fully qualified one-liner auto-taps and trusts only this formula. If you `brew tap krv-labs/tap` first, run `brew trust --formula krv-labs/tap/topos` before `brew install topos`.
+
 > [!TIP]
 > **Prefer an editor-managed install?** In VS Code or Cursor, search `@mcp topos` in the Extensions view or choose [Install MCP server](https://github.com/mcp/Krv-Labs/topos). This is an alternative to `topos install`: your editor installs and manages the Topos MCP server for you.
 

--- a/agent-plugin/README.md
+++ b/agent-plugin/README.md
@@ -1,0 +1,46 @@
+# Topos Agent Plugin
+
+Portable [Agent Plugins](https://agent-plugins.org/) 1.0 package for Topos.
+
+Compatible clients discover this directory, load `plugin.json`, then optionally enable:
+
+- **Skill** — `skills/topos/SKILL.md` (Agent Skills format)
+- **MCP** — `mcp.json` stdio server (`topos mcp`)
+
+## Prerequisites
+
+1. Install the Topos CLI so `topos` is on `PATH`:
+
+   ```bash
+   curl -fsSL https://docs.krv.ai/topos/install.sh | bash
+   ```
+
+2. Point an Agent Plugins–compatible client at this package directory
+   (`agent-plugin/` in a clone, or a released copy of the same tree).
+
+Installation, enablement, and permissions remain client-managed
+([spec](https://agent-plugins.org/plugin-authors#package-boundaries)).
+
+## Layout
+
+```text
+agent-plugin/
+├── plugin.json
+├── mcp.json
+└── skills/
+    └── topos/
+        └── SKILL.md
+```
+
+`skills/topos/SKILL.md` must stay byte-identical to the ClawHub skill at
+`../skills/topos/SKILL.md`. Validate with:
+
+```bash
+python scripts/check_agent_plugin.py
+```
+
+## References
+
+- [Agent Plugins](https://agent-plugins.org/)
+- [Topos docs](https://docs.krv.ai/topos/)
+- [Agent contract](https://docs.krv.ai/topos/agents.html)

--- a/agent-plugin/README.md
+++ b/agent-plugin/README.md
@@ -33,11 +33,9 @@ agent-plugin/
 ```
 
 `skills/topos/SKILL.md` must stay byte-identical to the ClawHub skill at
-`../skills/topos/SKILL.md`. Validate with:
+`../skills/topos/SKILL.md` (in this repository). Validate from the repo root with:
 
-```bash
-python scripts/check_agent_plugin.py
-```
+    python scripts/check_agent_plugin.py
 
 ## References
 

--- a/agent-plugin/mcp.json
+++ b/agent-plugin/mcp.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "topos": {
+      "type": "stdio",
+      "command": "topos",
+      "args": ["mcp"]
+    }
+  }
+}

--- a/agent-plugin/plugin.json
+++ b/agent-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "topos",
-  "version": "0.4.4",
+  "version": "0.5.1",
   "description": "Structural code quality metrics, lattice verification, and refactor loops for agent-written code.",
   "author": {
     "name": "Krv Labs",

--- a/agent-plugin/plugin.json
+++ b/agent-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "topos",
+  "version": "0.4.4",
+  "description": "Structural code quality metrics, lattice verification, and refactor loops for agent-written code.",
+  "author": {
+    "name": "Krv Labs",
+    "url": "https://krv.ai"
+  },
+  "homepage": "https://docs.krv.ai/topos/",
+  "repository": "https://github.com/Krv-Labs/topos",
+  "license": "BSD-3-Clause",
+  "keywords": [
+    "code-quality",
+    "refactoring",
+    "mcp",
+    "metrics",
+    "security",
+    "agents"
+  ]
+}

--- a/agent-plugin/skills/topos/SKILL.md
+++ b/agent-plugin/skills/topos/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: topos
+description: Structural code quality metrics, lattice verification, and refactor loops for agent-written code.
+version: "0.4.4"
+homepage: https://docs.krv.ai/topos/
+metadata:
+  openclaw:
+    requires:
+      bins: [topos]
+    homepage: https://docs.krv.ai/topos/
+    os: [macos, linux]
+    emoji: "📐"
+  hermes:
+    tags: [code-quality, refactoring, security, metrics]
+    category: software-development
+    requires_toolsets: [terminal]
+---
+
+# Topos
+
+Topos scores code on three pillars — **SIMPLE**, **COMPOSABLE**, **SECURE** — and maps results to a medal lattice (SLOP → GOLD). Use it in a closed loop: measure, edit, re-measure.
+
+## Use Case
+
+Developers and AI coding agents use this skill to improve structural code quality, reduce complexity, verify refactors, and optimize toward GOLD or SILVER medals. It supports both CLI and MCP agent loops on local repositories.
+
+**Deployment geography:** Global (local execution; no region-restricted services).
+
+## When to Use
+
+Load this skill when the user asks to improve code quality, reduce complexity, check structural security footguns, verify a refactor, or optimize toward GOLD/SILVER medals.
+
+## Requirements / Dependencies
+
+**Requires API Key or External Credential:** No
+
+**Credential Type(s):** None
+
+**Runtime dependencies:**
+
+```bash
+curl -fsSL https://docs.krv.ai/topos/install.sh | bash
+npm install -g gitnexus   # enables COMPOSABLE / GOLD scoring
+```
+
+- `topos` CLI on `PATH` (install via [docs.krv.ai/topos/install.sh](https://docs.krv.ai/topos/install.sh))
+- Git repository for baseline comparisons (`topos assess_worktree_change`, untracked baselines via snapshot flow)
+- `.gitnexus` dependency graph for COMPOSABLE / GOLD scoring (generated automatically when `gitnexus` is installed; force refresh with `topos depgraph generate` or `topos_generate_depgraph`)
+
+COMPOSABLE is scored by default: `evaluate` / `inspect` and the MCP evaluate
+tools detect a missing or stale `.gitnexus` and regenerate it before scoring.
+Run `topos depgraph generate` only to force a refresh.
+
+**Optional MCP setup** (for tool-based agents, not required for CLI-only use):
+
+```bash
+topos install --all   # registers the MCP server in every supported harness
+topos status          # verify registration
+```
+
+Do not include secrets in prompts, logs, or output. Topos reads local source files and git state only; it does not transmit code to external services.
+
+## Known Risks and Mitigations
+
+Risk: The skill may guide agents to apply structural refactors that change behavior; Topos measures structure, not functional correctness.
+
+Mitigation: Run project tests or linters after each edit; treat Topos verdicts as structural signals, not proof of correctness.
+
+Risk: Agents may trust SECURE medal findings as full security assurance; Topos SECURE checks are structural heuristics, not full SAST.
+
+Mitigation: Pair with dedicated security tooling for high-stakes code; acknowledge remaining SECURE findings explicitly.
+
+Risk: Without GitNexus installed, COMPOSABLE scores are unavailable and GOLD is unreachable.
+
+Mitigation: Install `gitnexus` (`npm install -g gitnexus`); check MCP `warnings` and `coupling_available` before trusting composability scores.
+
+Risk: Cosmetic edits (whitespace, rename-only) may appear as improvements but do not move the lattice.
+
+Mitigation: Stop when MCP returns `SUSPICIOUS_NO_STRUCTURAL_CHANGE`; require `IMPROVEMENT` or `IMPROVEMENT_SCORE` before accepting a change.
+
+## Skill Output
+
+**Output type(s):** Analysis, markdown reports, JSON (MCP), shell commands
+
+**Output format:** CLI tables and ranked file lists; MCP structured payloads with `agent_contract` fields; per-function inspect detail
+
+**Output parameters:** Medal verdict (SLOP → GOLD), pillar scores (SIMPLE, COMPOSABLE, SECURE), ranked refactor targets, assessment status (`IMPROVEMENT`, `REGRESSION`, etc.)
+
+**Other properties:** Writes `.gitnexus` graph artifacts when depgraph is generated; does not modify source files unless the agent chooses to edit based on guidance
+
+## References
+
+- [Topos documentation](https://docs.krv.ai/topos/)
+- [Agent contract](https://docs.krv.ai/topos/agents.html)
+- [Source repository](https://github.com/Krv-Labs/topos)
+- [ClawHub listing](https://clawhub.ai/Krv-Labs/topos)
+
+## Agent Loop
+
+1. **Measure** — `topos evaluate <path> -r` (CLI) or `topos_evaluate_file` / `topos_evaluate_project` (MCP). COMPOSABLE is included by default. Pass `--gitnexus-dir` / `gitnexus_dir` to select a store; its parent becomes the COMPOSABLE project root (so you can evaluate from `$HOME` against `~/repo/.gitnexus`).
+2. **Inspect** — `topos inspect <file>` or `topos_inspect_code` for per-function complexity and metric detail.
+3. **Edit** — one focused structural change (extract helper, simplify branch, decouple import).
+4. **Verify** — re-run evaluate, or use `topos_assess_worktree_change` (baseline `HEAD`) for MCP loops. For untracked baselines: `topos_begin_refactor` → edit → `topos_assess_snapshot`.
+5. **Behavior check** — run project tests or linters; Topos does not prove correctness.
+
+Stop when the target medal is reached, the priority pillar passes, or further iterations plateau. Prefer structured `agent_contract` fields over parsing prose.
+
+## CLI Reference
+
+| Command | Purpose |
+| --- | --- |
+| `topos evaluate <path> -r` | Show the cumulative project quality rollup |
+| `topos evaluate <path> -r --failures <pillar>` | List the files whose gates fail one pillar |
+| `topos evaluate <path> -r --info` | Select a weak file and show ranked line-level refactor targets |
+| `topos config` | View or edit project priority and preference settings |
+| `topos inspect <file>` | Deep per-file metrics and suggestions |
+| `topos compare <a> <b>` | AST edit distance between two versions |
+| `topos coverage <source>... --tests <test>... [-r]` | Structural test coverage (UAST + k-gram recall) |
+| `topos depgraph generate` | Build GitNexus graph for COMPOSABLE scoring |
+| `topos graphify generate\|orphans` | Advisory orphan / fragile-edge hints (does not affect evaluate) |
+| `topos mcp` | Start the MCP server for tool-based agent loops |
+
+Without `--gitnexus-dir`, COMPOSABLE uses process **cwd** (CLI) or the MCP **file root** (`TOPOS_MCP_FILE_ROOT`, else server cwd), with store at `<root>/.gitnexus`. With `--gitnexus-dir` / `gitnexus_dir`, the store's parent is the COMPOSABLE project root for freshness and `gitnexus analyze` (CLI allows absolute paths outside cwd; MCP still requires the store under the file root). Pass `--no-composable` to score SIMPLE/SECURE only. The CLI accepts a one-run `--priority` override (a single pillar or a full comma-separated ranking) and `topos config` persists project defaults; MCP additionally returns the induced preference walk. Advisory `cycles`/`dependencies`/`process` hints are MCP-only, via `topos_refactor`.
+
+## MCP Tool Reference
+
+| Tool | Purpose |
+| --- | --- |
+| `topos_get_doc(topic="agent-contract")` | Compact loop contract — read first |
+| `topos_evaluate_file` | Score one file; returns 3 ranked edit spans (`refactor_targets`, gate failures first) |
+| `topos_evaluate_project` | Project rollup and worst-file list |
+| `topos_inspect_code` | Deep per-function complexity and metrics |
+| `topos_assess_worktree_change` | Compare working tree to a git baseline |
+| `topos_begin_refactor` / `topos_assess_snapshot` | Snapshot flow for untracked baselines |
+| `topos_assess_improvement` | Side-by-side variant comparison |
+| `topos_assess_changeset` | Assess several edited files at once against a git baseline |
+| `topos_generate_depgraph` / `topos_depgraph_status` | Force-refresh, or read-only diagnose, the GitNexus graph |
+| `topos_calculate_coverage` | Structural test coverage (separate from lattice) |
+| `topos_evaluate_code` | Score a source string when there is no file on disk |
+| `topos_inspect_code` / `topos_compare_code` / `topos_compare_files` | Deep metrics; AST edit distance between two versions |
+| `topos_preference_walk` | Resolve target / fallback / next-step verdicts for a ranking |
+| `topos_refactor` | Advisory hotspots (`cycles`, `dependencies`, `process`, `graphify`) — never affects the medal |
+| `topos_generate_graphify_graph` | Build the Graphify knowledge graph for `topos_refactor(target="graphify")` |
+
+MCP tool arguments are **flat objects** — `{"filepath": "..."}`, not `{"params": {...}}`.
+
+## Pitfalls
+
+- **No GitNexus → no COMPOSABLE.** The graph is generated automatically, but only if `gitnexus` is installed. If it isn't, `coupling_available` is `false` and GOLD is unreachable — check `warnings`.
+- **Missing `--gitnexus-dir` from a parent directory → slow COMPOSABLE setup.** Without the override, freshness fingerprints CLI cwd / MCP file root. Prefer `--gitnexus-dir <repo>/.gitnexus` (or `cd` into the repo / set `TOPOS_MCP_FILE_ROOT`) so only that repo is walked.
+- **Cosmetic edits don't count.** Whitespace and rename-only changes won't move the lattice; MCP returns `SUSPICIOUS_NO_STRUCTURAL_CHANGE`.
+- **SECURE is structural, not full SAST.** Pair with dedicated security tooling for high-stakes code.
+- **`topos refactor` is advisory.** It does not replace `topos evaluate` for scoring.
+
+## Verification
+
+A change is ready when:
+
+- Assessment status is `IMPROVEMENT` or `IMPROVEMENT_SCORE` (MCP), or the evaluate verdict improved (CLI).
+- Status is not `SUSPICIOUS_NO_STRUCTURAL_CHANGE` or `REGRESSION`.
+- Active SECURE findings are fixed or explicitly acknowledged.
+- Relevant tests/type checks pass, or their absence is reported.
+
+## Ethical Considerations
+
+Users should review agent-proposed code changes before committing, especially when refactoring production systems. Topos is an advisory structural quality tool; organizations should apply their own security, compliance, and code-review policies before deployment.

--- a/agent-plugin/skills/topos/SKILL.md
+++ b/agent-plugin/skills/topos/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: topos
-description: Structural code quality metrics, lattice verification, and refactor loops for agent-written code.
-version: "0.4.4"
+description: Evaluate and improve code with Topos. Use for complexity reduction, security checks, refactor verification, and PLATINUM/GOLD goals.
+version: "0.5.1"
 homepage: https://docs.krv.ai/topos/
 metadata:
   openclaw:
@@ -18,17 +18,17 @@ metadata:
 
 # Topos
 
-Topos scores code on three pillars — **SIMPLE**, **COMPOSABLE**, **SECURE** — and maps results to a medal lattice (SLOP → GOLD). Use it in a closed loop: measure, edit, re-measure.
+Topos scores code on four pillars — **SIMPLE**, **COMPOSABLE**, **SECURE**, **NAVIGABLE** — and maps results to a medal lattice (SLOP → PLATINUM). Use it in a closed loop: measure, edit, re-measure.
 
 ## Use Case
 
-Developers and AI coding agents use this skill to improve structural code quality, reduce complexity, verify refactors, and optimize toward GOLD or SILVER medals. It supports both CLI and MCP agent loops on local repositories.
+Developers and AI coding agents use this skill to improve structural code quality, reduce complexity, verify refactors, and optimize toward PLATINUM or GOLD medals. It supports both CLI and MCP agent loops on local repositories.
 
 **Deployment geography:** Global (local execution; no region-restricted services).
 
 ## When to Use
 
-Load this skill when the user asks to improve code quality, reduce complexity, check structural security footguns, verify a refactor, or optimize toward GOLD/SILVER medals.
+Load this skill when the user asks to improve code quality, reduce complexity, check structural security footguns, verify a refactor, or optimize toward PLATINUM/GOLD medals.
 
 ## Requirements / Dependencies
 
@@ -40,12 +40,12 @@ Load this skill when the user asks to improve code quality, reduce complexity, c
 
 ```bash
 curl -fsSL https://docs.krv.ai/topos/install.sh | bash
-npm install -g gitnexus   # enables COMPOSABLE / GOLD scoring
+npm install -g gitnexus   # enables COMPOSABLE / PLATINUM scoring
 ```
 
 - `topos` CLI on `PATH` (install via [docs.krv.ai/topos/install.sh](https://docs.krv.ai/topos/install.sh))
-- Git repository for baseline comparisons (`topos assess_worktree_change`, untracked baselines via snapshot flow)
-- `.gitnexus` dependency graph for COMPOSABLE / GOLD scoring (generated automatically when `gitnexus` is installed; force refresh with `topos depgraph generate` or `topos_generate_depgraph`)
+- Git repository for MCP baseline comparisons (`topos_assess_worktree_change`; untracked baselines via `topos_begin_refactor` → `topos_assess_snapshot`)
+- `.gitnexus` dependency graph for COMPOSABLE / PLATINUM scoring (generated automatically when `gitnexus` is installed; force refresh with `topos depgraph generate` or `topos_generate_depgraph`)
 
 COMPOSABLE is scored by default: `evaluate` / `inspect` and the MCP evaluate
 tools detect a missing or stale `.gitnexus` and regenerate it before scoring.
@@ -70,7 +70,7 @@ Risk: Agents may trust SECURE medal findings as full security assurance; Topos S
 
 Mitigation: Pair with dedicated security tooling for high-stakes code; acknowledge remaining SECURE findings explicitly.
 
-Risk: Without GitNexus installed, COMPOSABLE scores are unavailable and GOLD is unreachable.
+Risk: Without GitNexus installed, COMPOSABLE scores are unavailable and PLATINUM is unreachable.
 
 Mitigation: Install `gitnexus` (`npm install -g gitnexus`); check MCP `warnings` and `coupling_available` before trusting composability scores.
 
@@ -84,7 +84,7 @@ Mitigation: Stop when MCP returns `SUSPICIOUS_NO_STRUCTURAL_CHANGE`; require `IM
 
 **Output format:** CLI tables and ranked file lists; MCP structured payloads with `agent_contract` fields; per-function inspect detail
 
-**Output parameters:** Medal verdict (SLOP → GOLD), pillar scores (SIMPLE, COMPOSABLE, SECURE), ranked refactor targets, assessment status (`IMPROVEMENT`, `REGRESSION`, etc.)
+**Output parameters:** Medal verdict (SLOP → PLATINUM), pillar scores (SIMPLE, COMPOSABLE, SECURE, NAVIGABLE), ranked refactor targets, assessment status (`IMPROVEMENT`, `REGRESSION`, etc.)
 
 **Other properties:** Writes `.gitnexus` graph artifacts when depgraph is generated; does not modify source files unless the agent chooses to edit based on guidance
 
@@ -97,13 +97,20 @@ Mitigation: Stop when MCP returns `SUSPICIOUS_NO_STRUCTURAL_CHANGE`; require `IM
 
 ## Agent Loop
 
-1. **Measure** — `topos evaluate <path> -r` (CLI) or `topos_evaluate_file` / `topos_evaluate_project` (MCP). COMPOSABLE is included by default. Pass `--gitnexus-dir` / `gitnexus_dir` to select a store; its parent becomes the COMPOSABLE project root (so you can evaluate from `$HOME` against `~/repo/.gitnexus`).
+1. **Measure** — `topos evaluate <path> -r` (CLI) or `topos_evaluate_file` / `topos_evaluate_project` (MCP). COMPOSABLE is included by default; run the CLI from the repo root. MCP derives the project from the tool's absolute file/directory path (`TOPOS_MCP_FILE_ROOT` is only an optional maximum boundary). Pass `--gitnexus-dir` / `gitnexus_dir` to select a store; its parent becomes the COMPOSABLE project root.
 2. **Inspect** — `topos inspect <file>` or `topos_inspect_code` for per-function complexity and metric detail.
 3. **Edit** — one focused structural change (extract helper, simplify branch, decouple import).
 4. **Verify** — re-run evaluate, or use `topos_assess_worktree_change` (baseline `HEAD`) for MCP loops. For untracked baselines: `topos_begin_refactor` → edit → `topos_assess_snapshot`.
 5. **Behavior check** — run project tests or linters; Topos does not prove correctness.
 
 Stop when the target medal is reached, the priority pillar passes, or further iterations plateau. Prefer structured `agent_contract` fields over parsing prose.
+
+## Lattice (v0.5.0)
+
+- **16 verdicts** on four generators: SIMPLE, COMPOSABLE, SECURE, NAVIGABLE.
+- **Medals:** 4 pillars pass → PLATINUM; 3 → GOLD; 2 → SILVER; 1 → BRONZE; 0 → SLOP.
+- **`IDEAL` requires all four pillars.** The former three-pillar top verdict is now `SIMPLE_COMPOSABLE_SECURE` (GOLD band). CI or agents pinned to `IDEAL` will fail on NAVIGABLE gate misses.
+- **Default ranking:** `SIMPLE ≻ NAVIGABLE ≻ SECURE ≻ COMPOSABLE`. `.topos.toml` and MCP `preferences.ranking` must list all four pillars.
 
 ## CLI Reference
 
@@ -112,15 +119,17 @@ Stop when the target medal is reached, the priority pillar passes, or further it
 | `topos evaluate <path> -r` | Show the cumulative project quality rollup |
 | `topos evaluate <path> -r --failures <pillar>` | List the files whose gates fail one pillar |
 | `topos evaluate <path> -r --info` | Select a weak file and show ranked line-level refactor targets |
-| `topos config` | View or edit project priority and preference settings |
+| `topos config show \| set --priority <ranking>` | View or persist project priority and preference settings |
 | `topos inspect <file>` | Deep per-file metrics and suggestions |
 | `topos compare <a> <b>` | AST edit distance between two versions |
 | `topos coverage <source>... --tests <test>... [-r]` | Structural test coverage (UAST + k-gram recall) |
 | `topos depgraph generate` | Build GitNexus graph for COMPOSABLE scoring |
-| `topos graphify generate\|orphans` | Advisory orphan / fragile-edge hints (does not affect evaluate) |
+| `topos install [--all]` | Register the MCP server in agent harnesses (Claude, Cursor, Codex, …) |
+| `topos uninstall [--all]` | Remove Topos-owned MCP entries from harness configs |
+| `topos status` | Show which harnesses are configured |
 | `topos mcp` | Start the MCP server for tool-based agent loops |
 
-Without `--gitnexus-dir`, COMPOSABLE uses process **cwd** (CLI) or the MCP **file root** (`TOPOS_MCP_FILE_ROOT`, else server cwd), with store at `<root>/.gitnexus`. With `--gitnexus-dir` / `gitnexus_dir`, the store's parent is the COMPOSABLE project root for freshness and `gitnexus analyze` (CLI allows absolute paths outside cwd; MCP still requires the store under the file root). Pass `--no-composable` to score SIMPLE/SECURE only. The CLI accepts a one-run `--priority` override (a single pillar or a full comma-separated ranking) and `topos config` persists project defaults; MCP additionally returns the induced preference walk. Advisory `cycles`/`dependencies`/`process` hints are MCP-only, via `topos_refactor`.
+Without `--gitnexus-dir`, COMPOSABLE uses process **cwd** (CLI) or the project derived from the MCP tool's absolute file/directory path, with store at `<project>/.gitnexus`. `TOPOS_MCP_FILE_ROOT` is an optional maximum boundary, not normal editor setup. With `--gitnexus-dir` / `gitnexus_dir`, the store's parent is the COMPOSABLE project root for freshness and `gitnexus analyze` (CLI allows absolute paths outside cwd; MCP requires the store under the derived project). Pass `--no-composable` to disable only COMPOSABLE/MDG scoring; SIMPLE, SECURE, and the AST-derived NAVIGABLE pillar continue to be scored. `topos evaluate` accepts a one-run `--priority` override (a single pillar or a full comma-separated ranking) — `inspect` does not — and `topos config set --priority` persists project defaults; MCP additionally returns the induced preference walk. Advisory `cycles`/`dependencies`/`process` hints are MCP-only, via `topos_refactor`.
 
 ## MCP Tool Reference
 
@@ -139,25 +148,24 @@ Without `--gitnexus-dir`, COMPOSABLE uses process **cwd** (CLI) or the MCP **fil
 | `topos_evaluate_code` | Score a source string when there is no file on disk |
 | `topos_inspect_code` / `topos_compare_code` / `topos_compare_files` | Deep metrics; AST edit distance between two versions |
 | `topos_preference_walk` | Resolve target / fallback / next-step verdicts for a ranking |
-| `topos_refactor` | Advisory hotspots (`cycles`, `dependencies`, `process`, `graphify`) — never affects the medal |
-| `topos_generate_graphify_graph` | Build the Graphify knowledge graph for `topos_refactor(target="graphify")` |
+| `topos_refactor` | Advisory hotspots (`cycles`, `dependencies`, `process`) — never affects the medal |
 
 MCP tool arguments are **flat objects** — `{"filepath": "..."}`, not `{"params": {...}}`.
 
 ## Pitfalls
 
-- **No GitNexus → no COMPOSABLE.** The graph is generated automatically, but only if `gitnexus` is installed. If it isn't, `coupling_available` is `false` and GOLD is unreachable — check `warnings`.
-- **Missing `--gitnexus-dir` from a parent directory → slow COMPOSABLE setup.** Without the override, freshness fingerprints CLI cwd / MCP file root. Prefer `--gitnexus-dir <repo>/.gitnexus` (or `cd` into the repo / set `TOPOS_MCP_FILE_ROOT`) so only that repo is walked.
+- **No GitNexus → no COMPOSABLE.** The graph is generated automatically, but only if `gitnexus` is installed. If it isn't, `coupling_available` is `false` and PLATINUM is unreachable — check `warnings`.
+- **Missing `--gitnexus-dir` from a parent directory → slow COMPOSABLE setup.** Without the override, freshness fingerprints CLI cwd (or the MCP-derived project). Prefer `--gitnexus-dir <repo>/.gitnexus` (or `cd` into the repo) so only that repo is walked. MCP does not need `TOPOS_MCP_FILE_ROOT` for normal editor use.
 - **Cosmetic edits don't count.** Whitespace and rename-only changes won't move the lattice; MCP returns `SUSPICIOUS_NO_STRUCTURAL_CHANGE`.
 - **SECURE is structural, not full SAST.** Pair with dedicated security tooling for high-stakes code.
-- **`topos refactor` is advisory.** It does not replace `topos evaluate` for scoring.
+- **`topos_refactor` (MCP-only) is advisory.** It does not replace `topos evaluate` / `topos_evaluate_file` for scoring. There is no `topos refactor` CLI subcommand.
 
 ## Verification
 
 A change is ready when:
 
 - Assessment status is `IMPROVEMENT` or `IMPROVEMENT_SCORE` (MCP), or the evaluate verdict improved (CLI).
-- Status is not `SUSPICIOUS_NO_STRUCTURAL_CHANGE` or `REGRESSION`.
+- Any other status — `LATERAL_MOVE`, `REGRESSION`, `REGRESSION_SCORE`, `SUSPICIOUS_NO_STRUCTURAL_CHANGE` — is not ready.
 - Active SECURE findings are fixed or explicitly acknowledged.
 - Relevant tests/type checks pass, or their absence is reported.
 

--- a/docs/source/agents.rst
+++ b/docs/source/agents.rst
@@ -24,6 +24,8 @@ UI, or follow the setup tabs below to register it directly.
 - `Glama MCP server page <https://glama.ai/mcp/servers/Krv-Labs/topos>`_
 - `ClawHub skill <https://clawhub.ai/krv-labs/skills/topos>`_ (OpenClaw):
   ``openclaw skills install @Krv-Labs/topos``
+- `Agent Plugins <https://agent-plugins.org/>`_ package at ``agent-plugin/``
+  (``plugin.json`` + skill + ``mcp.json``; requires ``topos`` on ``PATH``)
 
 MCP Setup
 ---------

--- a/scripts/check_agent_plugin.py
+++ b/scripts/check_agent_plugin.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Validate the Agent Plugins 1.0 package under agent-plugin/."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import tomllib
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parent.parent
+PLUGIN_ROOT = ROOT / "agent-plugin"
+PLUGIN_SCHEMA = "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json"
+MCP_SCHEMA = "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json"
+NAME_RE = re.compile(r"^(?!.*(?:--|\.\.))[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$")
+PLUGIN_TOP_LEVEL = {
+    "$schema",
+    "name",
+    "version",
+    "description",
+    "author",
+    "homepage",
+    "repository",
+    "license",
+    "keywords",
+    "extensions",
+}
+MCP_TOP_LEVEL = {"$schema", "mcpServers"}
+STDIO_KEYS = {"type", "command", "args", "env", "cwd"}
+HTTP_KEYS = {"type", "url", "headers"}
+
+
+def cargo_version() -> str:
+    with (ROOT / "Cargo.toml").open("rb") as f:
+        data = tomllib.load(f)
+    if "package" in data and "version" in data["package"]:
+        return data["package"]["version"]
+    return data["workspace"]["package"]["version"]
+
+
+def load_json(path: Path, errors: list[str]) -> dict[str, Any] | None:
+    if not path.is_file():
+        errors.append(f"{path.relative_to(ROOT)}: missing")
+        return None
+    if path.is_symlink():
+        errors.append(f"{path.relative_to(ROOT)}: must be a regular file, not a symlink")
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        errors.append(f"{path.relative_to(ROOT)}: invalid JSON ({exc})")
+        return None
+    if not isinstance(data, dict):
+        errors.append(f"{path.relative_to(ROOT)}: must be a JSON object")
+        return None
+    return data
+
+
+def validate_plugin_manifest(data: dict[str, Any], expected_version: str) -> list[str]:
+    errors: list[str] = []
+    unknown = sorted(set(data) - PLUGIN_TOP_LEVEL)
+    # Spec: unknown top-level fields are reported but non-fatal for clients.
+    # For our authored package, treat them as errors so we stay schema-closed.
+    for key in unknown:
+        errors.append(f"agent-plugin/plugin.json: unknown top-level field {key!r}")
+
+    if data.get("$schema") != PLUGIN_SCHEMA:
+        errors.append(
+            f"agent-plugin/plugin.json: $schema must be {PLUGIN_SCHEMA!r}, "
+            f"got {data.get('$schema')!r}"
+        )
+
+    name = data.get("name")
+    if not isinstance(name, str) or not name:
+        errors.append("agent-plugin/plugin.json: name is required")
+    elif not NAME_RE.fullmatch(name) or len(name) > 64:
+        errors.append(f"agent-plugin/plugin.json: invalid name {name!r}")
+
+    version = data.get("version")
+    if version is None:
+        errors.append("agent-plugin/plugin.json: version is required in this repo")
+    elif not isinstance(version, str):
+        errors.append("agent-plugin/plugin.json: version must be a string")
+    elif version != expected_version:
+        errors.append(
+            f"agent-plugin/plugin.json: version {version!r} must match "
+            f"Cargo.toml {expected_version!r}"
+        )
+
+    for key in ("description", "homepage", "repository", "license"):
+        if key in data and not isinstance(data[key], str):
+            errors.append(f"agent-plugin/plugin.json: {key} must be a string")
+
+    if "keywords" in data:
+        keywords = data["keywords"]
+        if not isinstance(keywords, list) or not all(
+            isinstance(item, str) for item in keywords
+        ):
+            errors.append("agent-plugin/plugin.json: keywords must be an array of strings")
+
+    if "author" in data:
+        author = data["author"]
+        if not isinstance(author, dict):
+            errors.append("agent-plugin/plugin.json: author must be an object")
+        else:
+            for key in ("name", "email", "url"):
+                if key in author and not isinstance(author[key], str):
+                    errors.append(
+                        f"agent-plugin/plugin.json: author.{key} must be a string"
+                    )
+            unknown_author = sorted(set(author) - {"name", "email", "url"})
+            for key in unknown_author:
+                errors.append(
+                    f"agent-plugin/plugin.json: unknown author field {key!r}"
+                )
+
+    if "extensions" in data and not isinstance(data["extensions"], dict):
+        errors.append("agent-plugin/plugin.json: extensions must be an object")
+
+    return errors
+
+
+def validate_stdio_server(name: str, server: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    unknown = sorted(set(server) - STDIO_KEYS)
+    for key in unknown:
+        errors.append(
+            f"agent-plugin/mcp.json: mcpServers.{name}: unknown field {key!r}"
+        )
+    command = server.get("command")
+    if not isinstance(command, str) or not command:
+        errors.append(
+            f"agent-plugin/mcp.json: mcpServers.{name}: command is required"
+        )
+    elif " " in command.strip():
+        errors.append(
+            f"agent-plugin/mcp.json: mcpServers.{name}: command must be one token"
+        )
+    if "args" in server:
+        args = server["args"]
+        if not isinstance(args, list) or not all(isinstance(item, str) for item in args):
+            errors.append(
+                f"agent-plugin/mcp.json: mcpServers.{name}: args must be string array"
+            )
+    if "env" in server and not isinstance(server["env"], dict):
+        errors.append(
+            f"agent-plugin/mcp.json: mcpServers.{name}: env must be an object"
+        )
+    if "cwd" in server and not isinstance(server["cwd"], str):
+        errors.append(
+            f"agent-plugin/mcp.json: mcpServers.{name}: cwd must be a string"
+        )
+    return errors
+
+
+def validate_http_server(name: str, server: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    unknown = sorted(set(server) - HTTP_KEYS)
+    for key in unknown:
+        errors.append(
+            f"agent-plugin/mcp.json: mcpServers.{name}: unknown field {key!r}"
+        )
+    url = server.get("url")
+    if not isinstance(url, str) or not url:
+        errors.append(f"agent-plugin/mcp.json: mcpServers.{name}: url is required")
+    if "headers" in server and not isinstance(server["headers"], dict):
+        errors.append(
+            f"agent-plugin/mcp.json: mcpServers.{name}: headers must be an object"
+        )
+    return errors
+
+
+def validate_mcp(data: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    unknown = sorted(set(data) - MCP_TOP_LEVEL)
+    for key in unknown:
+        errors.append(f"agent-plugin/mcp.json: unknown top-level field {key!r}")
+
+    if data.get("$schema") != MCP_SCHEMA:
+        errors.append(
+            f"agent-plugin/mcp.json: $schema must be {MCP_SCHEMA!r}, "
+            f"got {data.get('$schema')!r}"
+        )
+
+    servers = data.get("mcpServers")
+    if not isinstance(servers, dict) or not servers:
+        errors.append("agent-plugin/mcp.json: mcpServers must be a non-empty object")
+        return errors
+
+    for name, server in servers.items():
+        if not isinstance(server, dict):
+            errors.append(
+                f"agent-plugin/mcp.json: mcpServers.{name} must be an object"
+            )
+            continue
+        transport = server.get("type")
+        if transport == "stdio":
+            errors.extend(validate_stdio_server(name, server))
+        elif transport in {"streamable-http", "sse"}:
+            errors.extend(validate_http_server(name, server))
+        else:
+            errors.append(
+                f"agent-plugin/mcp.json: mcpServers.{name}: "
+                f"type must be stdio, streamable-http, or sse; got {transport!r}"
+            )
+    return errors
+
+
+def validate_skill_sync() -> list[str]:
+    canonical = ROOT / "skills" / "topos" / "SKILL.md"
+    packaged = PLUGIN_ROOT / "skills" / "topos" / "SKILL.md"
+    errors: list[str] = []
+    if not canonical.is_file():
+        errors.append("skills/topos/SKILL.md: missing canonical skill")
+        return errors
+    if not packaged.is_file():
+        errors.append("agent-plugin/skills/topos/SKILL.md: missing packaged skill")
+        return errors
+    if packaged.is_symlink():
+        errors.append(
+            "agent-plugin/skills/topos/SKILL.md: must be a regular file "
+            "(Agent Plugins forbids package-escaping symlinks)"
+        )
+        return errors
+    if canonical.read_bytes() != packaged.read_bytes():
+        errors.append(
+            "agent-plugin/skills/topos/SKILL.md differs from skills/topos/SKILL.md; "
+            "copy the canonical skill into the plugin package"
+        )
+    return errors
+
+
+def main() -> int:
+    if not PLUGIN_ROOT.is_dir():
+        print(f"agent-plugin root not found: {PLUGIN_ROOT}", file=sys.stderr)
+        return 1
+
+    expected_version = cargo_version()
+    errors: list[str] = []
+
+    plugin = load_json(PLUGIN_ROOT / "plugin.json", errors)
+    if plugin is not None:
+        errors.extend(validate_plugin_manifest(plugin, expected_version))
+
+    mcp = load_json(PLUGIN_ROOT / "mcp.json", errors)
+    if mcp is not None:
+        errors.extend(validate_mcp(mcp))
+
+    errors.extend(validate_skill_sync())
+
+    if errors:
+        for message in errors:
+            print(message, file=sys.stderr)
+        return 1
+
+    print(
+        f"agent-plugin check passed "
+        f"(Agent Plugins 1.0.0, version {expected_version})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_agent_plugin.py
+++ b/scripts/check_agent_plugin.py
@@ -130,11 +130,11 @@ def validate_stdio_server(name: str, server: dict[str, Any]) -> list[str]:
             f"agent-plugin/mcp.json: mcpServers.{name}: unknown field {key!r}"
         )
     command = server.get("command")
-    if not isinstance(command, str) or not command:
+    if not isinstance(command, str) or not command.strip():
         errors.append(
             f"agent-plugin/mcp.json: mcpServers.{name}: command is required"
         )
-    elif " " in command.strip():
+    elif command != command.strip() or re.search(r"\s", command):
         errors.append(
             f"agent-plugin/mcp.json: mcpServers.{name}: command must be one token"
         )
@@ -247,6 +247,11 @@ def main() -> int:
     mcp = load_json(PLUGIN_ROOT / "mcp.json", errors)
     if mcp is not None:
         errors.extend(validate_mcp(mcp))
+
+    for path in PLUGIN_ROOT.rglob("*"):
+        if path.is_symlink():
+            errors.append(f"{path.relative_to(ROOT)}: must not be a symlink")
+            break
 
     errors.extend(validate_skill_sync())
 

--- a/scripts/check_agent_plugin.py
+++ b/scripts/check_agent_plugin.py
@@ -30,6 +30,22 @@ PLUGIN_TOP_LEVEL = {
 MCP_TOP_LEVEL = {"$schema", "mcpServers"}
 STDIO_KEYS = {"type", "command", "args", "env", "cwd"}
 HTTP_KEYS = {"type", "url", "headers"}
+# Copied verbatim from the published 1.0.0 mcp.schema.json `cwd` pattern:
+# a plugin-relative "./" path, or a ${PLUGIN_ROOT}/${PLUGIN_DATA}-rooted one.
+CWD_RE = re.compile(r"^(?:\./|\$\{PLUGIN_ROOT\}(?:/|$)|\$\{PLUGIN_DATA\}(?:/|$))")
+# Spec 9.3: clients supply these themselves; an env entry naming either one
+# makes the server entry invalid.
+RESERVED_ENV = {"PLUGIN_ROOT", "PLUGIN_DATA"}
+
+
+def has_parent_segment(value: str) -> bool:
+    """True if any path segment is ``..``.
+
+    The schema anchors its `cwd` pattern at the start only, so "./../escape"
+    matches it. Spec 4.1(4) and 7.2.1 both demand post-resolution containment,
+    which a prefix test cannot provide — reject upward traversal outright.
+    """
+    return ".." in re.split(r"[/\\]", value)
 
 
 def cargo_version() -> str:
@@ -116,8 +132,17 @@ def validate_plugin_manifest(data: dict[str, Any], expected_version: str) -> lis
                     f"agent-plugin/plugin.json: unknown author field {key!r}"
                 )
 
-    if "extensions" in data and not isinstance(data["extensions"], dict):
-        errors.append("agent-plugin/plugin.json: extensions must be an object")
+    if "extensions" in data:
+        extensions = data["extensions"]
+        if not isinstance(extensions, dict):
+            errors.append("agent-plugin/plugin.json: extensions must be an object")
+        else:
+            for namespace, value in extensions.items():
+                if not isinstance(value, dict):
+                    errors.append(
+                        f"agent-plugin/plugin.json: extensions.{namespace} must be "
+                        f"an object"
+                    )
 
     return errors
 
@@ -138,20 +163,57 @@ def validate_stdio_server(name: str, server: dict[str, Any]) -> list[str]:
         errors.append(
             f"agent-plugin/mcp.json: mcpServers.{name}: command must be one token"
         )
+    elif not command.startswith("./") and re.search(r"[/\\]", command):
+        errors.append(
+            f"agent-plugin/mcp.json: mcpServers.{name}: command must be a bare "
+            f"executable name or a './'-prefixed plugin-relative path, "
+            f"got {command!r}"
+        )
+    elif has_parent_segment(command):
+        errors.append(
+            f"agent-plugin/mcp.json: mcpServers.{name}: command must not "
+            f"contain a '..' segment"
+        )
     if "args" in server:
         args = server["args"]
         if not isinstance(args, list) or not all(isinstance(item, str) for item in args):
             errors.append(
                 f"agent-plugin/mcp.json: mcpServers.{name}: args must be string array"
             )
-    if "env" in server and not isinstance(server["env"], dict):
-        errors.append(
-            f"agent-plugin/mcp.json: mcpServers.{name}: env must be an object"
-        )
-    if "cwd" in server and not isinstance(server["cwd"], str):
-        errors.append(
-            f"agent-plugin/mcp.json: mcpServers.{name}: cwd must be a string"
-        )
+    if "env" in server:
+        env = server["env"]
+        if not isinstance(env, dict):
+            errors.append(
+                f"agent-plugin/mcp.json: mcpServers.{name}: env must be an object"
+            )
+        else:
+            for key, value in env.items():
+                if key in RESERVED_ENV:
+                    errors.append(
+                        f"agent-plugin/mcp.json: mcpServers.{name}: env must not "
+                        f"set {key!r}; the client supplies it"
+                    )
+                if not isinstance(value, str):
+                    errors.append(
+                        f"agent-plugin/mcp.json: mcpServers.{name}: "
+                        f"env.{key} must be a string"
+                    )
+    if "cwd" in server:
+        cwd = server["cwd"]
+        if not isinstance(cwd, str):
+            errors.append(
+                f"agent-plugin/mcp.json: mcpServers.{name}: cwd must be a string"
+            )
+        elif not CWD_RE.match(cwd):
+            errors.append(
+                f"agent-plugin/mcp.json: mcpServers.{name}: cwd must start with "
+                f"'./', '${{PLUGIN_ROOT}}', or '${{PLUGIN_DATA}}'; got {cwd!r}"
+            )
+        elif has_parent_segment(cwd):
+            errors.append(
+                f"agent-plugin/mcp.json: mcpServers.{name}: cwd must not "
+                f"contain a '..' segment"
+            )
     return errors
 
 
@@ -165,10 +227,19 @@ def validate_http_server(name: str, server: dict[str, Any]) -> list[str]:
     url = server.get("url")
     if not isinstance(url, str) or not url:
         errors.append(f"agent-plugin/mcp.json: mcpServers.{name}: url is required")
-    if "headers" in server and not isinstance(server["headers"], dict):
-        errors.append(
-            f"agent-plugin/mcp.json: mcpServers.{name}: headers must be an object"
-        )
+    if "headers" in server:
+        headers = server["headers"]
+        if not isinstance(headers, dict):
+            errors.append(
+                f"agent-plugin/mcp.json: mcpServers.{name}: headers must be an object"
+            )
+        else:
+            for key, value in headers.items():
+                if not isinstance(value, str):
+                    errors.append(
+                        f"agent-plugin/mcp.json: mcpServers.{name}: "
+                        f"headers.{key} must be a string"
+                    )
     return errors
 
 
@@ -248,10 +319,12 @@ def main() -> int:
     if mcp is not None:
         errors.extend(validate_mcp(mcp))
 
-    for path in PLUGIN_ROOT.rglob("*"):
+    # Spec 4.1(3) permits symlinks that resolve inside the plugin root; this
+    # repo is stricter on purpose, because symlinks in a git-distributed
+    # package do not survive checkout on Windows without symlink support.
+    for path in sorted(PLUGIN_ROOT.rglob("*")):
         if path.is_symlink():
             errors.append(f"{path.relative_to(ROOT)}: must not be a symlink")
-            break
 
     errors.extend(validate_skill_sync())
 

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -54,6 +54,15 @@ def main(argv: list[str] | None = None) -> int:
             f"has {package_json['version']!r}, expected {expected!r}"
         )
 
+    plugin_manifest = json.loads(
+        (ROOT / "agent-plugin/plugin.json").read_text(encoding="utf-8")
+    )
+    if plugin_manifest.get("version") != expected:
+        errors.append(
+            "agent-plugin/plugin.json "
+            f"has {plugin_manifest.get('version')!r}, expected {expected!r}"
+        )
+
     mcp_manifest = json.loads((ROOT / ".mcp/server.json").read_text(encoding="utf-8"))
     if mcp_manifest["version"] != expected:
         errors.append(

--- a/tests/packaging/test_install_sh_preflight.py
+++ b/tests/packaging/test_install_sh_preflight.py
@@ -288,6 +288,10 @@ DOC_INSTALL_SITES = (
     "README.md",
     "docs/source/installation.rst",
     "skills/topos/SKILL.md",
+    # The Agent Plugins package ships its own copy of the skill plus a README
+    # that advertises the installer independently of the canonical docs.
+    "agent-plugin/README.md",
+    "agent-plugin/skills/topos/SKILL.md",
 )
 
 


### PR DESCRIPTION
## Summary

- Implements [#310](https://github.com/Krv-Labs/topos/issues/310): portable [Agent Plugins](https://agent-plugins.org/) 1.0 package at `agent-plugin/`
- Adds `plugin.json` + `mcp.json` (`topos mcp` stdio) + packaged `skills/topos/SKILL.md` kept in sync with the ClawHub skill
- Adds `scripts/check_agent_plugin.py` and wires `plugin.json` version into `scripts/check_versions.py`
- Documents the install path in README / AGENTS / CLAUDE / agents.rst

## Solution plan

1. **Keep ClawHub path stable** — continue publishing from `skills/`; duplicate the skill into the plugin package (spec forbids escaping symlinks).
2. **Self-contained package** — `agent-plugin/` is the portable root clients load; MCP uses bare `topos` on `PATH` (same prerequisite as the skill).
3. **Guardrails** — validate closed manifest fields, MCP transport shape, Cargo version alignment, and byte-identical skill sync.
4. **Follow-ups (out of scope)** — client `extensions`, bundling the binary, moving ClawHub root to `agent-plugin/skills`.

## Test plan

- [x] `python scripts/check_agent_plugin.py`
- [x] `python scripts/check_skill.py`
- [x] `python scripts/check_versions.py`
- [x] Validate `plugin.json` / `mcp.json` against published Agent Plugins 1.0.0 JSON Schemas
- [ ] Load `./agent-plugin` in an Agent Plugins–compatible client once available locally
- [ ] Confirm `topos` on `PATH` and MCP tools appear after client enablement


Made with [Cursor](https://cursor.com)