### PR TITLE
fix(engine): TypeScript parser robustness & CPG security sink precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ that section. See the Git History & Release Convention in [`.agents/AGENTS.md`](
 
 ## [Unreleased]
 
+### Fixed
+
+- **TypeScript generic type imports and dynamic subscript accesses** ([#347](https://github.com/Krv-Labs/topos/issues/347), [#348](https://github.com/Krv-Labs/topos/issues/348)) — inline dynamic type imports in TypeScript generic arguments (`load<typeof import("...")>()`, `load<import("...")>()`) are sanitized during AST dispatch so tree-sitter parses the call expression cleanly without misidentifying `<` as a binary comparison operator and failing parse validation. In addition, `subscript_expression` is mapped to `MemberExpr` in the JavaScript/TypeScript UAST mapper, preventing defensive bracket lookups (`obj[key]`) from dropping to `Unknown` or being misclassified as dangerous execution call sinks.
+
 ### Breaking
 
 - **Graphify integration removed** (~1,680 production lines). Every signal it provided was already available from the GitNexus/MDG graph Topos loads for COMPOSABLE, usually at better fidelity — full `startLine`/`endLine` spans instead of point anchors, a first-class `Community` node label with `MEMBER_OF` edges instead of a bare Louvain field, and a continuous `confidence: f64` + `reason` instead of a three-value enum. It had no production consumer, no CI coverage, and no agent-facing recommendation, and it wrapped a pre-1.0 external tool with a documented history of schema breaks. See [`docs/decisions/refactor-suite.md`](docs/decisions/refactor-suite.md) § Removed target and issue [#325](https://github.com/Krv-Labs/topos/issues/325).

--- a/topos/engine/src/graphs/ast/dispatch.rs
+++ b/topos/engine/src/graphs/ast/dispatch.rs
@@ -54,6 +54,87 @@ fn tree_sitter_language(language: &str, file: Option<&str>) -> Result<Language, 
     })
 }
 
+/// Sanitize dynamic type import expressions inside TypeScript generic type
+/// arguments (e.g. `load<typeof import("...")>()`) so tree-sitter's parser
+/// recognizes `<` as the opening of `type_arguments` rather than a binary
+/// less-than comparison. Exact byte length is preserved so all node spans
+/// align with the original source.
+fn sanitize_typescript_type_imports(source: &str) -> String {
+    if !source.contains("import(") && !source.contains("import (") && !source.contains("import`") {
+        return source.to_string();
+    }
+
+    let bytes = source.as_bytes();
+    let len = bytes.len();
+    let mut out_bytes = bytes.to_vec();
+
+    let mut i = 0;
+    while i < len {
+        if bytes[i] == b'<' {
+            let start = i + 1;
+            let mut j = start;
+            while j < len
+                && (bytes[j] == b' ' || bytes[j] == b'\t' || bytes[j] == b'\n' || bytes[j] == b'\r')
+            {
+                j += 1;
+            }
+
+            let is_typeof_import = bytes[j..].starts_with(b"typeof import(")
+                || bytes[j..].starts_with(b"typeof import (")
+                || bytes[j..].starts_with(b"typeof import`");
+            let is_import = bytes[j..].starts_with(b"import(")
+                || bytes[j..].starts_with(b"import (")
+                || bytes[j..].starts_with(b"import`");
+
+            if is_typeof_import || is_import {
+                // Find matching `>` for this type argument list
+                let mut depth = 1;
+                let mut k = start;
+                let mut in_str: Option<u8> = None;
+                let mut in_paren: usize = 0;
+                while k < len && depth > 0 {
+                    let b = bytes[k];
+                    if let Some(quote) = in_str {
+                        if b == quote && (k == 0 || bytes[k - 1] != b'\\') {
+                            in_str = None;
+                        }
+                    } else {
+                        match b {
+                            b'"' | b'\'' | b'`' => in_str = Some(b),
+                            b'(' => in_paren += 1,
+                            b')' => in_paren = in_paren.saturating_sub(1),
+                            b'<' => depth += 1,
+                            b'>' if in_paren == 0 => {
+                                depth -= 1;
+                                if depth == 0 {
+                                    break;
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                    k += 1;
+                }
+
+                if depth == 0 && k < len {
+                    let span_len = k - start;
+                    if span_len >= 3 {
+                        out_bytes[start] = b'a';
+                        out_bytes[start + 1] = b'n';
+                        out_bytes[start + 2] = b'y';
+                        out_bytes[start + 3..k].fill(b' ');
+                    }
+                    i = k + 1;
+                    continue;
+                }
+            }
+        }
+        i += 1;
+    }
+
+    String::from_utf8(out_bytes).unwrap_or_else(|_| source.to_string())
+}
+
 /// Parse `source` and build both the tree-sitter tree and the UAST for
 /// it in one pass.
 pub fn parse_source(
@@ -66,8 +147,15 @@ pub fn parse_source(
     parser
         .set_language(&ts_language)
         .map_err(|e| DispatchError(format!("failed to load {language} grammar: {e}")))?;
+
+    let parse_input = if language == "typescript" {
+        sanitize_typescript_type_imports(source)
+    } else {
+        source.to_string()
+    };
+
     let tree = parser
-        .parse(source, None)
+        .parse(&parse_input, None)
         .ok_or_else(|| DispatchError(format!("parsing {language} source was cancelled")))?;
 
     let source_bytes = source.as_bytes();
@@ -150,5 +238,25 @@ mod tests {
         // an error node here.
         let result = parse_source("const el = <Foo />;", "typescript", Some("Widget.tsx")).unwrap();
         assert!(!result.has_errors);
+    }
+
+    #[test]
+    fn typescript_dynamic_type_imports_in_generics_parse_cleanly() {
+        let cases = [
+            "const x = load<typeof import('./module')>();\n",
+            "const x2 = load<import('./module')>();\n",
+            "const x3 = load<import('./module').Type>();\n",
+            "const x4 = load<typeof import('./module').Type>();\n",
+            "const x5 = fn<typeof import('./mod'), Other>();\n",
+            "const x6 = fn<import('./mod'), Other>();\n",
+            "const x7 = obj.method<typeof import('./mod')>();\n",
+            "const x8 = await load<typeof import('./mod')>();\n",
+            "type X = import('ai').StopCondition;\n",
+            "type Y = typeof import('ai');\n",
+        ];
+        for case in cases {
+            let res = parse_source(case, "typescript", None).unwrap();
+            assert!(!res.has_errors, "failed to parse cleanly: {case}");
+        }
     }
 }

--- a/topos/engine/src/graphs/uast/mapper_javascript.rs
+++ b/topos/engine/src/graphs/uast/mapper_javascript.rs
@@ -42,6 +42,7 @@ pub fn map_node_kind(node: &Node) -> &'static str {
         ("member_expression", "MemberExpr"),
         ("field_expression", "MemberExpr"),
         ("subscript", "MemberExpr"),
+        ("subscript_expression", "MemberExpr"),
         ("identifier", "Identifier"),
         ("module", "File"),
         ("program", "File"),
@@ -106,5 +107,22 @@ mod tests {
         let mut ops = Vec::new();
         collect_binary_operators(&uast, &mut ops);
         assert_eq!(ops, vec!["&&", "&&"]);
+    }
+
+    #[test]
+    fn maps_subscript_expression_to_member_expr() {
+        let source = "function requiredFunction(obj, key) { return obj[key]; }\n";
+        let tree = parse(source);
+        let uast = map_javascript_tree_to_uast(tree.root_node(), source.as_bytes(), None);
+        fn find_member_expr(node: &UASTNode) -> bool {
+            if node.kind == "MemberExpr" && node.native.node_kind == "subscript_expression" {
+                return true;
+            }
+            node.children.iter().any(find_member_expr)
+        }
+        assert!(
+            find_member_expr(&uast),
+            "subscript_expression was not mapped to MemberExpr"
+        );
     }
 }

--- a/topos/engine/src/graphs/uast/mapper_typescript.rs
+++ b/topos/engine/src/graphs/uast/mapper_typescript.rs
@@ -64,3 +64,50 @@ pub fn map_typescript_tree_to_uast(root: Node, source: &[u8], file: Option<&str>
         Some(&extract_attributes),
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tree_sitter::Parser;
+
+    fn parse(source: &str) -> tree_sitter::Tree {
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into())
+            .unwrap();
+        parser.parse(source, None).unwrap()
+    }
+
+    #[test]
+    fn maps_typescript_subscript_expression_to_member_expr() {
+        let source = "function requiredFunction(obj: any, key: string) { return obj[key]; }\n";
+        let tree = parse(source);
+        let uast = map_typescript_tree_to_uast(tree.root_node(), source.as_bytes(), None);
+        fn find_member_expr(node: &UASTNode) -> bool {
+            if node.kind == "MemberExpr" && node.native.node_kind == "subscript_expression" {
+                return true;
+            }
+            node.children.iter().any(find_member_expr)
+        }
+        assert!(
+            find_member_expr(&uast),
+            "typescript subscript_expression was not mapped to MemberExpr"
+        );
+    }
+
+    #[test]
+    fn maps_type_declarations_and_attributes() {
+        let source = "interface Foo {}\ntype Bar = number;\nenum Baz { A }\n";
+        let tree = parse(source);
+        let uast = map_typescript_tree_to_uast(tree.root_node(), source.as_bytes(), None);
+        let mut type_kinds = Vec::new();
+        for child in &uast.children {
+            if child.kind == "TypeDecl" {
+                if let Some(AttributeValue::Str(k)) = child.attributes.get("typeKind") {
+                    type_kinds.push(k.clone());
+                }
+            }
+        }
+        assert_eq!(type_kinds, vec!["interface", "typeAlias", "enum"]);
+    }
+}


### PR DESCRIPTION
### PR 3: TypeScript Parser Robustness & CPG Security Sink Precision

Closes #347
Closes #348

### Summary of Changes
1. **Dynamic Property Access Mapping (#348):**
   - Added `subscript_expression` mapping to `MemberExpr` in `topos/engine/src/graphs/uast/mapper_javascript.rs` (and inherited by TypeScript mapper).
   - Prevents dynamic property accesses (`obj[key]`) from falling back to `Unknown` or being misclassified as dangerous execution call sinks.

2. **Inline Dynamic Type Imports in TypeScript Generics (#347):**
   - Added `sanitize_typescript_type_imports` in `topos/engine/src/graphs/ast/dispatch.rs` to normalize inline dynamic type imports inside generic type arguments (e.g., `load<typeof import("...")>()`, `fn<import("...")>()`) before passing to tree-sitter.
   - Preserves exact source byte lengths, offsets, and spans so AST/UAST/CFG/PDG/CPG nodes align with the original source without triggering tree-sitter parser errors or collapsing evaluations to SLOP.

### Verification
- Added unit tests in `mapper_javascript.rs` and `mapper_typescript.rs` verifying `subscript_expression` maps to `MemberExpr`.
- Added unit tests in `dispatch.rs` exercising various forms of TypeScript dynamic type imports inside generics.
- Workspace test suite passed (`cargo test --workspace`).
- Linter and formatter clean (`cargo clippy --workspace --all-targets`, `cargo fmt --check`).