### PR TITLE
refactor(cfg): replace LoopContext wrapper with continue_stack

### DIFF
--- a/topos/engine/src/graphs/cfg/builder.rs
+++ b/topos/engine/src/graphs/cfg/builder.rs
@@ -29,12 +29,6 @@
 use super::models::{BasicBlock, Blocks, CFGEdge, EdgeKind};
 use crate::graphs::uast::models::{node_key, UASTNode};
 
-/// Stack frame for `continue` resolution within a loop.
-struct LoopContext {
-    /// Block id to jump to on `continue`.
-    continue_target: usize,
-}
-
 /// Pending control-flow destinations after a `finally` block completes.
 struct FinallyExit {
     fall_through_target: usize,
@@ -47,7 +41,8 @@ struct CFGBuildState {
     blocks: Blocks,
     edges: Vec<CFGEdge>,
     next_id: usize,
-    loop_stack: Vec<LoopContext>,
+    /// Innermost `continue` target — the loop header.
+    continue_stack: Vec<usize>,
     /// Innermost `break` target — loop `after` or switch/match join.
     break_stack: Vec<usize>,
     /// Active `finally` blocks and where each resumes afterward.
@@ -61,7 +56,7 @@ impl CFGBuildState {
             blocks: Blocks::new(),
             edges: Vec::new(),
             next_id: 0,
-            loop_stack: Vec::new(),
+            continue_stack: Vec::new(),
             break_stack: Vec::new(),
             finally_stack: Vec::new(),
             exit_id: 0,
@@ -166,7 +161,7 @@ fn handle_terminal_stmt(state: &mut CFGBuildState, stmt: &UASTNode, current_id: 
             }
         }
         "ContinueStmt" => {
-            if let Some(target) = state.loop_stack.last().map(|ctx| ctx.continue_target) {
+            if let Some(target) = state.continue_stack.last().copied() {
                 state.add_edge(current_id, target, EdgeKind::Continue);
             }
         }
@@ -421,9 +416,7 @@ impl<'state, 'a> BuildMachine<'state, 'a> {
         let after = self.state.new_block("loop_after");
         self.state.add_edge(header, body_entry, EdgeKind::True);
         self.state.add_edge(header, after, EdgeKind::False);
-        self.state.loop_stack.push(LoopContext {
-            continue_target: header,
-        });
+        self.state.continue_stack.push(header);
         self.state.break_stack.push(after);
         let body_output = self.new_output();
         self.tasks
@@ -605,7 +598,7 @@ impl<'state, 'a> BuildMachine<'state, 'a> {
     }
 
     fn finish_loop(&mut self, body_output: usize, header: usize, after: usize, output: usize) {
-        self.state.loop_stack.pop();
+        self.state.continue_stack.pop();
         self.state.break_stack.pop();
         if let Some(body_tail) = self.outputs[body_output] {
             self.state.add_edge(body_tail, header, EdgeKind::Loopback);


### PR DESCRIPTION
Closes #307

`LoopContext` was left holding a single field (`continue_target: usize`) once switch `break` handling moved to `break_stack`. This drops the wrapper and stores the loop header directly in `continue_stack: Vec<usize>`, so the break/continue state reads symmetrically at the `CFGBuildState` declaration.

## Change

`topos/engine/src/graphs/cfg/builder.rs` only, 6 insertions / 13 deletions:

- delete `struct LoopContext`
- `loop_stack: Vec<LoopContext>` -> `continue_stack: Vec<usize>`
- `start_loop` pushes `header`; `finish_loop` pops — same single push/pop pair as before
- `ContinueStmt` reads `continue_stack.last().copied()`

## No edge-contract change

Push and pop sites are unchanged in number and position, so stack depth stays balanced on every path. No edge kind, target, or ordering is touched — this is a pure representation change to the builder's own scratch state.

## Verification

- `cargo test -p topos-engine graphs::cfg` — 25 passed, 0 failed (includes `preserves_pre_refactor_edge_contracts_across_supported_languages` and `finally_paths_keep_distinct_completions_and_frames`)
- `cargo test -p topos-engine` — 371 passed, 0 failed, 1 ignored
- `cargo clippy -p topos-engine --all-targets` — clean
- `cargo fmt --all` — no other files touched

`finish_agent_contract` was flagged in the same review but belongs with #233; deliberately untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)