### PR TITLE
release: v0.5.1

### DIFF
--- a/.mcp/server.json
+++ b/.mcp/server.json
@@ -15,12 +15,12 @@
     "url": "https://github.com/Krv-Labs/topos",
     "source": "github"
   },
-  "version": "0.5.0",
+  "version": "0.5.1",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "topos-mcp",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
@@ -28,4 +28,3 @@
     }
   ]
 }
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ that section. See the Git History & Release Convention in [`.agents/AGENTS.md`](
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-08-08
+
 ### Fixed
 
 - **`cfg.cyclomatic` remediation no longer advises an action that worsens the metric it cites** ([#286](https://github.com/Krv-Labs/topos/issues/286), [#318](https://github.com/Krv-Labs/topos/pull/318)) — `cfg.cyclomatic` is a whole-file sum, so extracting a helper preserves the decisions and adds a function, moving the number up. The guidance now names the actual levers for a whole-file sum (collapse redundant decisions, or split the file) and surfaces the trade-off against `ast.max_function_complexity` rather than implying the two align.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1580,7 +1580,7 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "topos"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "clap",
  "console",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "topos-engine"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "blake2",
  "flate2",
@@ -1613,7 +1613,7 @@ dependencies = [
 
 [[package]]
 name = "topos-mcp"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,7 @@ resolver = "2"
 members = ["topos/engine", "topos/cli", "topos/mcp"]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 license = "BSD-3-Clause"
 repository = "https://github.com/Krv-Labs/topos"
-

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "topos-vscode",
   "displayName": "Topos: Code Quality Targets for Agents",
   "description": "Structural code-quality targets your coding agents can optimize toward, delivered as MCP tools for agent mode.",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "publisher": "KrvLabs",
   "icon": "icon.png",
   "license": "SEE LICENSE IN LICENSE",

--- a/skills/topos/SKILL.md
+++ b/skills/topos/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: topos
 description: Evaluate and improve code with Topos. Use for complexity reduction, security checks, refactor verification, and PLATINUM/GOLD goals.
-version: "0.5.0"
+version: "0.5.1"
 homepage: https://docs.krv.ai/topos/
 metadata:
   openclaw:


### PR DESCRIPTION
## Summary

- move the current `[Unreleased]` patch notes into `[0.5.1] - 2026-08-08`
- retain an empty `[Unreleased]` section for subsequent work
- bump Cargo, MCP Registry, VS Code extension, and Topos skill versions to `0.5.1`

## Included patches

- #318 — correct the `cfg.cyclomatic` remediation guidance
- #319 — reuse one parsed morphism for metric-location generation
- #320 — evaluate project-ranking gate inputs once per row
- #317 — simplify CFG continue-target bookkeeping without changing the edge contract

## Verification

- [x] `python3 scripts/check_versions.py --tag v0.5.1`
- [x] `python3 scripts/check_skill.py`
- [x] `python3 scripts/generate_self_badge.py --self-check`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `git diff --check`

## Release checklist

- [x] release branch is based on current `main`
- [x] changelog contains only changes already merged to `main`
- [x] final review
- [ ] squash-merge into `main`
- [ ] tag the resulting squash commit `v0.5.1`
