### PR TITLE
docs: document squash-merge + Unreleased changelog convention

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -83,29 +83,46 @@ Exposes tools, resources, and prompts for agent workflows:
 
 ## Git History & Release Convention
 
-`main`'s history is a series of squash-merged PRs. Keep it that way.
+From adoption onward, `main` is a linear series of squash-merged PRs. Do not rewrite published history to retrofit this convention.
 
-1. **One PR, one squash-merge into `main`.** No merge commits, no rebase-and-merge, no direct pushes to `main`. A PR addresses **a single issue, or a cluster of tightly related issues** that share a root cause or a fix site — if two changes want separate lines in the log, they want separate PRs.
-2. **Every user-visible PR adds its entry to `## [Unreleased]` in [`CHANGELOG.md`](../CHANGELOG.md)** as part of the PR itself, under the usual Keep a Changelog headings (`Added` / `Fixed` / `Changed` / `Breaking` / `Removed` / `Notes`). Do not defer changelog writing to release time — the person with the context is the one writing the PR. Internal-only churn (refactors with no behavior change, test-only edits, CI plumbing) needs no entry.
-3. **Scope the release second.** Once `Unreleased` reflects what actually landed, decide what the release *is* and pick its version. Scope follows the work; the work does not wait on a scope decision.
-4. **The release PR comes last** — it renames `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD`, bumps versions, and is itself squash-merged. Base the release branch on `main`, never on a previous release branch.
+1. **One coherent outcome per PR; one squash commit on `main`.** No merge commits, no rebase-and-merge, and no direct pushes to `main`. Treat the PR as the unit of review, release notes, and revert: if changes would be reviewed, reverted, or explained independently, separate them. A PR may close several issues only when they share one root cause and one coherent fix.
+2. **Use the PR title as the permanent commit subject.** Write it in Conventional Commit style and keep the PR description current with rationale, behavioral proof, and verification. Intermediate topic-branch commits may be iterative; optimize the permanent history at squash time.
+3. **Every notable user-visible PR updates `## [Unreleased]` in [`CHANGELOG.md`](../CHANGELOG.md).** Use the Keep a Changelog headings (`Added` / `Changed` / `Deprecated` / `Removed` / `Fixed` / `Security`), with project-specific `Breaking` or `Notes` sections when useful. Write the entry in the PR while its context is fresh. Internal-only churn (behavior-preserving refactors, test-only edits, CI plumbing) needs no entry.
+4. **Scope the release second.** Once `Unreleased` reflects what actually landed, decide what the release *is* and pick its version. Scope follows the work; the work does not wait on a scope decision.
+5. **The release PR comes last.** Move the contents of `## [Unreleased]` into `## [X.Y.Z] - YYYY-MM-DD`, retain an empty `## [Unreleased]` at the top, bump versions, and squash-merge the release PR. Base its branch on current `main`, never on a previous release branch, and tag the resulting squash commit.
 
 Corollary: do **not** open a long-lived release branch to accumulate feature PRs. Independent fixes go straight to `main` as they pass review. A release branch that exists before its scope is decided just collects drift.
 
+Repository settings must enforce the convention rather than relying on memory:
+
+- Allow squash merge only; require a linear history and a pull request for `main`.
+- Require the canonical CI checks and resolved review threads before merge.
+- Automatically delete merged head branches; keep any administrative bypass narrow and auditable.
+
 ### Stacked PRs
 
-Stacking is for **work that review surfaced** — a required fix to a PR under review, or a new issue found while reviewing it. Stack onto the PR branch, not onto a release branch.
+Stack only when a child change **structurally depends on an unmerged parent**. Discovery during review is not itself a reason to stack: an independent issue gets a branch and PR from `main`. Never use a stack as a release train.
 
-Before stacking, check the cheaper option: **if the parent has not merged and the fix belongs to its issue, just push another commit to the parent.** It squashes away anyway. Stack only when the follow-up is a *distinct* issue, or when the parent must land now and the follow-up would hold it up.
+Before stacking, check the cheaper option: **if the parent has not merged and the fix belongs to its outcome, push another commit to the parent.** It squashes away anyway. A child should represent a distinct, reviewable outcome that cannot yet be based on `main`.
 
-When the parent squash-merges, its individual commits cease to exist on `main`, so every child must be replanted:
+Keep stacks short, preferably two or three PRs. Base each child PR on its immediate parent branch, list the complete ordered stack in every PR description, review bottom-up, and never merge a child before its parent.
+
+Squash merging replaces the parent's commits with one new commit on `main`. Before merging the parent, record its old tip. After the merge, replant a direct child onto current `origin/main`:
 
 ```sh
-git rebase --onto main <parent-tip-before-merge> <child-branch>
-git push --force-with-lease
+git fetch origin
+git rebase --onto origin/main <old-parent-tip> <child-branch>
+git push --force-with-lease origin <child-branch>
 ```
 
-GitHub retargets the child's base automatically, but it does **not** rebase — skip this and the child's PR shows the parent's changes as its own. Replant children immediately after the parent merges, deepest last. This is the stacked-squash divergence that made the v0.4.x release branches painful; it is manageable for a short chain of review follow-ups and not manageable for a whole release's worth of features, which is why the two cases are governed differently.
+For a deeper stack such as `A <- B <- C`, record `B`'s old tip before rebasing it. Rebase shallowest to deepest so each descendant moves onto its newly rebased parent:
+
+```sh
+git rebase --onto <rebased-B-branch> <old-B-tip> <C-branch>
+git push --force-with-lease origin <C-branch>
+```
+
+GitHub retargets a child PR to the merged parent's base **after the merged parent branch is deleted**. Automatic head-branch deletion should do this; otherwise retarget the PR manually. Retargeting does not rewrite the child commits, so always perform the rebase, inspect the resulting diff, and rerun CI after every replant. Use `--force-with-lease` only on topic branches.
 
 ## Closed-Loop Agent Workflow
 Read `topos://docs/agent-contract` first. Use Topos as the structural verifier:

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -85,12 +85,27 @@ Exposes tools, resources, and prompts for agent workflows:
 
 `main`'s history is a series of squash-merged PRs. Keep it that way.
 
-1. **One PR, one squash-merge into `main`.** No merge commits, no rebase-and-merge, no direct pushes to `main`. A PR is the unit of history — if two changes want separate lines in the log, they want separate PRs.
+1. **One PR, one squash-merge into `main`.** No merge commits, no rebase-and-merge, no direct pushes to `main`. A PR addresses **a single issue, or a cluster of tightly related issues** that share a root cause or a fix site — if two changes want separate lines in the log, they want separate PRs.
 2. **Every user-visible PR adds its entry to `## [Unreleased]` in [`CHANGELOG.md`](../CHANGELOG.md)** as part of the PR itself, under the usual Keep a Changelog headings (`Added` / `Fixed` / `Changed` / `Breaking` / `Removed` / `Notes`). Do not defer changelog writing to release time — the person with the context is the one writing the PR. Internal-only churn (refactors with no behavior change, test-only edits, CI plumbing) needs no entry.
 3. **Scope the release second.** Once `Unreleased` reflects what actually landed, decide what the release *is* and pick its version. Scope follows the work; the work does not wait on a scope decision.
 4. **The release PR comes last** — it renames `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD`, bumps versions, and is itself squash-merged. Base the release branch on `main`, never on a previous release branch.
 
 Corollary: do **not** open a long-lived release branch to accumulate feature PRs. Independent fixes go straight to `main` as they pass review. A release branch that exists before its scope is decided just collects drift.
+
+### Stacked PRs
+
+Stacking is for **work that review surfaced** — a required fix to a PR under review, or a new issue found while reviewing it. Stack onto the PR branch, not onto a release branch.
+
+Before stacking, check the cheaper option: **if the parent has not merged and the fix belongs to its issue, just push another commit to the parent.** It squashes away anyway. Stack only when the follow-up is a *distinct* issue, or when the parent must land now and the follow-up would hold it up.
+
+When the parent squash-merges, its individual commits cease to exist on `main`, so every child must be replanted:
+
+```sh
+git rebase --onto main <parent-tip-before-merge> <child-branch>
+git push --force-with-lease
+```
+
+GitHub retargets the child's base automatically, but it does **not** rebase — skip this and the child's PR shows the parent's changes as its own. Replant children immediately after the parent merges, deepest last. This is the stacked-squash divergence that made the v0.4.x release branches painful; it is manageable for a short chain of review follow-ups and not manageable for a whole release's worth of features, which is why the two cases are governed differently.
 
 ## Closed-Loop Agent Workflow
 Read `topos://docs/agent-contract` first. Use Topos as the structural verifier:

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -81,6 +81,17 @@ Exposes tools, resources, and prompts for agent workflows:
 - **Resources**: `topos://docs/agent-contract`, `topos://docs/lattice`, `topos://docs/metrics`, `topos://docs/priority`, `topos://docs/preferences`, `topos://docs/workflows`.
 - **Prompts**: `topos_refactor_until_ideal`.
 
+## Git History & Release Convention
+
+`main`'s history is a series of squash-merged PRs. Keep it that way.
+
+1. **One PR, one squash-merge into `main`.** No merge commits, no rebase-and-merge, no direct pushes to `main`. A PR is the unit of history — if two changes want separate lines in the log, they want separate PRs.
+2. **Every user-visible PR adds its entry to `## [Unreleased]` in [`CHANGELOG.md`](../CHANGELOG.md)** as part of the PR itself, under the usual Keep a Changelog headings (`Added` / `Fixed` / `Changed` / `Breaking` / `Removed` / `Notes`). Do not defer changelog writing to release time — the person with the context is the one writing the PR. Internal-only churn (refactors with no behavior change, test-only edits, CI plumbing) needs no entry.
+3. **Scope the release second.** Once `Unreleased` reflects what actually landed, decide what the release *is* and pick its version. Scope follows the work; the work does not wait on a scope decision.
+4. **The release PR comes last** — it renames `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD`, bumps versions, and is itself squash-merged. Base the release branch on `main`, never on a previous release branch.
+
+Corollary: do **not** open a long-lived release branch to accumulate feature PRs. Independent fixes go straight to `main` as they pass review. A release branch that exists before its scope is decided just collects drift.
+
 ## Closed-Loop Agent Workflow
 Read `topos://docs/agent-contract` first. Use Topos as the structural verifier:
 measure, make one focused structural change, verify with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+Merged PRs add their entries to `[Unreleased]` as they land; the release PR renames
+that section. See the Git History & Release Convention in [`.agents/AGENTS.md`](.agents/AGENTS.md).
+
+## [Unreleased]
+
+### Fixed
+
+- **`cfg.cyclomatic` remediation no longer advises an action that worsens the metric it cites** ([#286](https://github.com/Krv-Labs/topos/issues/286), [#318](https://github.com/Krv-Labs/topos/pull/318)) — `cfg.cyclomatic` is a whole-file sum, so extracting a helper preserves the decisions and adds a function, moving the number up. The guidance now names the actual levers for a whole-file sum (collapse redundant decisions, or split the file) and surfaces the trade-off against `ast.max_function_complexity` rather than implying the two align.
+
+### Changed
+
+- **Ranking-list sorts evaluate each row's gates once** ([#305](https://github.com/Krv-Labs/topos/issues/305), [#320](https://github.com/Krv-Labs/topos/pull/320)) — project ranking comparators called `gate_metrics_for` per comparison, cloning each row's full `raw_metrics` map and reclassifying, for O(n log n) gate evaluations. Rows are now decorated with precomputed keys once, sorted, and projected back. Ordering and list membership are unchanged (verified by comparing `topos_evaluate_project` payloads across both binaries).
+- **Metric-location generation parses once per request** ([#306](https://github.com/Krv-Labs/topos/issues/306), [#319](https://github.com/Krv-Labs/topos/pull/319)) — SIMPLE and NAVIGABLE location collectors each built their own `ProgramMorphism` for the same single-file request. One morphism is now built and shared. Response shape and span ordering unchanged.
+- **CFG builder tracks continue targets directly** ([#307](https://github.com/Krv-Labs/topos/issues/307), [#317](https://github.com/Krv-Labs/topos/pull/317)) — after switch `break` handling moved to `break_stack`, `LoopContext` held a single field. Replaced with `continue_stack: Vec<usize>`. No edge-contract change.
+
 ## [0.5.0] - 2026-08-07
 
 ### Added


### PR DESCRIPTION
Records the repo git convention in `.agents/AGENTS.md` (hand-authored canonical rules — the root `AGENTS.md` is OpenWiki-regenerated and would clobber an edit there).

## The convention

1. **One coherent outcome per PR; one squash commit on `main`.** No merge commits, no rebase-and-merge, no direct pushes. Scope by what would be reviewed, reverted, and explained as a unit — a PR may close several issues only when they share one root cause and one coherent fix.
2. **The PR title is the permanent commit subject** — Conventional Commit style, with the description carrying rationale, behavioral proof, and verification. Topic-branch commits may be iterative; optimize history at squash time.
3. **Every notable user-visible PR updates `## [Unreleased]` in `CHANGELOG.md`**, written while the context is fresh. Internal-only churn (behavior-preserving refactors, test-only edits, CI plumbing) needs no entry.
4. **Release scope is decided after the work lands**, by reading what `Unreleased` accumulated.
5. **The release PR comes last** — moves `[Unreleased]` into `[X.Y.Z] - YYYY-MM-DD`, leaves an empty `[Unreleased]`, bumps versions, squash-merges, and tags the resulting commit. Its branch bases on current `main`, never on a prior release branch.

No long-lived release branches accumulating feature PRs. The convention applies from adoption onward; published history is not rewritten to retrofit it.

Repository settings enforce it rather than relying on memory: squash-only, linear history required, PR required for `main`, canonical checks and resolved threads before merge, automatic head-branch deletion, narrow and auditable admin bypass.

## Stacked PRs

Stack only when a child **structurally depends on an unmerged parent**. Discovery during review is not itself a reason to stack — an independent issue gets its own branch off `main`. Never use a stack as a release train. Keep stacks to two or three, base each child on its immediate parent, list the ordered stack in every description, review bottom-up, never merge a child before its parent.

The cheaper option comes first: if the parent has not merged and the fix belongs to its outcome, push another commit to the parent — it squashes away anyway.

Because squash merging replaces the parent commits with one new commit, children must be replanted:

```sh
git fetch origin
git rebase --onto origin/main <old-parent-tip> <child-branch>
git push --force-with-lease origin <child-branch>
```

For `A <- B <- C`, record each parent tip before rebasing it and move shallowest to deepest so every descendant lands on its newly rebased parent. GitHub retargets a child only after the merged head branch is deleted, and retargeting never rewrites commits — always rebase, inspect the diff, and rerun CI.

## Also in this PR

Opens the `[Unreleased]` section (`CHANGELOG.md` had none — entries were written at release time) and backfills the four fixes in review: #317, #318, #319, #320. Those were authored before this convention existed, so their entries land here rather than in their own branches. Everything after this carries its own.

**Merge this first.** #323, #324 and the pending Graphify removal all write into `[Unreleased]`, which does not exist until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)