### PR TITLE
fix(engine): reframe cfg.cyclomatic remediation as a trade-off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`cfg.cyclomatic` remediation no longer advises an action that worsens the metric it cites** ([#286](https://github.com/Krv-Labs/topos/issues/286), [#318](https://github.com/Krv-Labs/topos/pull/318)) — because `cfg.cyclomatic` is a whole-file sum, extracting a helper preserves the decisions and adds a function. The guidance now recommends collapsing redundant decisions or splitting the file, and makes the trade-off with `ast.max_function_complexity` explicit.
+
 ## [0.5.0] - 2026-08-07
 
 ### Added

--- a/topos/engine/src/evaluation/suggestions.rs
+++ b/topos/engine/src/evaluation/suggestions.rs
@@ -146,7 +146,7 @@ fn gate_message(r: &GateResult) -> String {
     let threshold = r.threshold().unwrap_or(value);
     match r.spec.metric {
         "cfg.cyclomatic" => format!(
-            "Extract helper functions to cut branching (cyclomatic {value:.0} > {threshold:.0})."
+            "Collapse redundant decisions or split this file (cyclomatic {value:.0} > {threshold:.0}) — extracting helpers lowers `ast.max_function_complexity` but raises this whole-file sum."
         ),
         "ast.max_function_complexity" => format!(
             "Split the most complex function (complexity {value:.0} > {threshold:.0})."


### PR DESCRIPTION
## Problem

`suggestions.rs` told agents to *extract helper functions* when `cfg.cyclomatic` failed. But `cfg.cyclomatic` is a **whole-file sum** — every function contributes +1 just by existing. Extracting a helper preserves every decision and adds one more function, so it can only move this number **up**. The remediation was self-defeating.

## Fix

Reword the message to name the levers that actually reduce a whole-file sum, and to make the trade-off explicit:

**Before**
> Extract helper functions to cut branching (cyclomatic 25 > 10).

**After**
> Collapse redundant decisions or split this file (cyclomatic 25 > 10) — extracting helpers lowers `ast.max_function_complexity` but raises this whole-file sum.

The two metrics moving in opposite directions is correct and useful — it is a real trade-off between per-function readability (`ast.max_function_complexity`) and whole-file surface area (`cfg.cyclomatic`). The bug was presenting one side as an imperative with no sign a trade-off existed. Now the reader picks based on which matters for the module.

## Scope

Guidance wording only. No change to metric computation, gates, or thresholds. `cfg.cyclomatic` remains advisory (`gates_achieved: false`, #193) — this is not a gate-correctness change.

## Verification

- Repo-wide search: the old string appeared in exactly one place; no test, snapshot, or doc quoted it.
- `cargo test -p topos-engine` — 371 passed.
- `cargo test -p topos-mcp` — 105 passed (the context-budget ratchet covers tool definitions, not suggestion text, and is unaffected).
- `cargo fmt --all -- --check` clean.

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)