### PR TITLE
fix(vscode): require js-yaml 4.3.1+ to close Dependabot alert #21

### DIFF
--- a/extensions/vscode/pnpm-lock.yaml
+++ b/extensions/vscode/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   diff: ^9.0.0
   fast-uri: ^3.1.5
   undici: ^7.29.0
+  js-yaml: ^4.3.1
 
 importers:
 
@@ -1249,8 +1250,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -2205,7 +2206,7 @@ snapshots:
       globals: 13.24.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -2347,7 +2348,7 @@ snapshots:
       '@textlint/types': 15.7.1
       chalk: 4.1.2
       debug: 4.4.3(supports-color@8.1.1)
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       pluralize: 2.0.0
       string-width: 4.2.3
@@ -2996,7 +2997,7 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
@@ -3330,7 +3331,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -3518,7 +3519,7 @@ snapshots:
       glob: 10.5.0
       he: 1.2.0
       is-path-inside: 3.0.3
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       log-symbols: 4.1.0
       minimatch: 9.0.9
       ms: 2.1.3
@@ -3714,7 +3715,7 @@ snapshots:
   rc-config-loader@4.1.4:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       json5: 2.2.3
       require-from-string: 2.0.2
     transitivePeerDependencies:

--- a/extensions/vscode/pnpm-workspace.yaml
+++ b/extensions/vscode/pnpm-workspace.yaml
@@ -11,6 +11,9 @@ overrides:
   fast-uri: "^3.1.5"
   # Transitive via @vscode/vsce → cheerio.
   undici: "^7.29.0"
+  # GHSA-5p4m-2wfm-xmqj: quadratic CPU consumption in !!omap resolution.
+  # Transitive via eslint/@vscode toolchain deps.
+  js-yaml: "^4.3.1"
 
 # Allow postinstall scripts required by the extension toolchain.
 allowBuilds:


### PR DESCRIPTION
## Summary
- Closes Dependabot alert #21 (GHSA-5p4m-2wfm-xmqj): `js-yaml` 4.3.0 has quadratic CPU consumption in `!!omap` resolution, fixed in 4.3.1.
- `js-yaml` is a transitive dev dependency (via eslint/textlint/rc-config-loader in `extensions/vscode`), never shipped in the packaged extension.
- Added `js-yaml: "^4.3.1"` to `extensions/vscode/pnpm-workspace.yaml` overrides, following the existing pattern used for `fast-uri`/`undici`/`diff`, and regenerated `pnpm-lock.yaml`.

## Test plan
- [ ] `pnpm install --lockfile-only` runs clean and lockfile passes supply-chain policy check (verified locally)
- [ ] Confirm Dependabot alert #21 auto-closes once merged to `main`
- [ ] `pnpm run compile` / `pnpm run test` still pass in `extensions/vscode`

🤖 Generated with [Claude Code](https://claude.com/claude-code)