### PR TITLE
perf(mcp): parse one morphism per metric-location request

### DIFF
--- a/topos/mcp/src/metric_locations.rs
+++ b/topos/mcp/src/metric_locations.rs
@@ -69,11 +69,30 @@ pub fn build_metric_locations(
 ) -> HashMap<String, Vec<FunctionEntry>> {
     let mut locations = HashMap::new();
 
-    if let Some(&max_func) = result.raw_metrics.get("ast.max_function_complexity") {
-        if max_func > SIMPLE.max_function_complexity {
-            let offending = offending_functions(source, language);
+    let complexity_gate_failed = result
+        .raw_metrics
+        .get("ast.max_function_complexity")
+        .is_some_and(|&max_func| max_func > SIMPLE.max_function_complexity);
+    let divergence_gate_failed = result
+        .raw_metrics
+        .get("nav.max_function_divergence")
+        .is_some_and(|&divergence| divergence > NAVIGABLE.max_function_divergence);
+
+    // One parse per request: both per-function collectors read this same
+    // UAST. Built only when a per-function gate actually failed, so a
+    // passing file still parses zero times here.
+    if complexity_gate_failed || divergence_gate_failed {
+        let morphism = parse(source, language);
+        if complexity_gate_failed {
+            let offending = offending_functions(&morphism, source);
             if !offending.is_empty() {
                 locations.insert("ast.max_function_complexity".to_string(), offending);
+            }
+        }
+        if divergence_gate_failed {
+            let offending = diverging_functions(&morphism, source);
+            if !offending.is_empty() {
+                locations.insert("nav.max_function_divergence".to_string(), offending);
             }
         }
     }
@@ -87,16 +106,22 @@ pub fn build_metric_locations(
         }
     }
 
-    if let Some(&divergence) = result.raw_metrics.get("nav.max_function_divergence") {
-        if divergence > NAVIGABLE.max_function_divergence {
-            let offending = diverging_functions(source, language);
-            if !offending.is_empty() {
-                locations.insert("nav.max_function_divergence".to_string(), offending);
-            }
-        }
-    }
-
     locations
+}
+
+#[cfg(test)]
+thread_local! {
+    /// Parses on this thread, so the regression test can assert one
+    /// morphism per request rather than one per collector. Thread-local
+    /// because the test harness runs these tests in parallel.
+    static PARSE_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+/// Sole construction point for the metric-location morphism.
+fn parse(source: &str, language: &str) -> ProgramMorphism {
+    #[cfg(test)]
+    PARSE_COUNT.with(|count| count.set(count.get() + 1));
+    ProgramMorphism::new(source, language)
 }
 
 /// Functions whose nesting divergence is over the NAVIGABLE gate,
@@ -106,8 +131,7 @@ pub fn build_metric_locations(
 /// — the field is the wire's generic "how bad is this" number, and a
 /// fractional log-weighted score has no better home in the existing shape.
 /// The exact value stays available in `raw_metrics`.
-fn diverging_functions(source: &str, language: &str) -> Vec<FunctionEntry> {
-    let morphism = ProgramMorphism::new(source, language);
+fn diverging_functions(morphism: &ProgramMorphism, source: &str) -> Vec<FunctionEntry> {
     let Some(ast) = morphism.ast.as_ref() else {
         return Vec::new();
     };
@@ -136,8 +160,7 @@ fn diverging_functions(source: &str, language: &str) -> Vec<FunctionEntry> {
         .collect()
 }
 
-fn offending_functions(source: &str, language: &str) -> Vec<FunctionEntry> {
-    let morphism = ProgramMorphism::new(source, language);
+fn offending_functions(morphism: &ProgramMorphism, source: &str) -> Vec<FunctionEntry> {
     let Some(ast) = morphism.ast.as_ref() else {
         return Vec::new();
     };
@@ -193,6 +216,24 @@ mod tests {
         assert_eq!(entries[0].name, "deep");
         assert_eq!(entries[0].start_line, Some(1));
         assert_eq!(entries[0].metric_source.as_deref(), Some("nav"));
+    }
+
+    /// One morphism per request, not one per collector: with both
+    /// per-function gates failing, the two collectors must share a single
+    /// parse.
+    #[test]
+    fn both_collectors_share_one_parse() {
+        let mut source = deeply_nested();
+        // Extra shallow branches push the same function past SIMPLE's
+        // per-function complexity gate as well.
+        for extra in 0..12 {
+            source.push_str(&format!("    if xs[{extra}]:\n        return 0\n"));
+        }
+        PARSE_COUNT.with(|count| count.set(0));
+        let locations = locations_for(&source);
+        assert!(locations.contains_key("ast.max_function_complexity"));
+        assert!(locations.contains_key("nav.max_function_divergence"));
+        assert_eq!(PARSE_COUNT.with(|count| count.get()), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`topos/mcp/src/metric_locations.rs` built a `ProgramMorphism` (and its UAST) separately inside `offending_functions` and `diverging_functions`. A single-file request that fails both the SIMPLE per-function complexity gate and the NAVIGABLE divergence gate therefore parsed the same source twice on the interactive agent path.

## Change

Hoist the construction into `build_metric_locations` — the single point every metric-location collector routes through — and pass `&ProgramMorphism` down to both collectors.

- The two gate conditions are evaluated up front, so the morphism is built only when a per-function gate actually failed. A passing file still parses **zero** times here (no eager-parse regression for the common case).
- `cfg.cyclomatic` is a module-level marker and never needed the AST; that branch is untouched.
- No cache, no `OnceCell`, no new trait or abstraction — plain parameter passing.
- `build_metric_locations`'s public signature is unchanged, so none of its four callers (`topos_evaluate_code`, `evaluate_file_sync`, `inspect_code_sync`, CLI `details_for_source`) needed edits.

## Response shape and ordering unchanged

- Same `HashMap<String, Vec<FunctionEntry>>` return type and same keys.
- Every `FunctionEntry` field is built by the same code as before.
- Span ordering is untouched: complexity entries still sort `Reverse(complexity)`, divergence entries still sort by `total_cmp` descending, both worst-first.
- The only reordering is *between* map inserts (`cfg.cyclomatic` now lands after the two function collectors), which is unobservable in a `HashMap`.

## Tests

Added one focused parse-count regression test, `both_collectors_share_one_parse`: a source that fails **both** per-function gates, asserting exactly one morphism construction and that both location keys are present. The counter is a `#[cfg(test)]` thread-local `Cell` bumped in the single `parse` seam — thread-local rather than a global `AtomicUsize` because the sibling tests in this module also call `build_metric_locations` and the harness runs them in parallel.

```
cargo test -p topos-mcp metric_locations   4 passed; 0 failed
cargo test -p topos-mcp                  106 passed; 0 failed; 1 ignored
cargo clippy --workspace --all-targets -- -D warnings   clean
cargo fmt --all -- --check                              clean
```

## Out of scope (observed, not fixed here)

Parsing is still duplicated *across* modules on a single request: `classify_code_string` / `classify_file`, `overlay_for_source` (`diagnostics.rs`), and `security_findings::cpg_for` each build their own `ProgramMorphism` from the same source, and `inspect_code_sync` builds one more at `tools/inspect.rs:303` for its function table. Deduplicating those means threading a morphism across module boundaries and is a materially larger change than this issue describes. The MCP project/multi-file page does not call `build_metric_locations` at all, so it was never affected by the duplication fixed here — though it does pay the per-module parse above once per file.

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)