### PR TITLE
feat(cli): CLI determinism, status clarity & pi harness support

### DIFF
--- a/topos/cli/src/commands/evaluate/info.rs
+++ b/topos/cli/src/commands/evaluate/info.rs
@@ -318,7 +318,7 @@ fn terminal_width(term: &Term, fallback: usize) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::BTreeMap;
 
     use topos_engine::core::omega::EvaluationValue;
 
@@ -327,7 +327,7 @@ mod tests {
     fn result(simple: f64, secure: f64) -> ClassificationResult {
         ClassificationResult {
             is_parseable: true,
-            scores: HashMap::from([
+            scores: BTreeMap::from([
                 ("simple".to_string(), simple),
                 ("secure".to_string(), secure),
             ]),

--- a/topos/cli/src/commands/evaluate/info_render.rs
+++ b/topos/cli/src/commands/evaluate/info_render.rs
@@ -239,7 +239,7 @@ fn weakest_dimension(result: &ClassificationResult) -> (&'static str, f64) {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::{BTreeMap, HashMap};
 
     use topos_engine::core::omega::EvaluationValue;
 
@@ -247,7 +247,7 @@ mod tests {
 
     fn result(simple: f64, secure: f64) -> ClassificationResult {
         ClassificationResult {
-            scores: HashMap::from([
+            scores: BTreeMap::from([
                 ("simple".to_string(), simple),
                 ("secure".to_string(), secure),
             ]),

--- a/topos/cli/src/commands/evaluate/summary.rs
+++ b/topos/cli/src/commands/evaluate/summary.rs
@@ -1,5 +1,6 @@
 //! Compact cumulative rendering for `topos evaluate`.
 
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use console::Style;
@@ -164,7 +165,7 @@ fn render_summary(
         let passing = overall
             .get(pillar)
             .is_some_and(|value| *value != EvaluationValue::Slop);
-        let status = status_text(passing, options);
+        let status = status_text(passing, average, options);
         let mut row = if single_file {
             format!(
                 "{}  {:<12}  {status}  {:>4.0}%",
@@ -634,11 +635,13 @@ pub(crate) fn failure_file_indices(
     indices
 }
 
-fn status_text(passing: bool, options: RenderOptions) -> String {
-    let (symbol, label, style) = if passing {
-        ("✓", "PASS", Style::new().green().bold())
-    } else {
+fn status_text(passing: bool, score: f64, options: RenderOptions) -> String {
+    let (symbol, label, style) = if !passing {
         ("X", "FAIL", Style::new().red().bold())
+    } else if score < 0.25 {
+        ("!", "WARN", Style::new().yellow().bold())
+    } else {
+        ("✓", "PASS", Style::new().green().bold())
     };
     format!("{} {label}", paint(symbol, style, options))
 }
@@ -705,7 +708,7 @@ fn score_rail(score: f64, width: usize) -> String {
         .collect()
 }
 
-fn floor_verdict(overall: &std::collections::HashMap<String, EvaluationValue>) -> EvaluationValue {
+fn floor_verdict(overall: &BTreeMap<String, EvaluationValue>) -> EvaluationValue {
     let bits = PILLARS.iter().fold(0, |bits, pillar| {
         bits | overall
             .get(*pillar)
@@ -730,7 +733,7 @@ fn common_parent(files: &[PathBuf]) -> Option<PathBuf> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::BTreeMap;
 
     use topos_engine::evaluation::policies::base::Priority;
 
@@ -739,7 +742,7 @@ mod tests {
     fn result(simple_passes: bool) -> ClassificationResult {
         ClassificationResult {
             is_parseable: true,
-            dimensions: HashMap::from([(
+            dimensions: BTreeMap::from([(
                 "simple".to_string(),
                 if simple_passes {
                     EvaluationValue::Simple
@@ -747,7 +750,7 @@ mod tests {
                     EvaluationValue::Slop
                 },
             )]),
-            scores: HashMap::from([("simple".to_string(), 0.6)]),
+            scores: BTreeMap::from([("simple".to_string(), 0.6)]),
             lattice_element: if simple_passes {
                 EvaluationValue::Simple
             } else {
@@ -1077,6 +1080,7 @@ mod tests {
     fn styled_summary_colors_failure_and_pass_symbols() {
         let failure = status_text(
             false,
+            0.5,
             RenderOptions {
                 styled: true,
                 width: 120,
@@ -1084,6 +1088,15 @@ mod tests {
         );
         let pass = status_text(
             true,
+            0.5,
+            RenderOptions {
+                styled: true,
+                width: 120,
+            },
+        );
+        let warn = status_text(
+            true,
+            0.2,
             RenderOptions {
                 styled: true,
                 width: 120,
@@ -1091,6 +1104,32 @@ mod tests {
         );
         assert!(failure.contains("\u{1b}[31m"));
         assert!(pass.contains("\u{1b}[32m"));
+        assert!(warn.contains("\u{1b}[33m"));
+        assert!(warn.contains("WARN"));
+    }
+
+    #[test]
+    fn low_score_passing_renders_warn_status() {
+        let mut low = result(true);
+        low.scores.insert("simple".to_string(), 0.1);
+        let output = render_summary(
+            &[PathBuf::from("low.rs")],
+            &[low],
+            SummaryView {
+                language: "rust",
+                options: RenderOptions {
+                    styled: false,
+                    width: 120,
+                },
+                composable_requested: false,
+                show_info_hint: false,
+                composable_notices: &[],
+                action: "Evaluated",
+            },
+        )
+        .join("\n");
+        assert!(output.contains("! WARN"));
+        assert!(!output.contains("✓ PASS"));
     }
 
     #[test]
@@ -1124,9 +1163,10 @@ mod tests {
     fn weak_spots_rank_by_displayed_average() {
         let files = vec![PathBuf::from("balanced.rs"), PathBuf::from("weak.rs")];
         let mut balanced = result(true);
-        balanced.scores = HashMap::from([("simple".to_string(), 0.5), ("secure".to_string(), 0.5)]);
+        balanced.scores =
+            BTreeMap::from([("simple".to_string(), 0.5), ("secure".to_string(), 0.5)]);
         let mut weak = result(true);
-        weak.scores = HashMap::from([("simple".to_string(), 0.2), ("secure".to_string(), 0.1)]);
+        weak.scores = BTreeMap::from([("simple".to_string(), 0.2), ("secure".to_string(), 0.1)]);
         assert_eq!(
             ranked_file_indices(&files, &[balanced, weak], 5),
             vec![1, 0]
@@ -1136,7 +1176,7 @@ mod tests {
     #[test]
     fn weak_spots_show_average_before_the_verdict() {
         let mut scored = result(true);
-        scored.scores = HashMap::from([
+        scored.scores = BTreeMap::from([
             ("simple".to_string(), 0.5),
             ("composable".to_string(), 0.0),
             ("secure".to_string(), 1.0),

--- a/topos/cli/src/commands/inspect/detail.rs
+++ b/topos/cli/src/commands/inspect/detail.rs
@@ -165,7 +165,7 @@ fn plural(count: usize) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::BTreeMap;
 
     use topos_engine::core::omega::EvaluationValue;
 
@@ -174,11 +174,11 @@ mod tests {
     #[test]
     fn inspection_keeps_all_metrics_without_duplicate_entropy_section() {
         let result = ClassificationResult {
-            raw_metrics: HashMap::from([
+            raw_metrics: BTreeMap::from([
                 ("ast.entropy".to_string(), 0.33),
                 ("cfg.longest_path".to_string(), 8.0),
             ]),
-            interpretation: HashMap::from([(
+            interpretation: BTreeMap::from([(
                 "ast.entropy".to_string(),
                 "entropy within structured range".to_string(),
             )]),

--- a/topos/cli/src/commands/install/harness.rs
+++ b/topos/cli/src/commands/install/harness.rs
@@ -33,7 +33,7 @@ pub(crate) struct HarnessSpec {
     pub(crate) note: fn(&Path) -> Option<String>,
 }
 
-pub(crate) const HARNESSES: [HarnessSpec; 8] = [
+pub(crate) const HARNESSES: [HarnessSpec; 9] = [
     HarnessSpec {
         id: "claude",
         name: "Claude Code",
@@ -114,6 +114,16 @@ pub(crate) const HARNESSES: [HarnessSpec; 8] = [
         detect: detect_antigravity,
         note: antigravity_note,
     },
+    HarnessSpec {
+        id: "pi",
+        name: "pi",
+        artifact: Artifact::McpJson,
+        config_path: paths::pi_config,
+        active_msg: "MCP server registered in ~/.pi/agent/settings.json",
+        absent_msg: "no MCP server entry in ~/.pi/agent/settings.json",
+        detect: detect_pi,
+        note: no_note,
+    },
 ];
 
 /// Every harness id, in table order — the `--all` set and the `--help` list.
@@ -151,6 +161,10 @@ fn detect_copilot(home: &Path) -> bool {
 
 fn detect_cursor(home: &Path) -> bool {
     home.join(".cursor").is_dir()
+}
+
+fn detect_pi(home: &Path) -> bool {
+    home.join(".pi").is_dir()
 }
 
 fn detect_claude_desktop(home: &Path) -> bool {
@@ -239,6 +253,15 @@ mod tests {
             assert_ne!(spec.active_msg, "configured", "{} is not specific", spec.id);
             assert!(!spec.absent_msg.is_empty());
         }
+    }
+
+    #[test]
+    fn a_bare_pi_directory_detects_pi() {
+        let home = tmp_dir("pi-detect");
+        fs::create_dir_all(home.join(".pi")).unwrap();
+        let pi = spec("pi").unwrap();
+        assert!((pi.detect)(&home));
+        fs::remove_dir_all(home).ok();
     }
 
     #[test]

--- a/topos/cli/src/commands/install/paths.rs
+++ b/topos/cli/src/commands/install/paths.rs
@@ -57,6 +57,10 @@ pub(crate) fn antigravity_config(home: &Path) -> PathBuf {
     home.join(".gemini/config/mcp_config.json")
 }
 
+pub(crate) fn pi_config(home: &Path) -> PathBuf {
+    home.join(".pi/agent/settings.json")
+}
+
 pub(crate) fn claude_desktop_config(home: &Path) -> PathBuf {
     if cfg!(windows) {
         app_data(home).join("Claude/claude_desktop_config.json")
@@ -93,6 +97,7 @@ mod tests {
             copilot_config(home),
             cursor_config(home),
             antigravity_config(home),
+            pi_config(home),
         ] {
             assert!(
                 path.starts_with(home),

--- a/topos/cli/tests/install_e2e.rs
+++ b/topos/cli/tests/install_e2e.rs
@@ -213,7 +213,7 @@ fn config_of(status: &Value, id: &str) -> PathBuf {
 
 /// Every harness id in table order, so tests can iterate the whole set without
 /// duplicating the table.
-const IDS: [&str; 8] = [
+const IDS: [&str; 9] = [
     "claude",
     "claude-desktop",
     "codex",
@@ -222,6 +222,7 @@ const IDS: [&str; 8] = [
     "cursor",
     "vscode",
     "antigravity",
+    "pi",
 ];
 
 // ---------------------------------------------------------------------------
@@ -561,7 +562,7 @@ fn a_second_install_reports_everything_active_and_writes_nothing() {
         after_first == snapshot(&home),
         "a second install rewrote files that were already correct"
     );
-    assert_eq!(status_json(&home)["active"], 8);
+    assert_eq!(status_json(&home)["active"], 9);
 
     fs::remove_dir_all(&home).ok();
 }
@@ -675,7 +676,7 @@ fn a_headless_uninstall_applies_without_a_prompt() {
     let home = scratch_home("headless");
     seed(&home, ".claude.json", SEED_CLAUDE_JSON);
     topos(&home, &["install", "--all"]).expect_code(0);
-    assert_eq!(status_json(&home)["active"], 8);
+    assert_eq!(status_json(&home)["active"], 9);
 
     // No `--yes`, no `--dry-run`, and no stream is a tty (see `topos`), so this
     // is the `Headless` arm: CI parity, apply. The `Ambiguous` arm — stderr

--- a/topos/engine/src/core/characteristic_morphism.rs
+++ b/topos/engine/src/core/characteristic_morphism.rs
@@ -45,7 +45,7 @@
 //! and SECURE needs a CPG, so both are reported as "not measured" when
 //! the caller supplies no such representation.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 
 use crate::core::morphism::ProgramMorphism;
@@ -66,17 +66,17 @@ pub struct ClassificationResult {
     pub is_parseable: bool,
     /// Per-generator value in `Ω`: the singleton generator
     /// (SIMPLE/COMPOSABLE/SECURE/NAVIGABLE) when satisfied, SLOP otherwise.
-    pub dimensions: HashMap<String, EvaluationValue>,
+    pub dimensions: BTreeMap<String, EvaluationValue>,
     /// Per-generator normalized quality score in `[0.0, 1.0]`.
-    pub scores: HashMap<String, f64>,
+    pub scores: BTreeMap<String, f64>,
     /// Overall `Ω` element — the join of the satisfied generators.
     pub lattice_element: EvaluationValue,
     /// Generator emphasis label (metadata / guidance).
     pub priority: Priority,
     /// All raw metric floats, namespaced by representation.
-    pub raw_metrics: HashMap<String, f64>,
+    pub raw_metrics: BTreeMap<String, f64>,
     /// Per-metric interpretation strings.
-    pub interpretation: HashMap<String, String>,
+    pub interpretation: BTreeMap<String, String>,
     /// Whether the source is an import/export-only entrypoint module
     /// (drives gate exemptions; see [`crate::evaluation::policies::gates`]).
     pub is_entrypoint_module: bool,
@@ -90,12 +90,12 @@ impl Default for ClassificationResult {
     fn default() -> Self {
         ClassificationResult {
             is_parseable: false,
-            dimensions: HashMap::new(),
-            scores: HashMap::new(),
+            dimensions: BTreeMap::new(),
+            scores: BTreeMap::new(),
             lattice_element: EvaluationValue::Slop,
             priority: Priority::default(),
-            raw_metrics: HashMap::new(),
-            interpretation: HashMap::new(),
+            raw_metrics: BTreeMap::new(),
+            interpretation: BTreeMap::new(),
             is_entrypoint_module: false,
             is_stable_leaf_module: false,
         }
@@ -197,15 +197,15 @@ impl CharacteristicMorphism {
             }
         }
 
-        let mut raw_metrics = HashMap::new();
+        let mut raw_metrics = BTreeMap::new();
         raw_metrics.extend(simple_raw.clone());
         raw_metrics.extend(composable_raw.clone());
         raw_metrics.extend(secure_raw.clone());
         raw_metrics.extend(navigable_raw.clone());
 
-        let mut dimensions = HashMap::new();
-        let mut scores = HashMap::new();
-        let mut interpretation = HashMap::new();
+        let mut dimensions = BTreeMap::new();
+        let mut scores = BTreeMap::new();
+        let mut interpretation = BTreeMap::new();
 
         if let Some(decision) = score_simple_dim(&simple_raw, is_entrypoint, source_size_bytes) {
             record(
@@ -287,7 +287,7 @@ impl CharacteristicMorphism {
     pub fn combine_dimensions(
         &self,
         results: &[ClassificationResult],
-    ) -> HashMap<String, EvaluationValue> {
+    ) -> BTreeMap<String, EvaluationValue> {
         Generator::ALL
             .into_iter()
             .map(|g| g.as_str())
@@ -317,9 +317,9 @@ impl CharacteristicMorphism {
 }
 
 fn record(
-    dimensions: &mut HashMap<String, EvaluationValue>,
-    scores: &mut HashMap<String, f64>,
-    interpretation: &mut HashMap<String, String>,
+    dimensions: &mut BTreeMap<String, EvaluationValue>,
+    scores: &mut BTreeMap<String, f64>,
+    interpretation: &mut BTreeMap<String, String>,
     dim: &str,
     generator: EvaluationValue,
     decision: ScoredDecision,
@@ -486,15 +486,15 @@ mod tests {
         let classifier = CharacteristicMorphism;
         let r1 = ClassificationResult {
             is_parseable: true,
-            dimensions: HashMap::from([("simple".to_string(), EvaluationValue::Simple)]),
-            scores: HashMap::from([("simple".to_string(), 0.8)]),
+            dimensions: BTreeMap::from([("simple".to_string(), EvaluationValue::Simple)]),
+            scores: BTreeMap::from([("simple".to_string(), 0.8)]),
             lattice_element: EvaluationValue::Simple,
             ..Default::default()
         };
         let r2 = ClassificationResult {
             is_parseable: true,
-            dimensions: HashMap::from([("simple".to_string(), EvaluationValue::Slop)]),
-            scores: HashMap::from([("simple".to_string(), 0.3)]),
+            dimensions: BTreeMap::from([("simple".to_string(), EvaluationValue::Slop)]),
+            scores: BTreeMap::from([("simple".to_string(), 0.3)]),
             lattice_element: EvaluationValue::Slop,
             ..Default::default()
         };
@@ -508,8 +508,8 @@ mod tests {
         let classifier = CharacteristicMorphism;
         let good = ClassificationResult {
             is_parseable: true,
-            dimensions: HashMap::from([("simple".to_string(), EvaluationValue::Simple)]),
-            scores: HashMap::from([("simple".to_string(), 0.9)]),
+            dimensions: BTreeMap::from([("simple".to_string(), EvaluationValue::Simple)]),
+            scores: BTreeMap::from([("simple".to_string(), 0.9)]),
             lattice_element: EvaluationValue::Simple,
             ..Default::default()
         };
@@ -526,8 +526,8 @@ mod tests {
         let classifier = CharacteristicMorphism;
         let has_repr = ClassificationResult {
             is_parseable: true,
-            dimensions: HashMap::from([("composable".to_string(), EvaluationValue::Composable)]),
-            scores: HashMap::from([("composable".to_string(), 0.9)]),
+            dimensions: BTreeMap::from([("composable".to_string(), EvaluationValue::Composable)]),
+            scores: BTreeMap::from([("composable".to_string(), 0.9)]),
             lattice_element: EvaluationValue::Composable,
             ..Default::default()
         };
@@ -535,8 +535,8 @@ mod tests {
         // absent, not present-and-failing.
         let missing_repr = ClassificationResult {
             is_parseable: true,
-            dimensions: HashMap::new(),
-            scores: HashMap::new(),
+            dimensions: BTreeMap::new(),
+            scores: BTreeMap::new(),
             lattice_element: EvaluationValue::Slop,
             ..Default::default()
         };

--- a/topos/engine/src/evaluation/suggestions.rs
+++ b/topos/engine/src/evaluation/suggestions.rs
@@ -73,7 +73,11 @@ pub fn suggest_refactors(
     // with Φ_COMPOSABLE via `coupling_gate_input`), and the stable-leaf and
     // instability exemptions are threaded through rather than hard-coded.
     let instability = result.raw_metrics.get("mdg.instability").copied();
-    let mut gate_metrics = result.raw_metrics.clone();
+    let mut gate_metrics: HashMap<String, f64> = result
+        .raw_metrics
+        .iter()
+        .map(|(k, v)| (k.clone(), *v))
+        .collect();
     gate_metrics.remove("mdg.instability");
     gate_metrics.extend(coupling_gate_input(
         instability,
@@ -178,23 +182,25 @@ fn gate_message(r: &GateResult) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use super::*;
     use crate::core::omega::EvaluationValue;
     use crate::evaluation::policies::base::Priority;
 
     fn result(
-        dimensions: HashMap<String, EvaluationValue>,
-        raw_metrics: HashMap<String, f64>,
+        dimensions: BTreeMap<String, EvaluationValue>,
+        raw_metrics: BTreeMap<String, f64>,
         lattice_element: EvaluationValue,
     ) -> ClassificationResult {
         ClassificationResult {
             is_parseable: true,
             dimensions,
-            scores: HashMap::new(),
+            scores: BTreeMap::new(),
             lattice_element,
             priority: Priority::Secure,
             raw_metrics,
-            interpretation: HashMap::new(),
+            interpretation: BTreeMap::new(),
             is_entrypoint_module: false,
             is_stable_leaf_module: false,
         }
@@ -203,8 +209,8 @@ mod tests {
     #[test]
     fn eval_finding_yields_secure_fix_naming_callee() {
         let result = result(
-            HashMap::from([("secure".to_string(), EvaluationValue::Slop)]),
-            HashMap::from([
+            BTreeMap::from([("secure".to_string(), EvaluationValue::Slop)]),
+            BTreeMap::from([
                 ("cpg.dangerous_calls".to_string(), 1.0),
                 ("cpg.taint_flows".to_string(), 0.0),
             ]),
@@ -250,8 +256,8 @@ mod tests {
         // (`gates_achieved: false`, issue #193) it cannot fail SIMPLE, so
         // the suggestion must say "improve" rather than "fix".
         let result = result(
-            HashMap::from([("simple".to_string(), EvaluationValue::Slop)]),
-            HashMap::from([
+            BTreeMap::from([("simple".to_string(), EvaluationValue::Slop)]),
+            BTreeMap::from([
                 ("cfg.cyclomatic".to_string(), 25.0),
                 ("ast.entropy".to_string(), 0.5),
             ]),
@@ -272,8 +278,8 @@ mod tests {
         // `is_entrypoint_module: false` keeps the entropy exemption from
         // swallowing the entropy failure.
         let result = result(
-            HashMap::from([("simple".to_string(), EvaluationValue::Slop)]),
-            HashMap::from([
+            BTreeMap::from([("simple".to_string(), EvaluationValue::Slop)]),
+            BTreeMap::from([
                 ("cfg.cyclomatic".to_string(), 25.0),
                 ("ast.max_function_complexity".to_string(), 20.0),
                 ("ast.entropy".to_string(), 0.95),
@@ -303,8 +309,8 @@ mod tests {
         // label was corrected. Same fixture as the severity test: all three
         // SIMPLE gates fail, and cyclomatic has by far the largest excess.
         let result = result(
-            HashMap::from([("simple".to_string(), EvaluationValue::Slop)]),
-            HashMap::from([
+            BTreeMap::from([("simple".to_string(), EvaluationValue::Slop)]),
+            BTreeMap::from([
                 ("cfg.cyclomatic".to_string(), 25.0),
                 ("ast.max_function_complexity".to_string(), 20.0),
                 ("ast.entropy".to_string(), 0.95),
@@ -332,8 +338,8 @@ mod tests {
     #[test]
     fn high_fan_out_yields_composable_suggestion() {
         let result = result(
-            HashMap::from([("composable".to_string(), EvaluationValue::Slop)]),
-            HashMap::from([
+            BTreeMap::from([("composable".to_string(), EvaluationValue::Slop)]),
+            BTreeMap::from([
                 ("mdg.fan_out".to_string(), 30.0),
                 ("mdg.instability".to_string(), 0.5),
             ]),
@@ -352,8 +358,8 @@ mod tests {
         // at or above the ratio's resolution limit (see `coupling_gate_input`),
         // so the fixture carries both: distance = |0.2 + 0.1 − 1| = 0.7.
         let result = result(
-            HashMap::from([("composable".to_string(), EvaluationValue::Slop)]),
-            HashMap::from([
+            BTreeMap::from([("composable".to_string(), EvaluationValue::Slop)]),
+            BTreeMap::from([
                 ("mdg.instability".to_string(), 0.1),
                 ("mdg.abstractness".to_string(), 0.2),
                 ("mdg.coupling".to_string(), 6.0),
@@ -375,11 +381,11 @@ mod tests {
     #[test]
     fn clean_file_yields_no_suggestions() {
         let result = result(
-            HashMap::from([
+            BTreeMap::from([
                 ("simple".to_string(), EvaluationValue::Simple),
                 ("secure".to_string(), EvaluationValue::Secure),
             ]),
-            HashMap::from([
+            BTreeMap::from([
                 ("cfg.cyclomatic".to_string(), 2.0),
                 ("ast.entropy".to_string(), 0.5),
                 ("cpg.dangerous_calls".to_string(), 0.0),
@@ -395,8 +401,8 @@ mod tests {
     fn allowlisted_finding_produces_no_secure_suggestion() {
         // The CLI passes only NON-allowlisted findings as active_findings.
         let result = result(
-            HashMap::from([("secure".to_string(), EvaluationValue::Slop)]),
-            HashMap::from([
+            BTreeMap::from([("secure".to_string(), EvaluationValue::Slop)]),
+            BTreeMap::from([
                 ("cpg.dangerous_calls".to_string(), 1.0),
                 ("cpg.taint_flows".to_string(), 0.0),
             ]),

--- a/topos/engine/src/evaluation/suppression.rs
+++ b/topos/engine/src/evaluation/suppression.rs
@@ -154,7 +154,7 @@ mod tests {
     use crate::core::characteristic_morphism::CharacteristicMorphism;
     use crate::core::morphism::ProgramMorphism;
     use crate::evaluation::policies::base::Priority;
-    use std::collections::HashMap;
+    use std::collections::BTreeMap;
     use std::path::PathBuf;
 
     const EVAL_SRC: &str = "def f(x):\n    return eval(x)\n";
@@ -211,7 +211,7 @@ mod tests {
         let cpg = morphism.build_cpg().unwrap().clone();
         let result = ClassificationResult {
             is_parseable: true,
-            dimensions: HashMap::from([
+            dimensions: BTreeMap::from([
                 ("simple".to_string(), EvaluationValue::Simple),
                 ("composable".to_string(), EvaluationValue::Composable),
                 ("navigable".to_string(), EvaluationValue::Navigable),

--- a/topos/mcp/src/formatting.rs
+++ b/topos/mcp/src/formatting.rs
@@ -3,7 +3,7 @@
 //! Converts `ClassificationResult` and distance results into the wire
 //! models defined in [`crate::schemas`], and renders the markdown channel.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use rmcp::model::{CallToolResult, ContentBlock};
 use serde::Serialize;
@@ -489,7 +489,7 @@ fn dim_for_metric_key(key: &str) -> Option<&'static str> {
 /// plus notes with no pillar mapping (e.g. `mdg.unavailable`).
 fn failing_interpretation(
     result: &ClassificationResult,
-    interpretation: &HashMap<String, String>,
+    interpretation: &BTreeMap<String, String>,
 ) -> HashMap<String, String> {
     let mut achieved: HashMap<&str, bool> = HashMap::new();
     for (dim, _) in PILLAR_METRIC_PREFIXES {
@@ -573,11 +573,17 @@ pub fn to_evaluation_result(
             .or_insert_with(|| mdg_unavailable_message(&opts.warnings));
     }
 
-    let raw_metrics;
+    let raw_metrics: HashMap<String, f64>;
+    let interpretation_out: HashMap<String, String>;
     if opts.verbose {
-        raw_metrics = result.raw_metrics.clone();
+        raw_metrics = result
+            .raw_metrics
+            .iter()
+            .map(|(k, v)| (k.clone(), *v))
+            .collect();
+        interpretation_out = interpretation.into_iter().collect();
     } else {
-        interpretation = failing_interpretation(result, &interpretation);
+        interpretation_out = failing_interpretation(result, &interpretation);
         raw_metrics = HashMap::new();
     }
 
@@ -671,7 +677,7 @@ pub fn to_evaluation_result(
         guidance: build_guidance(&display_result),
         coupling_available,
         raw_metrics,
-        interpretation,
+        interpretation: interpretation_out,
         metric_locations: opts.metric_locations,
         warnings: opts.warnings.clone(),
         agent_contract,

--- a/topos/mcp/src/refactor_targets.rs
+++ b/topos/mcp/src/refactor_targets.rs
@@ -199,7 +199,11 @@ fn structural_metric_targets(filepath: &str, result: &ClassificationResult) -> V
     // `raw_metrics`); keep this block in sync with its sibling caller
     // `topos_engine::evaluation::suggestions::suggest_refactors`.
     let instability = result.raw_metrics.get("mdg.instability").copied();
-    let mut gate_metrics = result.raw_metrics.clone();
+    let mut gate_metrics: HashMap<String, f64> = result
+        .raw_metrics
+        .iter()
+        .map(|(k, v)| (k.clone(), *v))
+        .collect();
     gate_metrics.remove("mdg.instability");
     gate_metrics.extend(coupling_gate_input(
         instability,

--- a/topos/mcp/src/tools/evaluate.rs
+++ b/topos/mcp/src/tools/evaluate.rs
@@ -1,7 +1,7 @@
 //! Evaluation tools: code string, single file, and whole project.
 
 use std::cmp::Ordering;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 
 use rmcp::handler::server::wrapper::Parameters;
@@ -495,7 +495,11 @@ fn evaluate_single_file(
             .collect(),
         pillars: build_pillars(&result_for_rollup, dep_graph.is_some()),
         raw_metrics: if verbose {
-            result.raw_metrics.clone()
+            result
+                .raw_metrics
+                .iter()
+                .map(|(k, v)| (k.clone(), *v))
+                .collect()
         } else {
             HashMap::new()
         },
@@ -558,7 +562,7 @@ fn min_scores_by_dim(results: &[ClassificationResult]) -> HashMap<String, f64> {
         .collect()
 }
 
-fn aggregate_floor_verdict(rolled: &HashMap<String, EvaluationValue>) -> LatticeElement {
+fn aggregate_floor_verdict(rolled: &BTreeMap<String, EvaluationValue>) -> LatticeElement {
     let satisfied: Vec<Generator> = Generator::ALL
         .into_iter()
         .filter(|g| rolled.get(g.as_str()) == Some(&g.value()))
@@ -587,7 +591,11 @@ fn gate_metrics_for(result: &ClassificationResult) -> HashMap<String, f64> {
     let instability = result.raw_metrics.get("mdg.instability").copied();
     let fan_in = result.raw_metrics.get("mdg.fan_in").copied();
     let fan_out = result.raw_metrics.get("mdg.fan_out").copied();
-    let mut gate_metrics = result.raw_metrics.clone();
+    let mut gate_metrics: HashMap<String, f64> = result
+        .raw_metrics
+        .iter()
+        .map(|(k, v)| (k.clone(), *v))
+        .collect();
     gate_metrics.remove("mdg.instability");
     gate_metrics.extend(coupling_gate_input(
         instability,
@@ -1056,7 +1064,7 @@ fn empty_project_result(
 }
 
 fn aggregate_explanation(
-    rolled: &HashMap<String, EvaluationValue>,
+    rolled: &BTreeMap<String, EvaluationValue>,
     rolled_scores: &HashMap<String, f64>,
     hard_fail_head: Option<&ProjectFileEntry>,
     entries: &[ProjectFileEntry],


### PR DESCRIPTION
### Summary

Resolves #332, #350, #345.

1. **Byte-deterministic JSON serialization (#332):** Converted `ClassificationResult` maps (`dimensions`, `scores`, `raw_metrics`, `interpretation`) and `combine_dimensions` to `BTreeMap` so JSON outputs preserve alphabetical key ordering.
2. **Status clarity for low scores (#350):** Updated the summary table renderer so passing pillars with diagnostic scores below 25% display `! WARN` rather than contradictory `✓ PASS 0%`.
3. **Pi harness configuration (#345):** Added `pi` to supported harnesses configuring `~/.pi/agent/settings.json` with detection on `~/.pi`.