### PR TITLE
perf(mcp): check the security overlay's guards before parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ that section. See the Git History & Release Convention in [`.agents/AGENTS.md`](
 
 ## [Unreleased]
 
+### Changed
+
+- **The security overlay decides before it parses** ([#322](https://github.com/Krv-Labs/topos/issues/322), [#331](https://github.com/Krv-Labs/topos/pull/331)) — `overlay_for_file` / `overlay_for_source` built a `ProgramMorphism` before checking the two conditions that make an overlay possible at all (parseable, and SECURE actually failing). Every SECURE-passing file therefore paid a full tree-sitter parse whose only consumer was an early `return None`, and `overlay_for_file` re-read from disk a file `classify_file` had just read. The guards now run first. Most visible in the project loop, which calls `overlay_for_file` once per file: on a clean codebase that was one wasted read + parse per file. `topos_inspect_code` on a SECURE-clean 1820-line Rust file drops from 118.5 ms to 99.8 ms (~16%). Verdicts, findings, and acknowledged risks are unchanged — verified by diffing `topos evaluate --json` across both binaries on corpora exercising both the firing and passing paths.
+
 ## [0.5.1] - 2026-08-08
 
 ### Fixed

--- a/topos/mcp/src/diagnostics.rs
+++ b/topos/mcp/src/diagnostics.rs
@@ -61,19 +61,30 @@ fn acknowledged_to_models(verdict: &AdjustedVerdict) -> Vec<AcknowledgedRisk> {
         .collect()
 }
 
+/// Whether an overlay can exist at all — decidable from the classification
+/// alone, without touching the source.
+///
+/// Both public entry points check this *before* building a `ProgramMorphism`,
+/// so a SECURE-passing file never pays for a parse whose only consumer is the
+/// `build_cpg` below. That matters most in the project loop
+/// (`tools::evaluate::evaluate_single_file`), which calls `overlay_for_file`
+/// once per file: on a clean codebase every one of those parses — and, via
+/// `from_file`, a second read of a file `classify_file` already read — was
+/// discarded unused. Keep the guard ahead of the parse.
+fn overlay_applies(result: &ClassificationResult) -> bool {
+    result.is_parseable && secure_failed(result)
+}
+
 fn overlay(
     morphism: &mut ProgramMorphism,
     result: &ClassificationResult,
     file_path: Option<&Path>,
     allows: &[String],
 ) -> Option<SecurityOverlay> {
-    if !result.is_parseable {
+    if !overlay_applies(result) {
         return None;
     }
     let config = config_for(file_path, allows);
-    if !secure_failed(result) {
-        return None;
-    }
 
     let cpg = morphism.build_cpg().cloned();
     // Pass the *raw* findings (full registry — `allow: None`) so that
@@ -107,6 +118,9 @@ pub fn overlay_for_file(
     result: &ClassificationResult,
     allows: &[String],
 ) -> Option<SecurityOverlay> {
+    if !overlay_applies(result) {
+        return None;
+    }
     let language = crate::evaluation::detect_language(path);
     let mut morphism = ProgramMorphism::from_file(path, language).ok()?;
     overlay(&mut morphism, result, Some(path), allows)
@@ -120,6 +134,9 @@ pub fn overlay_for_source(
     file_path: Option<&Path>,
     allows: &[String],
 ) -> Option<SecurityOverlay> {
+    if !overlay_applies(result) {
+        return None;
+    }
     let mut morphism = ProgramMorphism::new(source, language);
     overlay(&mut morphism, result, file_path, allows)
 }
@@ -132,6 +149,38 @@ mod tests {
 
     // `eval(...)` is a dangerous call, so SECURE fails and the overlay engages.
     const EVAL_SRC: &str = "def f(expr):\n    return eval(expr)\n";
+
+    /// The guards now run ahead of the parse, so the passing path returns
+    /// `None` having never built a morphism. Pins the half of the contract
+    /// that hoist could have broken: no overlay for SECURE-clean source, and
+    /// none for unparseable source either — the early `None` must still
+    /// distinguish "nothing to report" from "could not look".
+    #[test]
+    fn secure_clean_and_unparseable_sources_produce_no_overlay() {
+        let clean = "def f(x):\n    return x + 1\n";
+        let result =
+            classify_code_string(clean, "python", Priority::Simple).expect("classification runs");
+        assert!(result.is_parseable);
+        assert!(
+            overlay_for_source(clean, "python", &result, None, &[]).is_none(),
+            "a SECURE-passing file has no overlay to report"
+        );
+
+        // An allow list must not conjure an overlay where SECURE passed.
+        assert!(
+            overlay_for_source(clean, "python", &result, None, &["eval".to_string()]).is_none(),
+            "an unused --allow does not manufacture an overlay"
+        );
+
+        let broken = "def f(:\n";
+        let broken_result = classify_code_string(broken, "python", Priority::Simple)
+            .expect("classification runs on unparseable source");
+        assert!(!broken_result.is_parseable);
+        assert!(
+            overlay_for_source(broken, "python", &broken_result, None, &[]).is_none(),
+            "unparseable source yields no overlay"
+        );
+    }
 
     #[test]
     fn one_off_allow_acknowledges_risk_rather_than_stripping_it() {

--- a/topos/mcp/src/tools/inspect.rs
+++ b/topos/mcp/src/tools/inspect.rs
@@ -433,4 +433,65 @@ mod tests {
 
         std::fs::remove_dir_all(&project_root).ok();
     }
+
+    /// Evidence for issue #322: what fraction of `topos_inspect_code` latency
+    /// is actually tree-sitter parsing?
+    ///
+    /// #322 proposes threading one `ProgramMorphism` across four module
+    /// boundaries to kill the duplicate parses, but gates that refactor on a
+    /// measurement first — "4x a cheap operation is still cheap." This is that
+    /// measurement, not a regression test: it asserts nothing about timing
+    /// (wall clock is not a CI invariant) and stays `#[ignore]`d so it costs
+    /// nothing until someone asks the question again.
+    ///
+    ///     cargo test --release -p topos-mcp -- --ignored --nocapture
+    ///
+    /// Release matters — a debug-build tree-sitter number is meaningless.
+    /// Two subjects, an outlier-large file and an ordinary one, so the ratio
+    /// can be told apart from an artifact of file size.
+    #[test]
+    #[ignore = "measurement for #322, not an assertion; run with --release --nocapture"]
+    fn parse_share_of_inspect_latency() {
+        const ITERS: u32 = 20;
+        let crate_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let subjects = [
+            ("largest in crate", "src/tools/assess.rs"),
+            ("ordinary module", "src/diagnostics.rs"),
+        ];
+
+        for (label, rel) in subjects {
+            let subject = crate_root.join(rel);
+            let source = std::fs::read_to_string(&subject).expect("read subject file");
+
+            // Warm up so neither number pays first-touch grammar loading.
+            let _ = ProgramMorphism::new(&source, "rust");
+
+            let t0 = std::time::Instant::now();
+            for _ in 0..ITERS {
+                std::hint::black_box(ProgramMorphism::new(&source, "rust"));
+            }
+            let parse_total = t0.elapsed();
+
+            let params = params_from(serde_json::json!({
+                "code": source,
+                "language": "rust",
+            }));
+            let t1 = std::time::Instant::now();
+            for _ in 0..ITERS {
+                std::hint::black_box(inspect_code_sync(params.clone()));
+            }
+            let inspect_total = t1.elapsed();
+
+            let share = parse_total.as_secs_f64() / inspect_total.as_secs_f64() * 100.0;
+            println!(
+                "#322 {label}: {rel} ({} lines), {ITERS} iters\n\
+                 \x20 one parse:     {:>9.3?}\n\
+                 \x20 one inspect:   {:>9.3?}\n\
+                 \x20 parse share:   {share:.1}% of inspect latency (per redundant parse)",
+                source.lines().count(),
+                parse_total / ITERS,
+                inspect_total / ITERS,
+            );
+        }
+    }
 }


### PR DESCRIPTION
Refs #322. Measurement + the one fix that measurement made unambiguous.

## What #322 asked for

#322 forbids refactoring before measuring — "4x a cheap operation is still cheap" — and says to **close the issue** if parse time is a small fraction of `topos_inspect_code` latency.

Measured it. It isn't.

| subject | lines | one parse | one inspect | parse share |
| --- | --- | --- | --- | --- |
| `mcp/src/tools/assess.rs` | 1820 | 17.9 ms | 99.8 ms | **17.9%** |
| `mcp/src/diagnostics.rs` | 225 | 1.44 ms | 5.59 ms | **25.7%** |

Per *redundant* parse. The ordinary-sized file is the worse one, so this is not an artifact of picking a large subject.

The measurement ships as an `#[ignore]`d test (`tools/inspect.rs::parse_share_of_inspect_latency`) — evidence, not an assertion; it asserts nothing about wall clock and costs nothing in CI.

```
cargo test --release -p topos-mcp -- --ignored --nocapture
```

## What this PR actually fixes

Reading the four sites turned up something separate from what #322 describes, and not `inspect`-specific.

`diagnostics.rs::overlay()` returns `None` unless the result is parseable **and** SECURE actually failed — but both public entry points built a `ProgramMorphism` *before* calling it. So every SECURE-passing file paid a full tree-sitter parse whose only consumer was an early return, and `overlay_for_file` additionally re-read from disk a file `classify_file` had just read.

The project loop (`evaluate_single_file`) calls `overlay_for_file` once per file. On a codebase where most files pass SECURE — the normal case — that was one wasted read + parse **per file, for the entire scan**.

Fix: hoist the two conditions into `overlay_applies` and check it in both entry points before constructing the morphism. Root cause, one place, rather than patching the 11 call sites across `tools/inspect.rs`, `tools/evaluate.rs`, `tools/assess.rs`, and `cli/src/commands/evaluate/info.rs`.

`topos_inspect_code` on a SECURE-clean 1820-line Rust file: **118.5 ms → 99.8 ms (~16%)**.

## Behavior is unchanged

`config_for` used to run between the two guards, but its result was discarded on the early-return path, so moving it below both is inert.

Verified by diffing `topos evaluate --json` across both binaries on two corpora:

- `topos/engine/src` — all SECURE-passing (max `cpg.dangerous_calls` = 0)
- a fixture with `os.system` + `eval` — SECURE-failing, 2 dangerous calls

Identical on both the firing and passing paths. Plus a new unit test pinning the passing path (`secure_clean_and_unparseable_sources_produce_no_overlay`), which covers SECURE-clean source, an unused `--allow` that must not manufacture an overlay, and unparseable source.

646 workspace tests pass; clippy and `fmt --check` clean.

## Two corrections to the #322 body

1. `security_findings.rs:233` (`cpg_for`) is inside `#[cfg(test)] mod tests` — a test helper, not a production parse. The real fourth site is `metric_locations.rs:85`, already made conditional by #319. Production parses were **3 always**, 4 on a per-function gate failure — not 4 always.
2. The wasted overlay parse above, which the issue frames as an `inspect` concern but which cost more in the project loop.

## Deliberately not in this PR

The remaining duplication — `classify_code_string`/`classify_file` and `inspect.rs:303` still parse the same source — needs `&ProgramMorphism` threaded across module boundaries. At ~18-26% per parse it is now justified, but it is a materially larger diff on the interactive agent path.

**#322 stays open** with the numbers and that scoping attached, per its own stated preference for threading over a cache / `OnceCell` / new context abstraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
